### PR TITLE
fix: Add CLI support for endpoings list --mine and --usage-type

### DIFF
--- a/src/together/lib/cli/api/endpoints.py
+++ b/src/together/lib/cli/api/endpoints.py
@@ -354,7 +354,7 @@ def list(
     endpoints = client.endpoints.list(
         type=type or omit,
         usage_type=usage_type or omit,
-        mine=mine or omit,
+        mine=mine if mine is not None else omit,
     )
 
     if not endpoints:


### PR DESCRIPTION
Adds support for `--mine` and `--usage-type` to the endpoints CLI

```bash
> together endpoints list --json --usage-type on-demand | jq 'length'
Endpoints:
9

> together endpoints list --json --usage-type reserved | jq 'length' 
Endpoints:
16

> together endpoints list --mine --json --usage-type reserved | jq 'length'
Endpoints:
0

> together endpoints list --mine --json --usage-type on-demand | jq 'length'
Endpoints:
8
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wires `--mine` and `--usage-type` flags into `endpoints list`, forwarding filters to the API (along with `type`).
> 
> - **CLI - endpoints list**:
>   - Wire `--mine` and `--usage-type` options to `client.endpoints.list` (`mine`, `usage_type`).
>   - Ensure `type` is forwarded (`type=type or omit`).
>   - Rename internal params (`_mine` -> `mine`, `_usage_type` -> `usage_type`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 779b1d553bef74934c9e49ea40d2e17ef08c5ffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->