### PR TITLE
feat: Add `ls` shorthand command for `list` commands in cli

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -281,7 +281,7 @@ _CLI = "together.lib.cli.api"
 ## Files API commands
 files_app = app.command(App(name="files", help="File API commands"))
 files_app.command(f"{_CLI}.files.upload:upload", help="Upload files for fine-tuning, evals, etc.")
-files_app.command(f"{_CLI}.files.list:list", help="List files on the Together platform")
+files_app.command(f"{_CLI}.files.list:list", alias="ls", help="List files on the Together platform")
 files_app.command(f"{_CLI}.files.retrieve:retrieve", help="Retrieve metadata for a file from the Together platform")
 files_app.command(
     f"{_CLI}.files.retrieve_content:retrieve_content", help="Download the contents of a file from the Together platform"
@@ -292,7 +292,9 @@ files_app.command(f"{_CLI}.files.check:check", help="Check a local file for issu
 # Fine-tuning API commands
 fine_tuning_app = app.command(App(name="fine-tuning", help="Fine-tuning API commands", alias="ft"))
 fine_tuning_app.command((f"{_CLI}.fine_tuning.create:create"), help="Start a new fine-tuning job")
-fine_tuning_app.command((f"{_CLI}.fine_tuning.list:list"), help="List fine-tuning jobs on the Together platform")
+fine_tuning_app.command(
+    (f"{_CLI}.fine_tuning.list:list"), alias="ls", help="List fine-tuning jobs on the Together platform"
+)
 fine_tuning_app.command(
     (f"{_CLI}.fine_tuning.retrieve:retrieve"), help="Retrieve metadata for a fine-tuning job from the Together platform"
 )
@@ -314,7 +316,7 @@ fine_tuning_app.command(
 
 ## Models API commands
 models_app = app.command(App(name="models", help="Models API commands"))
-models_app.command((f"{_CLI}.models.list:list"), help="List models on the Together platform")
+models_app.command((f"{_CLI}.models.list:list"), alias="ls", help="List models on the Together platform")
 models_app.command((f"{_CLI}.models.upload:upload"), help="Upload a model to the Together platform")
 
 ## Endpoints API commands
@@ -329,7 +331,7 @@ endpoints_app.command(
 endpoints_app.command((f"{_CLI}.endpoints.stop:stop"), help="Stop an endpoint")
 endpoints_app.command((f"{_CLI}.endpoints.start:start"), help="Start an endpoint")
 endpoints_app.command((f"{_CLI}.endpoints.delete:delete"), help="Delete an endpoint from the Together platform")
-endpoints_app.command((f"{_CLI}.endpoints.list:list"), help="List endpoints on the Together platform")
+endpoints_app.command((f"{_CLI}.endpoints.list:list"), alias="ls", help="List endpoints on the Together platform")
 endpoints_app.command((f"{_CLI}.endpoints.update:update"), help="Update an endpoint on the Together platform")
 endpoints_app.command(
     (f"{_CLI}.endpoints.availability_zones:availability_zones"), help="List availability zones for deploying models"
@@ -338,7 +340,7 @@ endpoints_app.command(
 ## Evals API commands
 evals_app = app.command(App(name="evals", help="Evals API commands"))
 evals_app.command((f"{_CLI}.evals.create:create"), help="Create a new eval job")
-evals_app.command((f"{_CLI}.evals.list:list"), help="List eval jobs on the Together platform")
+evals_app.command((f"{_CLI}.evals.list:list"), alias="ls", help="List eval jobs on the Together platform")
 evals_app.command(
     (f"{_CLI}.evals.retrieve:retrieve"), help="Retrieve metadata for an eval job from the Together platform"
 )
@@ -358,7 +360,7 @@ beta_app = app.command(beta_root_app)
 
 ### Clusters API commands
 clusters_app = beta_app.command(App(name="clusters", help="Clusters API commands"))
-clusters_app.command((f"{_CLI}.beta.clusters.list:list"), help="List clusters on the Together platform")
+clusters_app.command((f"{_CLI}.beta.clusters.list:list"), alias="ls", help="List clusters on the Together platform")
 clusters_app.command((f"{_CLI}.beta.clusters.create:create"), help="Create a new cluster")
 clusters_app.command(
     (f"{_CLI}.beta.clusters.retrieve:retrieve"), help="Retrieve metadata for a cluster from the Together platform"
@@ -370,7 +372,7 @@ clusters_app.command((f"{_CLI}.beta.clusters.get_credentials:get_credentials"), 
 
 ### Clusters > Storage API commands
 storage_app = clusters_app.command(App(name="storage", help="Clusters Storage API commands", group="Subcommands"))
-storage_app.command((f"{_CLI}.beta.clusters.storage.list:list"), help="List storage volumes for a cluster")
+storage_app.command((f"{_CLI}.beta.clusters.storage.list:list"), alias="ls", help="List storage volumes for a cluster")
 storage_app.command((f"{_CLI}.beta.clusters.storage.create:create"), help="Create a new storage volume for a cluster")
 storage_app.command(
     (f"{_CLI}.beta.clusters.storage.retrieve:retrieve"),
@@ -398,7 +400,7 @@ jig_app.command((f"{_CLI}.beta.jig.jig:job_status_cli"), name="job-status", help
 jig_app.command(
     (f"{_CLI}.beta.jig.jig:queue_status_cli"), name="queue-status", help="Get queue metrics for the deployment"
 )
-jig_app.command((f"{_CLI}.beta.jig.jig:list_deployments_cli"), name="list", help="List all deployments")
+jig_app.command((f"{_CLI}.beta.jig.jig:list_deployments_cli"), name="list", alias="ls", help="List all deployments")
 
 secrets_app = jig_app.command(App(name="secrets", help="Manage deployment secrets", group="Subcommands"))
 secrets_app.command((f"{_CLI}.beta.jig.jig:secrets_set_cli"), name="set", help="Set a secret (create or update)")
@@ -406,7 +408,9 @@ secrets_app.command((f"{_CLI}.beta.jig.jig:secrets_unset_cli"), name="unset", he
 secrets_app.command(
     (f"{_CLI}.beta.jig.jig:secrets_delete_cli"), name="delete", help="Delete a secret and unset it locally"
 )
-secrets_app.command((f"{_CLI}.beta.jig.jig:secrets_list_cli"), name="list", help="List all secrets with sync status")
+secrets_app.command(
+    (f"{_CLI}.beta.jig.jig:secrets_list_cli"), name="list", alias="ls", help="List all secrets with sync status"
+)
 
 ### Jig > volumes
 storage_app = jig_app.command(App(name="volumes", help="Jig Volumes API commands", group="Subcommands"))
@@ -424,7 +428,9 @@ storage_app.command(
     name="describe",
     help="Retrieve metadata for a volume from the Together platform",
 )
-storage_app.command((f"{_CLI}.beta.jig.jig:jig_volumes_list"), name="list", help="List volumes for a JIG deployment")
+storage_app.command(
+    (f"{_CLI}.beta.jig.jig:jig_volumes_list"), name="list", alias="ls", help="List volumes for a JIG deployment"
+)
 
 
 def main() -> None:

--- a/src/together/lib/cli/_track_cli.py
+++ b/src/together/lib/cli/_track_cli.py
@@ -207,6 +207,7 @@ def _canonical_telemetry_command(cmd: str) -> str:
     primary = _TELEMETRY_SUBCOMMAND_ALIASES.get(parts[0])
     if primary is not None:
         parts[0] = primary
+    parts = ["list" if p == "ls" else p for p in parts]
     return " ".join(parts)
 
 
@@ -217,6 +218,7 @@ def parse_command_and_flags(app: App, tokens: list[str]) -> tuple[str, list[str]
     whether the invocation is under ``beta``.
 
     Subcommand aliases (e.g. ``ft``) are normalized to their primary names (e.g. ``fine-tuning``).
+    The ``list`` alias ``ls`` is normalized to ``list`` in the returned command path.
 
     Requires the root cyclopts :class:`~cyclopts.App` so positional values are not mistaken
     for subcommand tokens (e.g. ``beta jig secrets set <name> <value>``).

--- a/src/together/lib/cli/utils/_help_formatter.py
+++ b/src/together/lib/cli/utils/_help_formatter.py
@@ -20,11 +20,11 @@ def _names_renderer(entry: HelpEntry) -> str:
     """Combine parameter names and shorts."""
     # Commands
     if len(entry.names) == 1:
-        return entry.names[0]
-
-    # Subcommand aliases (e.g. fine-tuning + ft): cyclopts puts all in positive_names
-    if not entry.shorts and all(not n.startswith("-") for n in entry.names):
-        return f"{entry.names[0]} ({', '.join(entry.names[1:])})"
+        names = entry.names[0]
+        short_part = ", ".join(entry.shorts).strip() if entry.shorts else ""
+        if short_part:
+            return f"{short_part}, {names}"
+        return names
 
     # Parameters
     names = " ".join(entry.names[1:]) if entry.names else ""

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -178,6 +178,16 @@ def test_parse_command_and_flags_normalizes_ft_to_fine_tuning() -> None:
     assert is_beta is False
 
 
+def test_parse_command_and_flags_normalizes_ls_alias_to_list() -> None:
+    from together.lib.cli import app
+    from together.lib.cli._track_cli import parse_command_and_flags
+
+    cmd, flags, is_beta = parse_command_and_flags(app, ["endpoints", "ls", "--json"])
+    assert cmd == "endpoints list"
+    assert flags == ["json"]
+    assert is_beta is False
+
+
 def test_parse_command_and_flags_positionals_are_argument_names_not_command_tokens() -> None:
     from together.lib.cli import app
     from together.lib.cli._track_cli import parse_command_and_flags


### PR DESCRIPTION
This add `ls` as a shorthand command for all `list` commands. The following are now valid:

```
tg files ls
tg ft ls
tg endpoints ls
tg evals ls
tg models ls
tg beta clusters ls
tg beta clusters storage ls
tg beta jig ls
tg beta jig secrets ls
tg beta jig volumes ls
```

example of help output with alias commands
<img width="701" height="151" alt="image" src="https://github.com/user-attachments/assets/c9f6cc20-8766-4513-a672-bc256cc8f63d" />
