### PR TITLE
Investigate mypy typing issue in together-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ conflicts = [
 # version pins are in uv.lock
 dev = [
     "pyright==1.1.399",
-    "mypy",
+    "mypy==1.17",
     "respx",
     "pytest",
     "pytest-asyncio",


### PR DESCRIPTION
Pin `mypy` to version 1.17 to resolve type inference errors introduced in `mypy==1.18.1`.

---
Linear Issue: [SDK-3738](https://linear.app/stainless/issue/SDK-3738/investigate-mypy-workaround-in-together-py-sdk)

<a href="https://cursor.com/background-agent?bcId=bc-c4bc0166-db6e-4d03-bece-d96d99ca5044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4bc0166-db6e-4d03-bece-d96d99ca5044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

