### PR TITLE
fix: Remove unnecessary logic require endpoints cli to have both min/max replicas provided together

### DIFF
--- a/src/together/lib/cli/api/endpoints.py
+++ b/src/together/lib/cli/api/endpoints.py
@@ -428,8 +428,6 @@ def update(
 
     if inactive_timeout is not None:
         kwargs["inactive_timeout"] = inactive_timeout
-    if inactive_timeout is not None:
-        kwargs["inactive_timeout"] = inactive_timeout
 
     client.endpoints.update(endpoint_id, **kwargs)
 


### PR DESCRIPTION
Endpoints team has confirmed that the API itself can handle taking only one value and will emit errors if the values do not work together. I've tested locally:

```bash
> together endpoints update endpoint-0581a3c2-707c-4e56-b538-a8d6a21058ba --max-replicas 2
Updated endpoint configuration:
  Max replicas: 2
Successfully updated endpoint
endpoint-0581a3c2-707c-4e56-b538-a8d6a21058ba

> together endpoints update endpoint-0581a3c2-707c-4e56-b538-a8d6a21058ba --min-replicas 200
Error: Min replicas cannot be greater than max replicas
```