### PR TITLE
chore: Add examples to the CLI help output for endpoint commands

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -26,6 +26,13 @@ from together.lib.cli.utils._prompt import PromptParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.utils._api_error import try_handle_server_error_message
 from together.lib.cli.utils._completion import install_completion
+from together.lib.cli.utils._help_examples import (
+    ENDPOINTS_HELP_EXAMPLES,
+    TOP_LEVEL_HELP_EXAMPLES,
+    ENDPOINTS_CREATE_HELP_EXAMPLES,
+    ENDPOINTS_UPDATE_HELP_EXAMPLES,
+    ENDPOINTS_HARDWARE_HELP_EXAMPLES,
+)
 from together.lib.cli.utils._help_formatter import help_formatter
 from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
@@ -326,17 +333,28 @@ models_app.command((f"{_CLI}.models.upload:upload"), help="Upload a model")
 ## Endpoints API commands
 endpoints_app = app.command(App(name="endpoints", help="Deploy and manage dedicated endpoints"))
 endpoints_app.command(
-    (f"{_CLI}.endpoints.hardware:hardware"), help="List available hardware configurations for deploying models"
+    (f"{_CLI}.endpoints.hardware:hardware"),
+    help="List available hardware configurations for deploying models",
+    help_epilogue=ENDPOINTS_HARDWARE_HELP_EXAMPLES,
 )
-endpoints_app.command((f"{_CLI}.endpoints.create:create"), alias="-c", help="Create a new endpoint")
-endpoints_app.command((f"{_CLI}.endpoints.retrieve:retrieve"), help="Get endpoint details")
-endpoints_app.command((f"{_CLI}.endpoints.stop:stop"), help="Stop an endpoint")
-endpoints_app.command((f"{_CLI}.endpoints.start:start"), help="Start an endpoint")
-endpoints_app.command((f"{_CLI}.endpoints.delete:delete"), alias="-d", help="Delete an endpoint")
-endpoints_app.command((f"{_CLI}.endpoints.list:list"), alias="ls", help="List your endpoints")
-endpoints_app.command((f"{_CLI}.endpoints.update:update"), help="Update an endpoint")
 endpoints_app.command(
-    (f"{_CLI}.endpoints.availability_zones:availability_zones"), help="List availability zones for deploying models"
+    (f"{_CLI}.endpoints.create:create"),
+    alias="-c",
+    help="Create a new endpoint",
+    help_epilogue=ENDPOINTS_CREATE_HELP_EXAMPLES,
+)
+endpoints_app.command((f"{_CLI}.endpoints.retrieve:retrieve"), help="Get endpoint details", help_epilogue="")
+endpoints_app.command((f"{_CLI}.endpoints.stop:stop"), help="Stop an endpoint", help_epilogue="")
+endpoints_app.command((f"{_CLI}.endpoints.start:start"), help="Start an endpoint", help_epilogue="")
+endpoints_app.command((f"{_CLI}.endpoints.delete:delete"), alias="-d", help="Delete an endpoint", help_epilogue="")
+endpoints_app.command((f"{_CLI}.endpoints.list:list"), alias="ls", help="List your endpoints", help_epilogue="")
+endpoints_app.command(
+    (f"{_CLI}.endpoints.update:update"), help="Update an endpoint", help_epilogue=ENDPOINTS_UPDATE_HELP_EXAMPLES
+)
+endpoints_app.command(
+    (f"{_CLI}.endpoints.availability_zones:availability_zones"),
+    help="List availability zones for deploying models",
+    help_epilogue="",
 )
 
 ## Evals API commands
