### PR TITLE
chore: Add `-c` as an alias for the create command

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -290,7 +290,7 @@ files_app.command(f"{_CLI}.files.check:check", help="Check a local file for issu
 
 # Fine-tuning API commands
 fine_tuning_app = app.command(App(name="fine-tuning", help="Fine-tuning API commands", alias="ft"))
-fine_tuning_app.command((f"{_CLI}.fine_tuning.create:create"), help="Start a new fine-tuning job")
+fine_tuning_app.command((f"{_CLI}.fine_tuning.create:create"), alias="-c", help="Start a new fine-tuning job")
 fine_tuning_app.command(
     (f"{_CLI}.fine_tuning.list:list"), alias="ls", help="List fine-tuning jobs on the Together platform"
 )
@@ -325,7 +325,7 @@ endpoints_app = app.command(App(name="endpoints", help="Endpoints API commands")
 endpoints_app.command(
     (f"{_CLI}.endpoints.hardware:hardware"), help="List available hardware configurations for deploying models"
 )
-endpoints_app.command((f"{_CLI}.endpoints.create:create"), help="Create a new endpoint")
+endpoints_app.command((f"{_CLI}.endpoints.create:create"), alias="-c", help="Create a new endpoint")
 endpoints_app.command(
     (f"{_CLI}.endpoints.retrieve:retrieve"), help="Retrieve metadata for an endpoint from the Together platform"
 )
@@ -344,7 +344,7 @@ endpoints_app.command(
 
 ## Evals API commands
 evals_app = app.command(App(name="evals", help="Evals API commands"))
-evals_app.command((f"{_CLI}.evals.create:create"), help="Create a new eval job")
+evals_app.command((f"{_CLI}.evals.create:create"), alias="-c", help="Create a new eval job")
 evals_app.command((f"{_CLI}.evals.list:list"), alias="ls", help="List eval jobs on the Together platform")
 evals_app.command(
     (f"{_CLI}.evals.retrieve:retrieve"), help="Retrieve metadata for an eval job from the Together platform"
@@ -366,7 +366,7 @@ beta_app = app.command(beta_root_app)
 ### Clusters API commands
 clusters_app = beta_app.command(App(name="clusters", help="Clusters API commands"))
 clusters_app.command((f"{_CLI}.beta.clusters.list:list"), alias="ls", help="List clusters on the Together platform")
-clusters_app.command((f"{_CLI}.beta.clusters.create:create"), help="Create a new cluster")
+clusters_app.command((f"{_CLI}.beta.clusters.create:create"), alias="-c", help="Create a new cluster")
 clusters_app.command(
     (f"{_CLI}.beta.clusters.retrieve:retrieve"), help="Retrieve metadata for a cluster from the Together platform"
 )
@@ -382,7 +382,9 @@ clusters_app.command((f"{_CLI}.beta.clusters.get_credentials:get_credentials"), 
 ### Clusters > Storage API commands
 storage_app = clusters_app.command(App(name="storage", help="Clusters Storage API commands", group="Subcommands"))
 storage_app.command((f"{_CLI}.beta.clusters.storage.list:list"), alias="ls", help="List storage volumes for a cluster")
-storage_app.command((f"{_CLI}.beta.clusters.storage.create:create"), help="Create a new storage volume for a cluster")
+storage_app.command(
+    (f"{_CLI}.beta.clusters.storage.create:create"), alias="-c", help="Create a new storage volume for a cluster"
+)
 storage_app.command(
     (f"{_CLI}.beta.clusters.storage.retrieve:retrieve"),
     help="Retrieve metadata for a storage volume from the Together platform",

--- a/src/together/lib/cli/_track_cli.py
+++ b/src/together/lib/cli/_track_cli.py
@@ -209,6 +209,7 @@ def _canonical_telemetry_command(cmd: str) -> str:
         parts[0] = primary
     parts = ["list" if p == "ls" else p for p in parts]
     parts = ["delete" if p == "-d" else p for p in parts]
+    parts = ["create" if p == "-c" else p for p in parts]
     return " ".join(parts)
 
 
@@ -221,6 +222,7 @@ def parse_command_and_flags(app: App, tokens: list[str]) -> tuple[str, list[str]
     Subcommand aliases (e.g. ``ft``) are normalized to their primary names (e.g. ``fine-tuning``).
     The ``list`` alias ``ls`` is normalized to ``list`` in the returned command path.
     The ``delete`` alias ``-d`` is normalized to ``delete`` in the returned command path.
+    The ``create`` alias ``-c`` is normalized to ``create`` in the returned command path.
 
     Requires the root cyclopts :class:`~cyclopts.App` so positional values are not mistaken
     for subcommand tokens (e.g. ``beta jig secrets set <name> <value>``).
@@ -277,10 +279,10 @@ def _redact_secrets_in_error_text(s: str) -> str:
         s,
     )
     # OpenAI / common `sk-…` API keys; Hugging Face `hf_…`; Together-style `tog_…`
-    s = re.sub(r"(?i)(?<![a-z0-9_-])(sk-[a-z0-9_-]{20,})(?![a-z0-9_-])", "<redacted>", s)
-    s = re.sub(r"(?i)(?<![a-z0-9_])(hf_[a-z0-9_-]{20,})(?![a-z0-9_])", "<redacted>", s)
-    s = re.sub(r"(?i)(?<![a-z0-9_])(tgp_[a-z0-9_-]{8,})(?![a-z0-9_])", "<redacted>", s)
-    s = re.sub(r"(?i)(bearer\s+)[A-Za-z0-9._\-/+]{20,}", r"\1<redacted>", s)
+    s = re.sub(r"(?i)(?<![a-z0-9_-])(sk-[a-z0-9_-]+)(?![a-z0-9_-])", "<redacted>", s)
+    s = re.sub(r"(?i)(?<![a-z0-9_])(hf_[a-z0-9_-]+)(?![a-z0-9_])", "<redacted>", s)
+    s = re.sub(r"(?i)(?<![a-z0-9_])(tgp_[a-z0-9_-]+)(?![a-z0-9_])", "<redacted>", s)
+    s = re.sub(r"(?i)(bearer\s+)[A-Za-z0-9._\-/+]+", r"\1<redacted>", s)
     s = re.sub(
         r"(?i)(api[_-]?key\s*[\"':=]\s*|api[_-]?key\s+)([A-Za-z0-9._\-]{20,})",
         r"\1<redacted>",

--- a/src/together/lib/cli/utils/_help_formatter.py
+++ b/src/together/lib/cli/utils/_help_formatter.py
@@ -18,12 +18,20 @@ def _is_union_origin(origin: object | None) -> bool:
 # Define custom column renderers
 def _names_renderer(entry: HelpEntry) -> str:
     """Combine parameter names and shorts."""
+    is_command = entry.type is None
+
     # Commands
-    names = ", ".join(sorted(entry.names, key=len)).strip() if entry.names else ""
-    short_part = ", ".join(entry.shorts).strip() if entry.shorts else ""
-    if short_part:
-        return f"{short_part}, {names}"
-    return names
+    if is_command:
+        names = ", ".join(sorted(entry.names, key=len)).strip() if entry.names else ""
+        short_part = ", ".join(entry.shorts).strip() if entry.shorts else ""
+        if short_part:
+            return f"{short_part}, {names}"
+        return names
+
+    # Parameters
+    names = " ".join(entry.names[1:]) if entry.names else ""
+    shorts = " ".join(entry.shorts) if entry.shorts else ""
+    return " ".join([names, shorts]).strip()
 
 
 def _strip_annotated_for_display(hint: object) -> object:

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -240,6 +240,16 @@ def test_parse_command_and_flags_normalizes_minus_d_alias_to_delete() -> None:
     assert is_beta is False
 
 
+def test_parse_command_and_flags_normalizes_minus_c_alias_to_create() -> None:
+    from together.lib.cli import app
+    from together.lib.cli._track_cli import parse_command_and_flags
+
+    cmd, flags, is_beta = parse_command_and_flags(app, ["endpoints", "-c", "--model", "model-1"])
+    assert cmd == "endpoints create"
+    assert "model" in flags
+    assert is_beta is False
+
+
 def test_parse_command_and_flags_positionals_are_argument_names_not_command_tokens() -> None:
     from together.lib.cli import app
     from together.lib.cli._track_cli import parse_command_and_flags


### PR DESCRIPTION
Adds `-c` as an alias for `create` commands. E.g.,

`tg endpoints -c` will run the create command just the same as `tg endpoints create`

Help output:

<img width="571" height="231" alt="image" src="https://github.com/user-attachments/assets/53538037-6f81-4266-8b1f-7eeedbbc65e8" />
