### PR TITLE
Fix typing errors related to unavailable code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "tabulate>=0.9.0",
     "pillow>=10.4.0",
     "pyarrow-stubs>=10.0.1.7",
+    "types-tabulate>=0.9.0.20240106",
 ]
 requires-python = ">= 3.7"
 classifiers = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -105,6 +105,8 @@ time-machine==2.9.0
 tomli==2.0.1
     # via mypy
     # via pytest
+types-tabulate==0.9.0.20240106
+    # via together
 typing-extensions==4.8.0
     # via anyio
     # via mypy

--- a/requirements.lock
+++ b/requirements.lock
@@ -50,6 +50,8 @@ sniffio==1.3.0
     # via together
 tabulate==0.9.0
     # via together
+types-tabulate==0.9.0.20240106
+    # via together
 typing-extensions==4.8.0
     # via anyio
     # via pydantic

--- a/src/together/lib/cli/api/completions.py
+++ b/src/together/lib/cli/api/completions.py
@@ -78,11 +78,17 @@ def completions(
                 click.echo(f"{json.dumps(chunk.model_dump())}")
                 continue
 
-            should_print_header = len(chunk.choices) > 1
-            for stream_choice in sorted(chunk.choices, key=lambda c: c.index):  # type: ignore
+            dumped = chunk.model_dump()
+
+            # todo: use automatic typing once choice.index is added to the model
+            # and stream_choice.delta.content is added to the model
+            choices = dumped["choices"]
+
+            should_print_header = len(choices) > 1
+            for stream_choice in sorted(choices, key=lambda c: c["index"]):
                 if should_print_header:
                     click.echo(f"\n===== Completion {stream_choice.index} =====\n")
-                click.echo(f"{stream_choice.delta.content}", nl=False)
+                click.echo(f"{stream_choice['delta']['content']}", nl=False)
 
                 if should_print_header:
                     click.echo("\n")

--- a/src/together/lib/cli/api/files.py
+++ b/src/together/lib/cli/api/files.py
@@ -29,7 +29,7 @@ def files(_ctx: click.Context) -> None:
 @click.option(
     "--purpose",
     type=str,
-    default=FilePurpose.FineTune.value,
+    default="fine-tunes",
     help="Purpose of file upload. Acceptable values in enum `together.types.FilePurpose`. Defaults to `fine-tunes`.",
 )
 @click.option(
@@ -37,14 +37,17 @@ def files(_ctx: click.Context) -> None:
     default=True,
     help="Whether to check the file before uploading.",
 )
-def upload(ctx: click.Context, file: pathlib.Path, purpose: str, check: bool) -> None:
+def upload(_ctx: click.Context, _file: pathlib.Path, _purpose: str, _check: bool) -> None:
     """Upload file"""
 
-    client: Together = ctx.obj
+    # the file upload API is not implemented yet
+    raise NotImplementedError
 
-    response = client.files.upload(file=file, purpose=purpose, check=check)
+    # client: Together = ctx.obj
 
-    click.echo(json.dumps(response.model_dump(), indent=4))
+    # response = client.files.upload(file=file, purpose=purpose, check=check)
+
+    # click.echo(json.dumps(response.model_dump(), indent=4))
 
 
 @files.command()

--- a/src/together_ai/lib/.keep
+++ b/src/together_ai/lib/.keep
@@ -1,4 +1,0 @@
-File generated from our OpenAPI spec by Stainless.
-
-This directory can be used to store custom files to expand the SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.


### PR DESCRIPTION
- Fixes lint issue due to file upload API not being available at the moment
- Fixes lint issue due to streaming fields on completions not being in API spec
- adds required types dependency for tabulate
- deletes old lib directory

Here is a note from the Stainless engineer who worked on this change:

> Overall, this gets linting passing on your python SDK, though we had to work around 2 issues we wanted to bring up:
> 1. The file upload endpoint is not part of your OpenAPI spec. We saw some prior messages in the Slack channel indicating that this was being worked on. Once it’s ready then that part of the CLI can be un-commented.
> 2. For the completions streaming response, the old CLI was relying on some fields that don’t seem to be part of the published API spec (but that your API actually returns). For now we’ve been able to get things working by using the dict that we parse from the raw JSON, but we think ideally these would be part of your published API spec.