### PR TITLE
chore: Add `-d` as an alias for the delete command

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -285,7 +285,7 @@ files_app.command(f"{_CLI}.files.retrieve:retrieve", help="Retrieve metadata for
 files_app.command(
     f"{_CLI}.files.retrieve_content:retrieve_content", help="Download the contents of a file from the Together platform"
 )
-files_app.command(f"{_CLI}.files.delete:delete", help="Delete a file from the Together platform")
+files_app.command(f"{_CLI}.files.delete:delete", help="Delete a file from the Together platform", alias="-d")
 files_app.command(f"{_CLI}.files.check:check", help="Check a local file for issues")
 
 # Fine-tuning API commands
@@ -310,7 +310,9 @@ fine_tuning_app.command(
     help="Download the weights of a fine-tuned model from the Together platform",
 )
 fine_tuning_app.command(
-    (f"{_CLI}.fine_tuning.delete:delete"), help="Delete a fine-tuning job from the Together platform"
+    (f"{_CLI}.fine_tuning.delete:delete"),
+    help="Delete a fine-tuning job from the Together platform",
+    alias="-d",
 )
 
 ## Models API commands
@@ -329,7 +331,11 @@ endpoints_app.command(
 )
 endpoints_app.command((f"{_CLI}.endpoints.stop:stop"), help="Stop an endpoint")
 endpoints_app.command((f"{_CLI}.endpoints.start:start"), help="Start an endpoint")
-endpoints_app.command((f"{_CLI}.endpoints.delete:delete"), help="Delete an endpoint from the Together platform")
+endpoints_app.command(
+    (f"{_CLI}.endpoints.delete:delete"),
+    help="Delete an endpoint from the Together platform",
+    alias="-d",
+)
 endpoints_app.command((f"{_CLI}.endpoints.list:list"), alias="ls", help="List endpoints on the Together platform")
 endpoints_app.command((f"{_CLI}.endpoints.update:update"), help="Update an endpoint on the Together platform")
 endpoints_app.command(
@@ -365,7 +371,11 @@ clusters_app.command(
     (f"{_CLI}.beta.clusters.retrieve:retrieve"), help="Retrieve metadata for a cluster from the Together platform"
 )
 clusters_app.command((f"{_CLI}.beta.clusters.update:update"), help="Update a cluster on the Together platform")
-clusters_app.command((f"{_CLI}.beta.clusters.delete:delete"), help="Delete a cluster from the Together platform")
+clusters_app.command(
+    (f"{_CLI}.beta.clusters.delete:delete"),
+    help="Delete a cluster from the Together platform",
+    alias="-d",
+)
 clusters_app.command((f"{_CLI}.beta.clusters.list_regions:list_regions"), help="List regions for deploying clusters")
 clusters_app.command((f"{_CLI}.beta.clusters.get_credentials:get_credentials"), help="Get credentials for a cluster")
 
@@ -378,7 +388,9 @@ storage_app.command(
     help="Retrieve metadata for a storage volume from the Together platform",
 )
 storage_app.command(
-    (f"{_CLI}.beta.clusters.storage.delete:delete"), help="Delete a storage volume from the Together platform"
+    (f"{_CLI}.beta.clusters.storage.delete:delete"),
+    help="Delete a storage volume from the Together platform",
+    alias="-d",
 )
 
 ### JIG API commands
@@ -405,7 +417,10 @@ secrets_app = jig_app.command(App(name="secrets", help="Manage deployment secret
 secrets_app.command((f"{_CLI}.beta.jig.jig:secrets_set_cli"), name="set", help="Set a secret (create or update)")
 secrets_app.command((f"{_CLI}.beta.jig.jig:secrets_unset_cli"), name="unset", help="Remove a secret from local state")
 secrets_app.command(
-    (f"{_CLI}.beta.jig.jig:secrets_delete_cli"), name="delete", help="Delete a secret and unset it locally"
+    (f"{_CLI}.beta.jig.jig:secrets_delete_cli"),
+    name="delete",
+    help="Delete a secret and unset it locally",
+    alias="-d",
 )
 secrets_app.command(
     (f"{_CLI}.beta.jig.jig:secrets_list_cli"), name="list", alias="ls", help="List all secrets with sync status"
@@ -420,7 +435,10 @@ storage_app.command(
     (f"{_CLI}.beta.jig.jig:jig_volumes_update_cli"), name="update", help="Update a volume and re-upload files"
 )
 storage_app.command(
-    (f"{_CLI}.beta.jig.jig:jig_volumes_delete_cli"), name="delete", help="Delete a volume from the Together platform"
+    (f"{_CLI}.beta.jig.jig:jig_volumes_delete_cli"),
+    name="delete",
+    help="Delete a volume from the Together platform",
+    alias="-d",
 )
 storage_app.command(
     (f"{_CLI}.beta.jig.jig:jig_volumes_describe"),

--- a/src/together/lib/cli/_track_cli.py
+++ b/src/together/lib/cli/_track_cli.py
@@ -208,6 +208,7 @@ def _canonical_telemetry_command(cmd: str) -> str:
     if primary is not None:
         parts[0] = primary
     parts = ["list" if p == "ls" else p for p in parts]
+    parts = ["delete" if p == "-d" else p for p in parts]
     return " ".join(parts)
 
 
@@ -219,6 +220,7 @@ def parse_command_and_flags(app: App, tokens: list[str]) -> tuple[str, list[str]
 
     Subcommand aliases (e.g. ``ft``) are normalized to their primary names (e.g. ``fine-tuning``).
     The ``list`` alias ``ls`` is normalized to ``list`` in the returned command path.
+    The ``delete`` alias ``-d`` is normalized to ``delete`` in the returned command path.
 
     Requires the root cyclopts :class:`~cyclopts.App` so positional values are not mistaken
     for subcommand tokens (e.g. ``beta jig secrets set <name> <value>``).

--- a/src/together/lib/cli/utils/_help_formatter.py
+++ b/src/together/lib/cli/utils/_help_formatter.py
@@ -19,17 +19,11 @@ def _is_union_origin(origin: object | None) -> bool:
 def _names_renderer(entry: HelpEntry) -> str:
     """Combine parameter names and shorts."""
     # Commands
-    if len(entry.names) == 1:
-        names = entry.names[0]
-        short_part = ", ".join(entry.shorts).strip() if entry.shorts else ""
-        if short_part:
-            return f"{short_part}, {names}"
-        return names
-
-    # Parameters
-    names = " ".join(entry.names[1:]) if entry.names else ""
-    shorts = " ".join(entry.shorts) if entry.shorts else ""
-    return " ".join([names, shorts]).strip()
+    names = ", ".join(sorted(entry.names, key=len)).strip() if entry.names else ""
+    short_part = ", ".join(entry.shorts).strip() if entry.shorts else ""
+    if short_part:
+        return f"{short_part}, {names}"
+    return names
 
 
 def _strip_annotated_for_display(hint: object) -> object:

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -230,6 +230,16 @@ def test_parse_command_and_flags_normalizes_ls_alias_to_list() -> None:
     assert is_beta is False
 
 
+def test_parse_command_and_flags_normalizes_minus_d_alias_to_delete() -> None:
+    from together.lib.cli import app
+    from together.lib.cli._track_cli import parse_command_and_flags
+
+    cmd, flags, is_beta = parse_command_and_flags(app, ["endpoints", "-d", "ep-1", "--json", "--yes"])
+    assert cmd == "endpoints delete"
+    assert "endpoint_id" in flags
+    assert is_beta is False
+
+
 def test_parse_command_and_flags_positionals_are_argument_names_not_command_tokens() -> None:
     from together.lib.cli import app
     from together.lib.cli._track_cli import parse_command_and_flags


### PR DESCRIPTION
Adds `-d` as an alias for delete commands. E.g.,

`tg ft -d ft-12345-61324` will run the delete command just the same as `tg ft delete`

Help output:

<img width="1199" height="227" alt="image" src="https://github.com/user-attachments/assets/9ac9dab9-227e-4c50-b807-f012a5af4059" />
