### PR TITLE
fix: Remove certain negative boolean flags that were added by cyclopts

### DIFF
--- a/src/together/lib/cli/api/beta/clusters/get_credentials.py
+++ b/src/together/lib/cli/api/beta/clusters/get_credentials.py
@@ -32,11 +32,12 @@ async def get_credentials(
     overwrite_existing: Annotated[
         bool,
         Parameter(
-            help="If there is a conflict with the existing kubeconfig, overwrite the existing kubeconfig instead of raising an error."
+            help="If there is a conflict with the existing kubeconfig, overwrite the existing kubeconfig instead of raising an error.",
+            negative=False,
         ),
     ] = False,
     set_default_context: Annotated[
-        bool, Parameter(help="If true, set the default context to the cluster name.")
+        bool, Parameter(help="If true, set the default context to the cluster name.", negative=False)
     ] = False,
     *,
     config: CLIConfigParameter,

--- a/src/together/lib/cli/api/endpoints/create.py
+++ b/src/together/lib/cli/api/endpoints/create.py
@@ -20,10 +20,14 @@ MinReplicasParameter = Annotated[int, Parameter(help="Minimum number of replicas
 MaxReplicasParameter = Annotated[int, Parameter(help="Maximum number of replicas to deploy (must be >= 0)")]
 HardwareParameter = Annotated[Optional[str], Parameter(help="Hardware configuration to use for inference")]
 DisplayNameParameter = Annotated[Optional[str], Parameter(help="A human-readable name for the endpoint")]
-NoPromptCacheParameter = Annotated[Optional[bool], Parameter(help="Deprecated and no longer has any effect.")]
-NoSpeculativeDecodingParameter = Annotated[bool, Parameter(help="Disable speculative decoding for this endpoint")]
+NoPromptCacheParameter = Annotated[
+    Optional[bool], Parameter(help="Deprecated and no longer has any effect.", negative=False, show=False)
+]
+NoSpeculativeDecodingParameter = Annotated[
+    bool, Parameter(help="Disable speculative decoding for this endpoint", negative=False)
+]
 NoAutoStartParameter = Annotated[
-    bool, Parameter(help="Create the endpoint in STOPPED state instead of auto-starting it")
+    bool, Parameter(help="Create the endpoint in STOPPED state instead of auto-starting it", negative=False)
 ]
 InactiveTimeoutParameter = Annotated[
     Optional[int],
@@ -34,7 +38,7 @@ InactiveTimeoutParameter = Annotated[
 AvailabilityZoneParameter = Annotated[
     Optional[str], Parameter(help="Start endpoint in specified availability zone (e.g., us-central-4b)")
 ]
-WaitParameter = Annotated[bool, Parameter(help="Wait for the endpoint to be ready after creation")]
+WaitParameter = Annotated[bool, Parameter(help="Wait for the endpoint to be ready after creation", negative=False)]
 
 
 @handle_endpoint_api_errors("Endpoints")

--- a/src/together/lib/cli/api/endpoints/list.py
+++ b/src/together/lib/cli/api/endpoints/list.py
@@ -18,9 +18,12 @@ from together.lib.cli.utils._mock_pagination import AfterParameter, mock_paginat
 async def list(
     _type: Annotated[
         Optional[Literal["dedicated", "serverless"]],
-        Parameter(name="--type", help="Deprecated and no longer has any effect."),
+        Parameter(name="--type", help="Deprecated and no longer has any effect.", show=False),
     ] = None,
-    _mine: Annotated[Optional[bool], Parameter(name="--mine", help="Deprecated and no longer has any effect.")] = None,
+    _mine: Annotated[
+        Optional[bool],
+        Parameter(name="--mine", help="Deprecated and no longer has any effect.", negative=False, show=False),
+    ] = None,
     usage_type: Annotated[
         Optional[Literal["on-demand", "reserved"]], Parameter(help="Filter by usage type options")
     ] = None,

--- a/src/together/lib/cli/api/endpoints/start.py
+++ b/src/together/lib/cli/api/endpoints/start.py
@@ -16,7 +16,7 @@ async def start(
         str,
         Parameter(required=True, help="The ID of the endpoint to start"),
     ],
-    wait: Annotated[bool, Parameter(help="Wait for the endpoint to start")] = False,
+    wait: Annotated[bool, Parameter(help="Wait for the endpoint to start", negative=False)] = False,
     *,
     config: CLIConfigParameter,
 ) -> None:

--- a/src/together/lib/cli/api/endpoints/stop.py
+++ b/src/together/lib/cli/api/endpoints/stop.py
@@ -15,7 +15,7 @@ from together.lib.cli.api.endpoints._utils import handle_endpoint_api_errors
 @handle_endpoint_api_errors("Endpoints")
 async def stop(
     endpoint_id: str,
-    wait: Annotated[bool, Parameter(help="Wait for the endpoint to stop")] = False,
+    wait: Annotated[bool, Parameter(help="Wait for the endpoint to stop", negative=False)] = False,
     *,
     config: CLIConfigParameter,
 ) -> None:

--- a/src/together/lib/cli/api/fine_tuning/delete.py
+++ b/src/together/lib/cli/api/fine_tuning/delete.py
@@ -14,7 +14,7 @@ from together.lib.cli.components.loader import show_loading_status
 async def delete(
     fine_tune_id: str,
     force: Annotated[Optional[bool], Parameter(negative="", help="Force deletion without confirmation")] = False,
-    quiet: Annotated[Optional[bool], Parameter(negative="", help="Deprecated, use --force instead")] = None,
+    quiet: Annotated[Optional[bool], Parameter(negative="", help="Deprecated, use --force instead", show=False)] = None,
     *,
     config: CLIConfigParameter,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "together"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
| Command | Before | After |
|---|---|---|
| `clusters get-credentials` |<img width="861" height="218" alt="image" src="https://github.com/user-attachments/assets/183ae0ea-8504-468e-be45-22731a525fe1" />|<img width="862" height="212" alt="image" src="https://github.com/user-attachments/assets/f18795cd-1b22-4d9c-8ec5-f88d83fc2742" />|
| `endpoints create` |<img width="859" height="302" alt="image" src="https://github.com/user-attachments/assets/838df47e-96a6-48cd-a9e8-20e880c43298" />| <img width="858" height="257" alt="image" src="https://github.com/user-attachments/assets/dfee0cc3-9ad0-4983-b6c7-f847af57fade" /> |
| `endpoints list` |<img width="860" height="173" alt="image" src="https://github.com/user-attachments/assets/9539ae91-8f3f-4989-b9d3-3638f9a6f203" />|<img width="859" height="145" alt="image" src="https://github.com/user-attachments/assets/6827184d-1317-4b4a-b76a-15aac265a869" />|
| `endpoints start` |<img width="855" height="145" alt="image" src="https://github.com/user-attachments/assets/9898b781-9647-48bb-b5e9-65a9db00c87e" />|<img width="857" height="146" alt="image" src="https://github.com/user-attachments/assets/7f6085fe-4d4a-43c1-b127-e4c93173d732" />|
| `endpoints stop` |<img width="859" height="146" alt="image" src="https://github.com/user-attachments/assets/7ba0e787-9715-446f-b3f6-1d2bbc2504bc" />|<img width="856" height="144" alt="image" src="https://github.com/user-attachments/assets/14e81f37-4fd2-4a9e-9705-42b7296bfb10" />|
| `fine-tuning delete` |<img width="860" height="155" alt="image" src="https://github.com/user-attachments/assets/1d6f3345-c6ec-4a85-9296-9d4ed63b9924" />|<img width="860" height="144" alt="image" src="https://github.com/user-attachments/assets/8826f7dd-d191-42cd-a3ba-02e1d7bfa068" />|

Note: Also hiding some parameters that are now deprecated or unfunctional