### PR TITLE
feat: Add default retrieve handler when passing an id to commands

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -19,7 +19,6 @@ from together.lib.cli._track_cli import (
     CliTrackingEvents,
     track_cli,
     flush_pending_events,
-    parse_command_and_flags,
     sanitize_cli_error_message,
 )
 from together.lib.cli.utils.config import CLIConfig
@@ -28,6 +27,7 @@ from together.lib.cli.utils._console import console
 from together.lib.cli.utils._api_error import try_handle_server_error_message
 from together.lib.cli.utils._completion import install_completion
 from together.lib.cli.utils._help_formatter import help_formatter
+from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
 app = App(
     version=__version__,
@@ -131,8 +131,7 @@ async def launcher(
         json=output_json or False,
     )
 
-    remaining = list(tokens)
-    (parsed_command, explicit_args, is_beta_command) = parse_command_and_flags(app, [*remaining])
+    (parsed_command, explicit_args, is_beta_command, remaining) = preparse_tokens(app, [*tokens])
 
     if output_json:
         explicit_args.append("json")
@@ -380,16 +379,20 @@ clusters_app.command((f"{_CLI}.beta.clusters.list_regions:list_regions"), help="
 clusters_app.command((f"{_CLI}.beta.clusters.get_credentials:get_credentials"), help="Get credentials for a cluster")
 
 ### Clusters > Storage API commands
-storage_app = clusters_app.command(App(name="storage", help="Clusters Storage API commands", group="Subcommands"))
-storage_app.command((f"{_CLI}.beta.clusters.storage.list:list"), alias="ls", help="List storage volumes for a cluster")
-storage_app.command(
+clusters_storage_app = clusters_app.command(
+    App(name="storage", help="Clusters Storage API commands", group="Subcommands")
+)
+clusters_storage_app.command(
+    (f"{_CLI}.beta.clusters.storage.list:list"), alias="ls", help="List storage volumes for a cluster"
+)
+clusters_storage_app.command(
     (f"{_CLI}.beta.clusters.storage.create:create"), alias="-c", help="Create a new storage volume for a cluster"
 )
-storage_app.command(
+clusters_storage_app.command(
     (f"{_CLI}.beta.clusters.storage.retrieve:retrieve"),
     help="Retrieve metadata for a storage volume from the Together platform",
 )
-storage_app.command(
+clusters_storage_app.command(
     (f"{_CLI}.beta.clusters.storage.delete:delete"),
     help="Delete a storage volume from the Together platform",
     alias="-d",
@@ -431,7 +434,10 @@ secrets_app.command(
 ### Jig > volumes
 storage_app = jig_app.command(App(name="volumes", help="Jig Volumes API commands", group="Subcommands"))
 storage_app.command(
-    (f"{_CLI}.beta.jig.jig:jig_volumes_create_cli"), name="create", help="Create a new volume for a JIG deployment"
+    (f"{_CLI}.beta.jig.jig:jig_volumes_create_cli"),
+    name="create",
+    alias="-c",
+    help="Create a new volume for a JIG deployment",
 )
 storage_app.command(
     (f"{_CLI}.beta.jig.jig:jig_volumes_update_cli"), name="update", help="Update a volume and re-upload files"
@@ -445,11 +451,20 @@ storage_app.command(
 storage_app.command(
     (f"{_CLI}.beta.jig.jig:jig_volumes_describe"),
     name="describe",
+    alias="retrieve",
     help="Retrieve metadata for a volume from the Together platform",
 )
 storage_app.command(
     (f"{_CLI}.beta.jig.jig:jig_volumes_list"), name="list", alias="ls", help="List volumes for a JIG deployment"
 )
+
+# Adds a default handler for when a user sends an id after a command without a retrieve command
+# add_default_retrieve_command(endpoints_app, "endpoint-")
+# add_default_retrieve_command(evals_app, "eval-")
+# add_default_retrieve_command(files_app, "file-")
+# add_default_retrieve_command(fine_tuning_app, "ft-")
+# add_default_retrieve_command(clusters_app, UUID_RE)
+# add_default_retrieve_command(clusters_storage_app, UUID_RE)
 
 
 def main() -> None:

--- a/src/together/lib/cli/_track_cli.py
+++ b/src/together/lib/cli/_track_cli.py
@@ -11,14 +11,10 @@ import threading
 import urllib.error
 import urllib.request
 from enum import Enum
-from typing import TYPE_CHECKING, Any, TypeVar, Callable, cast
+from typing import Any, TypeVar, Callable, cast
 from pathlib import Path
 
 from detect_agent import determine_agent
-from cyclopts.exceptions import CycloptsError
-
-if TYPE_CHECKING:
-    from cyclopts import App
 
 from together import __version__
 from together.lib.utils import log_debug
@@ -173,83 +169,6 @@ def track_cli(event_name: CliTrackingEvents, args: dict[str, Any]) -> threading.
     _thread_pool.append(thread)
     thread.start()
     return thread
-
-
-def _long_option_names_in_tokens(tokens: list[str]) -> list[str]:
-    names: list[str] = []
-    for token in tokens:
-        if token.startswith("--"):
-            names.append(token.removeprefix("--").split("=", 1)[0])
-    return names
-
-
-def _legacy_command_before_first_option(tokens: list[str]) -> tuple[str, bool]:
-    """Fallback when cyclopts cannot resolve a command chain (unknown invocations)."""
-    parts: list[str] = []
-    for token in tokens:
-        if token.startswith("--"):
-            break
-        parts.append(token)
-    is_beta_command = bool(parts and parts[0] == "beta")
-    if is_beta_command:
-        parts = parts[1:]
-    return (" ".join(parts), is_beta_command)
-
-
-# First subcommand token only (alias -> primary name) for stable telemetry.
-_TELEMETRY_SUBCOMMAND_ALIASES: dict[str, str] = {"ft": "fine-tuning"}
-
-
-def _canonical_telemetry_command(cmd: str) -> str:
-    if not cmd:
-        return cmd
-    parts = cmd.split()
-    primary = _TELEMETRY_SUBCOMMAND_ALIASES.get(parts[0])
-    if primary is not None:
-        parts[0] = primary
-    parts = ["list" if p == "ls" else p for p in parts]
-    parts = ["delete" if p == "-d" else p for p in parts]
-    parts = ["create" if p == "-c" else p for p in parts]
-    return " ".join(parts)
-
-
-def parse_command_and_flags(app: App, tokens: list[str]) -> tuple[str, list[str], bool]:
-    """
-    Return telemetry-safe command path (registered subcommands only), argument *names* from
-    cyclopts resolution (including positional parameters — values are never returned), and
-    whether the invocation is under ``beta``.
-
-    Subcommand aliases (e.g. ``ft``) are normalized to their primary names (e.g. ``fine-tuning``).
-    The ``list`` alias ``ls`` is normalized to ``list`` in the returned command path.
-    The ``delete`` alias ``-d`` is normalized to ``delete`` in the returned command path.
-    The ``create`` alias ``-c`` is normalized to ``create`` in the returned command path.
-
-    Requires the root cyclopts :class:`~cyclopts.App` so positional values are not mistaken
-    for subcommand tokens (e.g. ``beta jig secrets set <name> <value>``).
-    """
-    argv = list(tokens)
-    chain, _, rest_after_chain = app.parse_commands(argv, include_parent_meta=False)
-    legacy_cmd, legacy_beta = _legacy_command_before_first_option(argv)
-
-    if chain:
-        is_beta_command = chain[0] == "beta"
-        chain_tail = list(chain[1:] if is_beta_command else chain)
-        parsed_command = " ".join(chain_tail)
-        # ``beta`` alone matches first; remaining tokens are not nested beta subcommands (invalid path).
-        if chain == ("beta",) and rest_after_chain:
-            parsed_command = legacy_cmd
-    else:
-        parsed_command = legacy_cmd
-        is_beta_command = legacy_beta
-
-    explicit_args: list[str] = []
-    try:
-        _, bound, _unused, _ignored = app.parse_known_args(argv)
-        explicit_args.extend(bound.arguments.keys())
-    except CycloptsError:
-        explicit_args.extend(_long_option_names_in_tokens(rest_after_chain))
-
-    return (_canonical_telemetry_command(parsed_command), explicit_args, is_beta_command)
 
 
 def _redact_secrets_in_error_text(s: str) -> str:

--- a/src/together/lib/cli/utils/_help_formatter.py
+++ b/src/together/lib/cli/utils/_help_formatter.py
@@ -29,6 +29,9 @@ def _names_renderer(entry: HelpEntry) -> str:
         return names
 
     # Parameters
+    if len(entry.names) == 1:
+        return entry.names[0]
+
     names = " ".join(entry.names[1:]) if entry.names else ""
     shorts = " ".join(entry.shorts) if entry.shorts else ""
     return " ".join([names, shorts]).strip()

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import re
+
+from cyclopts import App
+from cyclopts.exceptions import CycloptsError
+
+_UUID_RE = re.compile(r"^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$")
+
+_COMMAND_ID_IDENTIFIERS = {
+    "ft": re.compile(r"^ft-"),
+    "fine-tuning": re.compile(r"^ft-"),
+    "files": re.compile(r"^file-"),
+    "evals": re.compile(r"^eval-"),
+    "endpoints": re.compile(r"^endpoint-"),
+    "beta clusters": _UUID_RE,
+    "beta clusters storage": _UUID_RE,
+    "beta jig volumes": _UUID_RE,
+}
+
+
+def _expand_implicit_retrieve_tokens(app: App, *tokens: str) -> list[str]:
+    """
+    Some commands (e.g. ft, eval, endpoint, cluster, volume) allow the user to provide an ID instead of a command.
+    When this happens, we need to expand the tokens to include the retrieve command.
+    For example, if the user runs "tg ft ft-12345678-90ab", we need to expand it to "tg ft retrieve ft-12345678-90ab".
+    """
+
+    (command_tokens, _app, args_tokens) = app.parse_commands(tokens)
+    command = " ".join(list(command_tokens))
+
+    regex = _COMMAND_ID_IDENTIFIERS.get(command)
+
+    if len(args_tokens) == 0:
+        return list(tokens)
+
+    if regex and regex.match(args_tokens[0]):
+        return list(command_tokens) + ["retrieve"] + list(args_tokens)
+
+    return list(tokens)
+
+
+def _long_option_names_in_tokens(tokens: list[str]) -> list[str]:
+    names: list[str] = []
+    for token in tokens:
+        if token.startswith("--"):
+            names.append(token.removeprefix("--").split("=", 1)[0])
+    return names
+
+
+def _legacy_command_before_first_option(tokens: list[str]) -> tuple[str, bool]:
+    """Fallback when cyclopts cannot resolve a command chain (unknown invocations)."""
+    parts: list[str] = []
+    for token in tokens:
+        if token.startswith("--"):
+            break
+        parts.append(token)
+    is_beta_command = bool(parts and parts[0] == "beta")
+    if is_beta_command:
+        parts = parts[1:]
+    return (" ".join(parts), is_beta_command)
+
+
+# First subcommand token only (alias -> primary name) for stable telemetry.
+_TELEMETRY_SUBCOMMAND_ALIASES: dict[str, str] = {"ft": "fine-tuning"}
+
+
+def _canonical_telemetry_command(cmd: str) -> str:
+    if not cmd:
+        return cmd
+    parts = cmd.split()
+    primary = _TELEMETRY_SUBCOMMAND_ALIASES.get(parts[0])
+    if primary is not None:
+        parts[0] = primary
+    parts = ["list" if p == "ls" else p for p in parts]
+    parts = ["delete" if p == "-d" else p for p in parts]
+    parts = ["create" if p == "-c" else p for p in parts]
+    return " ".join(parts)
+
+
+def preparse_tokens(app: App, tokens: list[str]) -> tuple[str, list[str], bool, list[str]]:
+    """
+    Return telemetry-safe command path (registered subcommands only), argument *names* from
+    cyclopts resolution (including positional parameters — values are never returned), and
+    whether the invocation is under ``beta``.
+
+    Subcommand aliases (e.g. ``ft``) are normalized to their primary names (e.g. ``fine-tuning``).
+    The ``list`` alias ``ls`` is normalized to ``list`` in the returned command path.
+    The ``delete`` alias ``-d`` is normalized to ``delete`` in the returned command path.
+    The ``create`` alias ``-c`` is normalized to ``create`` in the returned command path.
+    Implicit ``retrieve`` for most commands is applied here so telemetry matches execution.
+
+    Requires the root cyclopts :class:`~cyclopts.App` so positional values are not mistaken
+    for subcommand tokens (e.g. ``beta jig secrets set <name> <value>``).
+
+    Implicit ``retrieve`` for ``tg ft <job-id>`` is applied here so telemetry matches execution.
+    """
+    argv = list(tokens)
+    argv = _expand_implicit_retrieve_tokens(app, *argv)
+    chain, _, rest_after_chain = app.parse_commands(argv, include_parent_meta=False)
+    legacy_cmd, legacy_beta = _legacy_command_before_first_option(argv)
+
+    if chain:
+        is_beta_command = chain[0] == "beta"
+        chain_tail = list(chain[1:] if is_beta_command else chain)
+        parsed_command = " ".join(chain_tail)
+        # ``beta`` alone matches first; remaining tokens are not nested beta subcommands (invalid path).
+        if chain == ("beta",) and rest_after_chain:
+            parsed_command = legacy_cmd
+    else:
+        parsed_command = legacy_cmd
+        is_beta_command = legacy_beta
+
+    explicit_args: list[str] = []
+    try:
+        _, bound, _unused, _ignored = app.parse_known_args(argv)
+        explicit_args.extend(bound.arguments.keys())
+    except CycloptsError:
+        explicit_args.extend(_long_option_names_in_tokens(rest_after_chain))
+
+    return (_canonical_telemetry_command(parsed_command), explicit_args, is_beta_command, argv)

--- a/tests/cli/test_fine_tuning.py
+++ b/tests/cli/test_fine_tuning.py
@@ -113,6 +113,14 @@ class TestFineTuningRetrieve:
         assert body["id"] == "ft-1"
         assert body["status"] == "completed"
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_implicit_retrieve_bare_job_id(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/fine-tunes/ft-1").mock(return_value=httpx.Response(200, json=_FT_RETRIEVE_BODY))
+        result = cli_runner.invoke(["ft", "ft-1", "--json"])
+        assert result.exit_code == 0
+        body = json.loads(result.output)
+        assert body["id"] == "ft-1"
+
 
 class TestFineTuningCancel:
     @pytest.mark.respx(base_url=base_url)

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -192,9 +192,9 @@ def test_track_cli_posts_json_when_enabled(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_parse_command_and_flags_splits_command_and_flags() -> None:
     from together.lib.cli import app
-    from together.lib.cli._track_cli import parse_command_and_flags
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
-    cmd, flags, is_beta = parse_command_and_flags(app, ["files", "upload", "--file", "ignored.txt"])
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["files", "upload", "--file", "ignored.txt"])
     assert cmd == "files upload"
     assert flags == ["file"]
     assert is_beta is False
@@ -202,9 +202,9 @@ def test_parse_command_and_flags_splits_command_and_flags() -> None:
 
 def test_parse_command_and_flags_strips_beta_prefix() -> None:
     from together.lib.cli import app
-    from together.lib.cli._track_cli import parse_command_and_flags
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
-    cmd, flags, is_beta = parse_command_and_flags(app, ["beta", "clusters", "list"])
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["beta", "clusters", "list"])
     assert cmd == "clusters list"
     assert flags == []
     assert is_beta is True
@@ -212,19 +212,38 @@ def test_parse_command_and_flags_strips_beta_prefix() -> None:
 
 def test_parse_command_and_flags_normalizes_ft_to_fine_tuning() -> None:
     from together.lib.cli import app
-    from together.lib.cli._track_cli import parse_command_and_flags
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
-    cmd, flags, is_beta = parse_command_and_flags(app, ["ft", "list", "--json"])
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["ft", "list", "--json"])
     assert cmd == "fine-tuning list"
     assert flags == ["json"]
     assert is_beta is False
 
 
+def test_parse_command_and_flags_inserts_implicit_retrieve_for_ft_job_id() -> None:
+    from together.lib.cli import app
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
+
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["ft", "ft-abcd-12", "--json"])
+    assert cmd == "fine-tuning retrieve"
+    assert "fine_tune_id" in flags
+    assert is_beta is False
+
+
+def test_parse_command_and_flags_implicit_retrieve_fine_tuning_spelling() -> None:
+    from together.lib.cli import app
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
+
+    cmd, _, is_beta, _ = preparse_tokens(app, ["fine-tuning", "ft-1", "--json"])
+    assert cmd == "fine-tuning retrieve"
+    assert is_beta is False
+
+
 def test_parse_command_and_flags_normalizes_ls_alias_to_list() -> None:
     from together.lib.cli import app
-    from together.lib.cli._track_cli import parse_command_and_flags
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
-    cmd, flags, is_beta = parse_command_and_flags(app, ["endpoints", "ls", "--json"])
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["endpoints", "ls", "--json"])
     assert cmd == "endpoints list"
     assert flags == ["json"]
     assert is_beta is False
@@ -232,9 +251,9 @@ def test_parse_command_and_flags_normalizes_ls_alias_to_list() -> None:
 
 def test_parse_command_and_flags_normalizes_minus_d_alias_to_delete() -> None:
     from together.lib.cli import app
-    from together.lib.cli._track_cli import parse_command_and_flags
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
-    cmd, flags, is_beta = parse_command_and_flags(app, ["endpoints", "-d", "ep-1", "--json", "--yes"])
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["endpoints", "-d", "ep-1", "--json", "--yes"])
     assert cmd == "endpoints delete"
     assert "endpoint_id" in flags
     assert is_beta is False
@@ -242,9 +261,9 @@ def test_parse_command_and_flags_normalizes_minus_d_alias_to_delete() -> None:
 
 def test_parse_command_and_flags_normalizes_minus_c_alias_to_create() -> None:
     from together.lib.cli import app
-    from together.lib.cli._track_cli import parse_command_and_flags
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
-    cmd, flags, is_beta = parse_command_and_flags(app, ["endpoints", "-c", "--model", "model-1"])
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["endpoints", "-c", "--model", "model-1"])
     assert cmd == "endpoints create"
     assert "model" in flags
     assert is_beta is False
@@ -252,9 +271,9 @@ def test_parse_command_and_flags_normalizes_minus_c_alias_to_create() -> None:
 
 def test_parse_command_and_flags_positionals_are_argument_names_not_command_tokens() -> None:
     from together.lib.cli import app
-    from together.lib.cli._track_cli import parse_command_and_flags
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
-    cmd, flags, is_beta = parse_command_and_flags(app, ["beta", "jig", "secrets", "set", "secret-name", "secret-value"])
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["beta", "jig", "secrets", "set", "secret-name", "secret-value"])
     assert cmd == "jig secrets set"
     assert set(flags) == {"name", "value"}
     assert is_beta is True


### PR DESCRIPTION
This enables a short hand `retrieve` by matching the `id` style as a heurestic to assume retrieve.

E.g., the following is now possible and shows the related command:

short | long 
----|----
`tg files file-xxx` | `tg files retrieve file-xxx`
`tg evals eval-xxxxx-xxx` | `tg evals retrieve eval-xxxxx-xxx`
`etc...` | 