@@ -434,6 +452,9 @@ storage_app.command(
 storage_app.command(
     (f"{_CLI}.beta.jig.jig:jig_volumes_list"), name="list", alias="ls", help="List volumes for a Jig deployment"
 )
+
+app.help_epilogue = TOP_LEVEL_HELP_EXAMPLES
+endpoints_app.help_epilogue = ENDPOINTS_HELP_EXAMPLES
 
 
 def main() -> None:

--- a/src/together/lib/cli/api/endpoints/hardware.py
+++ b/src/together/lib/cli/api/endpoints/hardware.py
@@ -14,7 +14,9 @@ from together.lib.cli.components.list import ListTable
 
 async def hardware(
     model: Annotated[Optional[str], Parameter(help="Show only hardware compatible with the given model")] = None,
-    available: Annotated[bool, Parameter(help="Show only available hardware for the given model")] = False,
+    available: Annotated[
+        bool, Parameter(help="Show only available hardware for the given model", negative=False)
+    ] = False,
     *,
     config: CLIConfigParameter,
 ) -> None:

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -1,0 +1,67 @@
+## Top-level commands
+
+TOP_LEVEL_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Fine tune a model for your dataset:
+  [primary]tg ft create --model Qwen/Qwen2-1.5B --training-file ./my-dataset.jsonl --lora[/primary]
+
+[dim]-[/dim] Deploy a model to a dedicated endpoint:
+  [primary]tg endpoints create --model Qwen/Qwen2.5-7B --hardware 2x_nvidia_h100_80gb_sxm --wait[/primary]
+
+[dim]-[/dim] Upload an external model to Together:
+  [primary]tg models upload --model-name my-org/my-model --model-source s3-or-hugging-face[/primary]
+"""
+
+## Endpoints API commands
+
+ENDPOINTS_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Create a new endpoint:
+  [primary]tg endpoints create --model Qwen/Qwen2.5-7B --hardware 2x_nvidia_h100_80gb_sxm --wait[/primary]
+
+[dim]-[/dim] Lookup available hardware for a model:
+  [primary]tg endpoints hardware --model Qwen/Qwen2.5-7B --available[/primary]
+
+[dim]-[/dim] List your endpoints:
+  [primary]tg endpoints list[/primary]
+
+[dim]-[/dim] Get details of an endpoint:
+  [primary]tg endpoints retrieve <endpoint-id>[/primary]
+
+[dim]-[/dim] Stop an endpoint:
+  [primary]tg endpoints stop <endpoint-id>[/primary]
+
+[dim]-[/dim] Change the autoscaling configuration for an endpoint:
+  [primary]tg endpoints update <endpoint-id> --min-replicas 4 --max-replicas 8[/primary]
+"""
+
+ENDPOINTS_HARDWARE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] List all hardware configurations:
+  [primary]tg endpoints hardware[/primary]
+
+[dim]-[/dim] List all hardware configurations for a model:
+  [primary]tg endpoints hardware --model Qwen/Qwen2.5-7B[/primary]
+
+[dim]-[/dim] List all available hardware configurations for a model:
+  [primary]tg endpoints hardware --model Qwen/Qwen2.5-7B --available[/primary]
+
+[dim]-[/dim] Grab the cheapest hardware configuration for a model:
+  [primary]tg endpoints hardware --model meta-llama/Meta-Llama-3-8B-Instruct --available --json | jq -r 'sort_by(.pricing.cents_per_minute) | .[0].id'[/primary]
+"""
+
+ENDPOINTS_CREATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Deploy your model with specific autoscaling configuration:
+  [primary]tg endpoints create --model MODEL --hardware HARDWARE --min-replicas 2 --max-replicas 4[/primary]
+
+[dim]-[/dim] Deploy your fine tuned model:
+  [primary]tg endpoints create --model $(tg ft $MY_FT_JOB_ID --json | jq -r '.model_output_name') --hardware HARDWARE[/primary]
+
+[dim]-[/dim] Create an endpoint to be started later:
+  [primary]tg endpoints create --model MODEL --hardware HARDWARE --no-auto-start[/primary]
+"""
+
+ENDPOINTS_UPDATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Change the autoscaling configuration for an endpoint:
+  [primary]tg endpoints update ENDPOINT_ID --min-replicas 4 --max-replicas 8[/primary]
+
+[dim]-[/dim] Change the auto-stop timeout for an endpoint:
+  [primary]tg endpoints update ENDPOINT_ID --inactive-timeout 30[/primary]
+"""

--- a/uv.lock
+++ b/uv.lock
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "together"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This adds help examples for `tg endpoints`

command | help
---|---
`tg` | <img width="720" height="449" alt="image" src="https://github.com/user-attachments/assets/4e1e7ff3-b03e-41af-8c19-79a1b55d3cc7" />
`tg endpoints` | <img width="710" height="602" alt="image" src="https://github.com/user-attachments/assets/5b976aa6-7abb-465d-869e-1baea377d3e0" />
`tg endpoints create --help` |  <img width="818" height="480" alt="image" src="https://github.com/user-attachments/assets/bb03ac9c-3ad3-4496-a2fc-bd332490f413" />
`tg endpoints availability-zones --help` | <img width="813" height="176" alt="image" src="https://github.com/user-attachments/assets/9a696d64-f0d6-4243-b0af-d7167cb0d05c" />
`tg endpoints hardware --help` | <img width="1026" height="414" alt="image" src="https://github.com/user-attachments/assets/964cac70-3308-479e-aa17-41f188b534b3" />
`tg endpoints delete --help` |  <img width="832" height="202" alt="image" src="https://github.com/user-attachments/assets/b3a18985-0340-43e9-b05d-c8299260f9a9" />
`tg endpoints ls --help` |  <img width="837" height="217" alt="image" src="https://github.com/user-attachments/assets/fbdd6f1c-daac-4b90-834a-d330c0d85602" />
`tg endpoints retrieve --help` | <img width="830" height="201" alt="image" src="https://github.com/user-attachments/assets/1769e363-17f9-4362-832b-3412317290f9" />
`tg endpoints start --help` | <img width="832" height="213" alt="image" src="https://github.com/user-attachments/assets/ff6a7cc6-7b9d-447a-a14a-1d32db017739" />
`tg endpoints stop --help` | <img width="842" height="216" alt="image" src="https://github.com/user-attachments/assets/c84643e9-dd87-4c4d-8edb-d673771ed9f5" />
`tg endpoints update --help` | <img width="832" height="359" alt="image" src="https://github.com/user-attachments/assets/33dc05c2-504d-4994-9f3d-8cdb0e9cb725" />

