### PR TITLE
fix: Remove false positives with `files check` command in certain scenarios

### DIFF
--- a/src/together/lib/utils/files.py
+++ b/src/together/lib/utils/files.py
@@ -75,6 +75,7 @@ def check_file(
     if not file.is_file():
         report_dict["found"] = False
         report_dict["is_check_passed"] = False
+        report_dict["message"] = f"File not found or path is not a regular file: {file}"
         return report_dict
     else:
         report_dict["found"] = True
@@ -105,9 +106,11 @@ def check_file(
         report_dict["filetype"] = "csv"
         data_report_dict = _check_csv(file, purpose)
     else:
-        report_dict["filetype"] = (
+        unknown_ext_msg = (
             f"Unknown extension of file {file}. Only files with extensions .jsonl, .parquet, and .csv are supported."
         )
+        report_dict["filetype"] = unknown_ext_msg
+        report_dict["message"] = unknown_ext_msg
         report_dict["is_check_passed"] = False
 
     report_dict.update(data_report_dict)

--- a/tests/cli/test_files.py
+++ b/tests/cli/test_files.py
@@ -68,6 +68,21 @@ class TestFilesCheck:
         result = cli_runner.invoke(["files", "check", str(sample)])
         assert result.exit_code == 0
 
+    def test_check_missing_file(self, tmp_path: Path, cli_runner: CliRunner) -> None:
+        missing = tmp_path / "nope.jsonl"
+        result = cli_runner.invoke(["files", "check", str(missing)])
+        assert result.exit_code == 1
+        assert "Checks passed" not in result.output
+        assert "not found" in result.output.lower() or "not a regular file" in result.output.lower()
+
+    def test_check_non_jsonl_extension(self, tmp_path: Path, cli_runner: CliRunner) -> None:
+        bad = tmp_path / "bad.txt"
+        bad.write_text("notjson", encoding="utf-8")
+        result = cli_runner.invoke(["files", "check", str(bad)])
+        assert result.exit_code == 1
+        assert "Checks passed" not in result.output
+        assert "Unknown extension" in result.output
+
 
 class TestFilesDelete:
     @pytest.mark.respx(base_url=base_url)

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -572,3 +572,21 @@ def test_check_csv_invalid_column(tmp_path: Path):
     report = check_file(file)
 
     assert not report["is_check_passed"]
+
+
+def test_check_file_missing_path(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.jsonl"
+    report = check_file(missing)
+    assert not report["is_check_passed"]
+    assert report["found"] is False
+    assert "Checks passed" not in report["message"]
+    assert "not found" in report["message"].lower() or "not a regular file" in report["message"].lower()
+
+
+def test_check_file_unknown_extension(tmp_path: Path) -> None:
+    f = tmp_path / "data.txt"
+    f.write_text("notjson\n", encoding="utf-8")
+    report = check_file(f)
+    assert not report["is_check_passed"]
+    assert "Unknown extension" in report["message"]
+    assert report["message"] == report["filetype"]


### PR DESCRIPTION

Previously:

```
echo "notjson" > /tmp/bad.txt
tg files check /tmp/bad.txt              # prints ":x: Checks passed"
tg files check /tmp/does_not_exist.jsonl # prints ":x: Checks passed"
```

Now:
```
echo "notjson" > /tmp/bad.txt
tg files check /tmp/bad.txt              # prints ":x: Unknown extension of file /tmp/bad.txt. Only files with extensions .jsonl, .parquet, and .csv are supported."
tg files check /tmp/does_not_exist.jsonl # prints ":x: File not found or path is not a regular file: /tmp/does_not_exist.jsonl"
```