### PR TITLE
Removing handling max bs from client, handling in the REST API

### DIFF
--- a/src/together/lib/resources/fine_tune.py
+++ b/src/together/lib/resources/fine_tune.py
@@ -60,17 +60,10 @@ def create_finetune_request(
 
     model_or_checkpoint = model or from_checkpoint
 
-    if batch_size == "max":
-        log_warn_once(
-            "Starting from together>=1.3.0, the default batch size is set to the maximum allowed value for each model."
-        )
     if warmup_ratio is None:
         warmup_ratio = 0.0
 
     training_type: TrainingType = FullTrainingTypeParam(type="Full")
-    max_batch_size: int = 0
-    max_batch_size_dpo: int = 0
-    min_batch_size: int = 0
     if lora:
         if model_limits.lora_training is None:
             raise ValueError(f"LoRA adapters are not supported for the selected model ({model_or_checkpoint}).")
@@ -95,27 +88,22 @@ def create_finetune_request(
         min_batch_size = model_limits.full_training.min_batch_size
         max_batch_size_dpo = model_limits.full_training.max_batch_size_dpo
 
-    if batch_size == "max":
-        if training_method == "dpo":
-            batch_size = max_batch_size_dpo
-        else:
-            batch_size = max_batch_size
+    if batch_size != "max":
+        if training_method == "sft":
+            if batch_size > max_batch_size:
+                raise ValueError(
+                    f"Requested batch size of {batch_size} is higher that the maximum allowed value of {max_batch_size}."
+                )
+        elif training_method == "dpo":
+            if batch_size > max_batch_size_dpo:
+                raise ValueError(
+                    f"Requested batch size of {batch_size} is higher that the maximum allowed value of {max_batch_size_dpo}."
+                )
 
-    if training_method == "sft":
-        if batch_size > max_batch_size:
+        if batch_size < min_batch_size:
             raise ValueError(
-                f"Requested batch size of {batch_size} is higher that the maximum allowed value of {max_batch_size}."
+                f"Requested batch size of {batch_size} is lower that the minimum allowed value of {min_batch_size}."
             )
-    elif training_method == "dpo":
-        if batch_size > max_batch_size_dpo:
-            raise ValueError(
-                f"Requested batch size of {batch_size} is higher that the maximum allowed value of {max_batch_size_dpo}."
-            )
-
-    if batch_size < min_batch_size:
-        raise ValueError(
-            f"Requested batch size of {batch_size} is lower that the minimum allowed value of {min_batch_size}."
-        )
 
     if warmup_ratio > 1 or warmup_ratio < 0:
         raise ValueError(f"Warmup ratio should be between 0 and 1 (got {warmup_ratio})")

--- a/tests/unit/test_fine_tune_resources.py
+++ b/tests/unit/test_fine_tune_resources.py
@@ -49,7 +49,7 @@ def test_simple_request():
     assert request["training_type"]["type"] == "Full"
     assert "batch_size" in request
     assert _MODEL_LIMITS.full_training is not None
-    assert request["batch_size"] == _MODEL_LIMITS.full_training.max_batch_size
+    assert request["batch_size"] == "max"
 
 
 def test_validation_file():
@@ -91,7 +91,7 @@ def test_lora_request():
     assert "lora_trainable_modules" in request["training_type"]
     assert request["training_type"]["lora_trainable_modules"] == "all-linear"
     assert "batch_size" in request
-    assert request["batch_size"] == _MODEL_LIMITS.lora_training.max_batch_size
+    assert request["batch_size"] == "max"
 
 
 def test_dpo_request_lora():
@@ -113,7 +113,7 @@ def test_dpo_request_lora():
     assert "lora_trainable_modules" in request["training_type"]
     assert request["training_type"]["lora_trainable_modules"] == "all-linear"
     assert "batch_size" in request
-    assert request["batch_size"] == _MODEL_LIMITS.lora_training.max_batch_size_dpo
+    assert request["batch_size"] == "max"
 
 
 def test_dpo_request():
@@ -129,7 +129,7 @@ def test_dpo_request():
     assert request["training_type"]["type"] == "Full"
     assert "batch_size" in request
     assert _MODEL_LIMITS.full_training is not None
-    assert request["batch_size"] == _MODEL_LIMITS.full_training.max_batch_size_dpo
+    assert request["batch_size"] == "max"
 
 
 def test_from_checkpoint_request():


### PR DESCRIPTION
Now we propagate batch_size="max" directly to REST API, where it will be resolved to a numeric value, based on the models' limits.