### PR TITLE
chore: Switch to an async version of DownloadManager

### DIFF
--- a/src/together/lib/__init__.py
+++ b/src/together/lib/__init__.py
@@ -10,10 +10,12 @@ from .resources import (
     UploadManager,
     DownloadManager,
     AsyncUploadManager,
+    AsyncDownloadManager,
 )
 
 __all__ = [
     "DownloadManager",
+    "AsyncDownloadManager",
     "AsyncUploadManager",
     "UploadManager",
     "FinetuneTrainingLimits",

--- a/src/together/lib/cli/api/fine_tuning/download.py
+++ b/src/together/lib/cli/api/fine_tuning/download.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 from cyclopts import Parameter
 
-from together import APIError, Together, APIStatusError
-from together.lib import DownloadManager
+from together import APIError, APIStatusError
+from together.lib import AsyncDownloadManager
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
@@ -87,15 +87,7 @@ async def download(
         os.environ.setdefault("TOGETHER_DISABLE_TQDM", "true")
 
     try:
-        # TODO: This is a temporary hack,
-        # We need to make the DownloadManager async so we can use the async client.
-        sync_client = Together(
-            api_key=config.client.api_key,
-            base_url=config.client.base_url,
-            timeout=config.client.timeout,
-            max_retries=config.client.max_retries,
-        )
-        file_path, file_size = DownloadManager(sync_client).download(
+        file_path, file_size = await AsyncDownloadManager(config.client).download(
             url=url,
             output=output,
             remote_name=ft_job.x_model_output_name,

--- a/src/together/lib/resources/__init__.py
+++ b/src/together/lib/resources/__init__.py
@@ -2,10 +2,12 @@ from .files import (
     UploadManager,
     DownloadManager,
     AsyncUploadManager,
+    AsyncDownloadManager,
 )
 
 __all__ = [
     "DownloadManager",
+    "AsyncDownloadManager",
     "UploadManager",
     "AsyncUploadManager",
 ]

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -267,7 +267,7 @@ class DownloadManager(SyncAPIResource):
                             raise APIStatusError(
                                 "Error downloading file",
                                 response=e.response,
-                                body=e.response,
+                                body=e.body,
                             ) from e
 
                 # Close the response

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -436,7 +436,7 @@ class AsyncDownloadManager(AsyncAPIResource):
                             raise APIStatusError(
                                 "Error downloading file",
                                 response=e.response,
-                                body=e.response,
+                                body=e.body,
                             ) from e
 
                 # Close the response

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -197,7 +197,7 @@ class DownloadManager(SyncAPIResource):
                     raise APIStatusError(
                         "Error downloading file",
                         response=e.response,
-                        body=e.response,
+                        body=e.body,
                     ) from e
 
                 if not fetch_metadata:

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -366,7 +366,7 @@ class AsyncDownloadManager(AsyncAPIResource):
                     raise APIStatusError(
                         "Error downloading file",
                         response=e.response,
-                        body=e.response,
+                        body=e.body,
                     ) from e
 
                 if not fetch_metadata:

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -287,6 +287,175 @@ class DownloadManager(SyncAPIResource):
         return str(file_path.resolve()), file_size
 
 
+class AsyncDownloadManager(AsyncAPIResource):
+    async def get_file_metadata(
+        self,
+        url: str,
+        output: Path | None = None,
+        remote_name: str | None = None,
+        fetch_metadata: bool = False,
+    ) -> Tuple[Path, int]:
+        """
+        gets remote file head and parses out file name and file size
+        """
+
+        if not fetch_metadata:
+            if isinstance(output, Path):
+                file_path = output
+            else:
+                assert isinstance(remote_name, str)
+                file_path = Path(remote_name)
+
+            return file_path, 0
+
+        try:
+            response = await self._client.get(
+                path=url,
+                options=RequestOptions(
+                    headers={"Range": "bytes=0-1"},
+                ),
+                cast_to=httpx.Response,
+                stream=False,
+            )
+        except APIStatusError as e:
+            raise APIStatusError(
+                "Error fetching file metadata",
+                response=e.response,
+                body=e.body,
+            ) from e
+
+        headers = response.headers
+
+        assert isinstance(headers, httpx.Headers)
+
+        file_path = _prepare_output(
+            headers=headers,
+            output=output,
+            remote_name=remote_name,
+        )
+
+        file_size = _get_file_size(headers)
+
+        return file_path, file_size
+
+    async def download(
+        self,
+        url: str,
+        output: Path | None = None,
+        remote_name: str | None = None,
+        fetch_metadata: bool = False,
+    ) -> Tuple[str, int]:
+        # pre-fetch remote file name and file size
+        file_path, file_size = await self.get_file_metadata(url, output, remote_name, fetch_metadata)
+
+        temp_file_manager = partial(tempfile.NamedTemporaryFile, mode="wb", dir=file_path.parent, delete=False)
+
+        # Prevent parallel downloads of the same file with a lock.
+        lock_path = Path(file_path.as_posix() + ".lock")
+
+        with FileLock(lock_path.as_posix()):
+            with temp_file_manager() as temp_file:
+                try:
+                    response = await self._client.get(
+                        path=url,
+                        cast_to=httpx.Response,
+                        stream=True,
+                    )
+                except APIStatusError as e:
+                    lock_path.unlink(missing_ok=True)
+                    raise APIStatusError(
+                        "Error downloading file",
+                        response=e.response,
+                        body=e.response,
+                    ) from e
+
+                if not fetch_metadata:
+                    file_size = int(response.headers.get("content-length", 0))
+
+                assert file_size != 0, "Unable to retrieve remote file."
+
+                # Download with retry logic
+                bytes_downloaded = 0
+                retry_count = 0
+                retry_delay = DOWNLOAD_INITIAL_RETRY_DELAY
+
+                DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
+
+                with tqdm(
+                    total=file_size,
+                    unit="B",
+                    unit_scale=True,
+                    desc=f"Downloading file {file_path.name}",
+                    disable=bool(DISABLE_TQDM),
+                ) as pbar:
+                    while bytes_downloaded < file_size:
+                        try:
+                            # If this is a retry, close the previous response and create a new one with Range header
+                            if bytes_downloaded > 0:
+                                await response.aclose()
+
+                                log.info(f"Resuming download from byte {bytes_downloaded}")
+                                response = await self._client.get(
+                                    path=url,
+                                    cast_to=httpx.Response,
+                                    stream=True,
+                                    options=RequestOptions(
+                                        headers={"Range": f"bytes={bytes_downloaded}-"},
+                                    ),
+                                )
+
+                            # Download chunks
+                            async for chunk in response.aiter_bytes(DOWNLOAD_BLOCK_SIZE):
+                                temp_file.write(chunk)  # type: ignore
+                                bytes_downloaded += len(chunk)
+                                pbar.update(len(chunk))
+
+                            # Successfully completed download
+                            break
+
+                        except (httpx.RequestError, httpx.StreamError, APIConnectionError) as e:
+                            if retry_count >= MAX_DOWNLOAD_RETRIES:
+                                log.error(f"Download failed after {retry_count} retries")
+                                raise DownloadError(
+                                    f"Download failed after {retry_count} retries. Last error: {str(e)}"
+                                ) from e
+
+                            retry_count += 1
+                            log.warning(
+                                f"Download interrupted at {bytes_downloaded}/{file_size} bytes. "
+                                f"Retry {retry_count}/{MAX_DOWNLOAD_RETRIES} in {retry_delay}s..."
+                            )
+                            await self._sleep(retry_delay)
+
+                            # Exponential backoff with max delay cap
+                            retry_delay = min(retry_delay * 2, DOWNLOAD_MAX_RETRY_DELAY)
+
+                        except APIStatusError as e:
+                            # For API errors, don't retry
+                            log.error(f"API error during download: {e}")
+                            raise APIStatusError(
+                                "Error downloading file",
+                                response=e.response,
+                                body=e.response,
+                            ) from e
+
+                # Close the response
+                await response.aclose()
+
+            # Raise exception if remote file size does not match downloaded file size
+            if os.stat(temp_file.name).st_size != file_size:
+                raise DownloadError(
+                    f"Downloaded file size `{bytes_downloaded}` bytes does not match remote file size `{file_size}` bytes."
+                )
+
+            # Moves temp file to output file path
+            chmod_and_replace(Path(temp_file.name), file_path)
+
+        lock_path.unlink(missing_ok=True)
+
+        return str(file_path.resolve()), file_size
+
+
 class UploadManager(SyncAPIResource):
     def get_upload_url(
         self,

--- a/tests/cli/test_fine_tuning.py
+++ b/tests/cli/test_fine_tuning.py
@@ -210,12 +210,12 @@ class TestFineTuningDownload:
             def __init__(self, _client: object) -> None:
                 pass
 
-            def download(self, **kwargs: object) -> tuple[str, int]:
+            async def download(self, **kwargs: object) -> tuple[str, int]:
                 assert "ft_id=ft-abcd-12" in str(kwargs.get("url", ""))
                 assert "checkpoint=model_output_path" in str(kwargs.get("url", ""))
                 return str(out_file), 1
 
-        with patch.object(_ft_download_mod, "DownloadManager", _DM):
+        with patch.object(_ft_download_mod, "AsyncDownloadManager", _DM):
             # Full fine-tunes require explicit --checkpoint-type default (CLI default is merged for LoRA).
             result = cli_runner.invoke(
                 [


### PR DESCRIPTION
Makes an AsyncDownloader so we can use async code in CLI and not wrap with a new client.