### PR TITLE
Investigate mypy typing issue in together-py

### DIFF
--- a/src/together/_utils/_utils.py
+++ b/src/together/_utils/_utils.py
@@ -371,18 +371,17 @@ def file_from_path(path: str) -> FileTypes:
 
 def get_required_header(headers: HeadersLike, header: str) -> str:
     lower_header = header.lower()
-    if is_mapping_t(headers):
-        # mypy doesn't understand the type narrowing here
-        for k, v in headers.items():  # type: ignore[misc, has-type]
-            if k.lower() == lower_header and isinstance(v, str):  # type: ignore[has-type]
-                return v  # type: ignore[has-type]
+    if is_mapping(headers):
+        for k, v in headers.items():
+            if k.lower() == lower_header and isinstance(v, str):
+                return v
 
     # to deal with the case where the header looks like Stainless-Event-Id
     intercaps_header = re.sub(r"([^\w])(\w)", lambda pat: pat.group(1) + pat.group(2).upper(), header.capitalize())
 
     for normalized_header in [header, lower_header, header.upper(), intercaps_header]:
         value = headers.get(normalized_header)
-        if value:
+        if value and isinstance(value, str):
             return value
 
     raise ValueError(f"Could not find {header} header")


### PR DESCRIPTION
Fixes mypy regression by improving type narrowing in `get_required_header`.

Mypy 1.18.1+ introduced a regression causing `[has-type]` errors when using `is_mapping_t` with the `HeadersLike` union type. This PR resolves the underlying typing problem by using `is_mapping` and adding an explicit `isinstance` check, removing the need for `type: ignore` workarounds.

---
Linear Issue: [SDK-3738](https://linear.app/stainless/issue/SDK-3738/investigate-mypy-workaround-in-together-py-sdk)

<a href="https://cursor.com/background-agent?bcId=bc-89fe83e1-c872-4676-b4e8-04bc1ea1183b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89fe83e1-c872-4676-b4e8-04bc1ea1183b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

