### PR TITLE
fix: Ensure jig works with Python 3.9

### DIFF
--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -17,7 +17,7 @@ import shutil
 import typing
 import asyncio
 import subprocess
-from typing import TYPE_CHECKING, Any, Union, Callable
+from typing import TYPE_CHECKING, Any, Union, Callable, Optional
 from pathlib import Path
 from datetime import datetime as dt
 from functools import wraps, cached_property
@@ -26,6 +26,7 @@ from dataclasses import field, asdict, dataclass, is_dataclass
 from typing_extensions import override
 
 import click
+import httpx
 from click import Context, echo
 from click.exceptions import Exit
 
@@ -102,19 +103,19 @@ class DeployConfig:
     description: str = ""
     gpu_type: str = "h100-80gb"
     gpu_count: int = 1
-    cpu: int | float = 1
-    memory: int | float = 8
+    cpu: Union[int, float] = 1
+    memory: Union[int, float] = 8
     storage: int = 100
     min_replicas: int = 1
     max_replicas: int = 1
     port: int = 8000
     environment_variables: dict[str, str] = field(default_factory=dict[str, str])
-    command: list[str] | None = None
+    command: Optional[list[str]] = None
     autoscaling: dict[str, Union[str, float, int]] = field(default_factory=dict[str, Union[str, float, int]])
     health_check_path: str = "/health"
     termination_grace_period_seconds: int = 300
     volume_mounts: list[VolumeMount] = field(default_factory=list[VolumeMount])
-    image: str | None = None
+    image: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> DeployConfig:
@@ -511,7 +512,8 @@ class Jig:
     def registry(self) -> str:
         """Get registry and namespace for current user"""
         if not self.state.registry_base_path:
-            response = self.together.get("/image-repositories/base-path", cast_to=dict[str, str])
+            res = self.together.get("/image-repositories/base-path", cast_to=httpx.Response)
+            response = res.json()
             # strip protocol for docker image format
             self.state.registry_base_path = response["base-path"].split("://", 1)[-1]
             self.state.save()
@@ -913,7 +915,7 @@ def _command(f: Callable[..., Any]) -> Callable[..., Any]:
             msg = str(e)
         except Exception as e:
             if DEBUG:
-                raise
+                raise e
             msg = f"Unexpected error: {e}"
         else:
             if result is not None:


### PR DESCRIPTION
The following would fail when using Python 3.9:

```
mkdir foo && cd foo
together beta jig init
together beta jig deploy
```

It would result in the following error:

```
$ TOGETHER_DEBUG=1 together beta jig deploy
Traceback (most recent call last):
  File "/Users/blaine/sites/together-py/.venv/bin/together", line 10, in <module>
    sys.exit(main())
  File "/Users/blaine/sites/together-py/.venv/lib/python3.9/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/Users/blaine/sites/together-py/.venv/lib/python3.9/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/Users/blaine/sites/together-py/.venv/lib/python3.9/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/blaine/sites/together-py/.venv/lib/python3.9/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/blaine/sites/together-py/.venv/lib/python3.9/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/blaine/sites/together-py/.venv/lib/python3.9/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/blaine/sites/together-py/.venv/lib/python3.9/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/blaine/sites/together-py/.venv/lib/python3.9/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 900, in wrapper
    result = f(Jig(ctx.obj, config_path), *args, **kwargs)
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 1024, in deploy
    jig.deploy(tag, build_only, warmup, detach, docker_args, existing_image)
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 618, in deploy
    elif deployment_image := self.config.deploy.image:
  File "/Users/blaine/.local/share/uv/python/cpython-3.9.18-macos-aarch64-none/lib/python3.9/functools.py", line 993, in __get__
    val = self.func(instance)
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 501, in config
    return Config.find(self._config_path)
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 200, in find
    return cls.load(data, pyproject_path)
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 238, in load
    return cls(
  File "<string>", line 8, in __init__
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 182, in __post_init__
    if err := validate(self, type(self)):
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 162, in validate
    if err := validate(getattr(value, k), t, f"{path}.{k}" if path else k):
  File "/Users/blaine/sites/together-py/src/together/lib/cli/api/beta/jig/jig.py", line 161, in validate
    for k, t in typing.get_type_hints(value_type, globalns=globals()).items():
  File "/Users/blaine/.local/share/uv/python/cpython-3.9.18-macos-aarch64-none/lib/python3.9/typing.py", line 1459, in get_type_hints
    value = _eval_type(value, base_globals, localns)
  File "/Users/blaine/.local/share/uv/python/cpython-3.9.18-macos-aarch64-none/lib/python3.9/typing.py", line 292, in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
  File "/Users/blaine/.local/share/uv/python/cpython-3.9.18-macos-aarch64-none/lib/python3.9/typing.py", line 554, in _evaluate
    eval(self.__forward_code__, globalns, localns),
  File "<string>", line 1, in <module>
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```
