### PR TITLE
chore: Add help examples to evals commands

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -27,8 +27,10 @@ from together.lib.cli.utils._console import console
 from together.lib.cli.utils._api_error import try_handle_server_error_message
 from together.lib.cli.utils._completion import install_completion
 from together.lib.cli.utils._help_examples import (
+    EVALS_HELP_EXAMPLES,
     ENDPOINTS_HELP_EXAMPLES,
     TOP_LEVEL_HELP_EXAMPLES,
+    EVALS_CREATE_HELP_EXAMPLES,
     ENDPOINTS_CREATE_HELP_EXAMPLES,
     ENDPOINTS_UPDATE_HELP_EXAMPLES,
     ENDPOINTS_HARDWARE_HELP_EXAMPLES,
@@ -358,11 +360,13 @@ endpoints_app.command(
 )
 
 ## Evals API commands
-evals_app = app.command(App(name="evals", help="Run and manage model evaluations"))
-evals_app.command((f"{_CLI}.evals.create:create"), alias="-c", help="Create a new eval job")
-evals_app.command((f"{_CLI}.evals.list:list"), alias="ls", help="List eval jobs")
-evals_app.command((f"{_CLI}.evals.retrieve:retrieve"), help="Get eval job details")
-evals_app.command((f"{_CLI}.evals.status:status"), help="Get an eval job's status")
+evals_app = app.command(App(name="evals", help="Run and manage model evaluations", help_epilogue=EVALS_HELP_EXAMPLES))
+evals_app.command(
+    (f"{_CLI}.evals.create:create"), alias="-c", help="Create a new eval job", help_epilogue=EVALS_CREATE_HELP_EXAMPLES
+)
+evals_app.command((f"{_CLI}.evals.list:list"), alias="ls", help="List eval jobs", help_epilogue="")
+evals_app.command((f"{_CLI}.evals.retrieve:retrieve"), help="Get eval job details", help_epilogue="")
+evals_app.command((f"{_CLI}.evals.status:status"), help="Get an eval job's status", help_epilogue="")
 
 ## Telemetry API commands
 telemetry_app = app.command(App(name="telemetry", help="Configure CLI telemetry"))

--- a/src/together/lib/cli/api/evals/create.py
+++ b/src/together/lib/cli/api/evals/create.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 from typing import Any, Dict, Union, Literal, Optional, Annotated, cast
+from pathlib import Path
 
 from cyclopts import Parameter
 
@@ -35,10 +35,10 @@ async def create(
     input_data_file_path: Annotated[str, Parameter(help="The path to the input data file")],
     judge_external_api_token: Annotated[
         Optional[str], Parameter(help="API token for access to the external judge model")
-    ],
+    ] = None,
     judge_external_base_url: Annotated[
         Optional[str], Parameter(help="Base URL for access to the external judge model")
-    ],
+    ] = None,
     model_field: Annotated[
         Optional[str],
         Parameter(
@@ -130,6 +130,14 @@ async def create(
     labels_list = labels.split(",") if labels else None
     pass_labels_list = pass_labels.split(",") if pass_labels else None
 
+    # If the user passes a path to a file, try to upload it to the files API first
+    # Uploads are idempotent so we can depend on this API always giving us a file ID
+    if _check_path_exists(input_data_file_path):
+        file_upload = await config.client.files.upload(Path(input_data_file_path), purpose="eval", check=False)
+        training_file = file_upload.id
+    else:
+        training_file = input_data_file_path
+
     model_to_evaluate_final: Union[Dict[str, Any], None, str] = None
     config_params_provided = any(
         [
@@ -154,7 +162,7 @@ async def create(
         model_to_evaluate_final = {
             "model": model_to_evaluate,
             "model_source": model_to_evaluate_source,
-            "max_tokens": model_to_evaluate_max_tokens,
+            "max_tokens": model_to_evaluate_max_tokens or 512,
             "temperature": model_to_evaluate_temperature,
             "system_template": model_to_evaluate_system_template,
             "input_template": model_to_evaluate_input_template,
@@ -185,7 +193,7 @@ async def create(
         model_a_final = {
             "model": model_a,
             "model_source": model_a_source,
-            "max_tokens": model_a_max_tokens,
+            "max_tokens": model_a_max_tokens or 512,
             "temperature": model_a_temperature,
             "system_template": model_a_system_template,
             "input_template": model_a_input_template,
@@ -216,7 +224,7 @@ async def create(
         model_b_final = {
             "model": model_b,
             "model_source": model_b_source,
-            "max_tokens": model_b_max_tokens,
+            "max_tokens": model_b_max_tokens or 512,
             "temperature": model_b_temperature,
             "system_template": model_b_system_template,
             "input_template": model_b_input_template,
@@ -239,7 +247,7 @@ async def create(
         response = await config.client.evals.create(
             type=type_val,
             parameters=ParametersEvaluationClassifyParameters(
-                input_data_file_path=input_data_file_path,
+                input_data_file_path=training_file,
                 judge=judge_config,
                 labels=labels_list or [],
                 pass_labels=pass_labels_list or [],
@@ -252,7 +260,7 @@ async def create(
         response = await config.client.evals.create(
             type="score",
             parameters=ParametersEvaluationScoreParameters(
-                input_data_file_path=input_data_file_path,
+                input_data_file_path=training_file,
                 judge=judge_config,
                 max_score=max_score,
                 min_score=min_score,
@@ -264,7 +272,7 @@ async def create(
         response = await config.client.evals.create(
             type=type_val,
             parameters=ParametersEvaluationCompareParameters(
-                input_data_file_path=input_data_file_path,
+                input_data_file_path=training_file,
                 judge=judge_config,
                 model_a=cast(ParametersEvaluationCompareParametersModelAEvaluationModelRequest, model_a_final),
                 model_b=cast(ParametersEvaluationCompareParametersModelBEvaluationModelRequest, model_b_final),
@@ -274,7 +282,13 @@ async def create(
     if config.json:
         console.print_json(openapi_dumps(response).decode("utf-8"))
     else:
-        console.print(json.dumps(response.model_dump(exclude_none=True), indent=4))
+        url = f"https://api.together.ai/evaluations/result/{response.workflow_id}"
+        console.print(f"[green]√ Evaluation job created[/green] [dim]([link={url}]{response.workflow_id}[/link])[/dim]")
+        console.print(f"  Evaluations may take some time to complete.\n")
+        console.print(f"  To retrieve the status:")
+        console.print(f"    [dim]-[/dim] [primary]tg evals status {response.workflow_id}[/primary]")
+        console.print(f"  To get the results:")
+        console.print(f"    [dim]-[/dim] [primary]tg evals {response.workflow_id}[/primary]")
 
 
 def _build_judge(
@@ -312,3 +326,12 @@ def _build_judge(
     if judge_external_base_url:
         judge_config["external_base_url"] = judge_external_base_url
     return judge_config
+
+
+def _check_path_exists(path_string: str) -> bool:
+    if path_string == "":
+        return False
+    p = Path(path_string)
+    if p.is_dir():
+        raise ValueError(f"Path {path_string} is a directory, not a file. Please provide a file path.")
+    return p.exists() and p.is_file()

--- a/src/together/lib/cli/api/evals/create.py
+++ b/src/together/lib/cli/api/evals/create.py
@@ -224,7 +224,7 @@ async def create(
         model_b_final = {
             "model": model_b,
             "model_source": model_b_source,
-            "max_tokens": model_b_max_tokens or 512,
+            "max_tokens": model_b_max_tokens if model_b_max_tokens is not None else 16000,
             "temperature": model_b_temperature,
             "system_template": model_b_system_template,
             "input_template": model_b_input_template,

--- a/src/together/lib/cli/api/evals/create.py
+++ b/src/together/lib/cli/api/evals/create.py
@@ -162,7 +162,7 @@ async def create(
         model_to_evaluate_final = {
             "model": model_to_evaluate,
             "model_source": model_to_evaluate_source,
-            "max_tokens": model_to_evaluate_max_tokens or 512,
+            "max_tokens": model_to_evaluate_max_tokens if model_to_evaluate_max_tokens is not None else 16000,
             "temperature": model_to_evaluate_temperature,
             "system_template": model_to_evaluate_system_template,
             "input_template": model_to_evaluate_input_template,

--- a/src/together/lib/cli/api/evals/create.py
+++ b/src/together/lib/cli/api/evals/create.py
@@ -193,7 +193,7 @@ async def create(
         model_a_final = {
             "model": model_a,
             "model_source": model_a_source,
-            "max_tokens": model_a_max_tokens or 512,
+            "max_tokens": model_a_max_tokens if model_a_max_tokens is not None else 16000,
             "temperature": model_a_temperature,
             "system_template": model_a_system_template,
             "input_template": model_a_input_template,

--- a/src/together/lib/cli/api/evals/list.py
+++ b/src/together/lib/cli/api/evals/list.py
@@ -6,8 +6,14 @@ from cyclopts import Parameter
 
 from together import omit
 from together.types import EvaluationJob
+from together.lib.utils import log_debug
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
+from together.types.evaluation_job import (
+    ResultsEvaluationScoreResults,
+    ResultsEvaluationCompareResults,
+    ResultsEvaluationClassifyResults,
+)
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.list import ListTable
 from together.lib.cli.components.loader import show_loading_status
@@ -45,25 +51,16 @@ async def list(
         return
 
     table = ListTable("Evals", empty_message="No evals found")
-    table.add_primary_column("Workflow ID", ratio=2)
-    table.add_column("Type")
-    table.add_column("Status")
-    table.add_column("Model")
-    table.add_column("Model A")
-    table.add_column("Model B")
+    table.add_primary_column("Workflow ID", ratio=1)
+    table.add_column("Type", ratio=1)
+    table.add_column("Result", ratio=4)
 
     for job in data:
-        model = _get_model_to_evaluate_name(job)
-        model_a = deep_get(job.parameters, ["model_a", "model"], "")
-        model_b = deep_get(job.parameters, ["model_b", "model"], "")
-        status_color = status_colors[job.status] if job.status in status_colors else "white"
+        result = _get_result(job)
         table.add_row(
             f"[link=https://api.together.ai/evaluations/result/{job.workflow_id}]{job.workflow_id}[/link]",
             job.type,
-            f"[{status_color}]{job.status}[/{status_color}]",
-            model,
-            model_a,
-            model_b,
+            result,
         )
     console.print(table)
     if next_cursor:
@@ -72,6 +69,60 @@ async def list(
 
 
 T = TypeVar("T")
+
+
+def _get_result(job: EvaluationJob) -> str:
+    try:
+        if job.status != "completed":
+            status_color = status_colors[job.status] if job.status in status_colors else "white"
+            return f"status: [{status_color}]{job.status}[/{status_color}]"
+
+        if job.type == "score":
+            score_job = cast(ResultsEvaluationScoreResults, job.results)
+            return "\n".join(
+                [
+                    f"mean score: [primary]{getattr(score_job.aggregated_scores, 'mean_score', 'N/A')}[/primary]",
+                    f"pass percentage: [primary]{getattr(score_job.aggregated_scores, 'pass_percentage', 'N/A')}[/primary]",
+                    f"std score: [primary]{getattr(score_job.aggregated_scores, 'std_score', 'N/A')}[/primary]",
+                ]
+            )
+
+        if job.type == "compare":
+            compare_job = cast(ResultsEvaluationCompareResults, job.results)
+            if (
+                compare_job.a_wins is not None
+                and compare_job.b_wins is not None
+                and compare_job.a_wins > compare_job.b_wins
+            ):
+                return f"Winning Model: [primary]{_get_model_name(job, 'model_a')}[/primary] (model A)"
+            elif (
+                compare_job.b_wins is not None
+                and compare_job.a_wins is not None
+                and compare_job.b_wins > compare_job.a_wins
+            ):
+                return f"Winning Model: [primary]{_get_model_name(job, 'model_b')}[/primary] (model B)"
+            else:
+                return "[primary]Tie[/primary]"
+
+        if job.type == "classify":
+            classify_job = cast(ResultsEvaluationClassifyResults, job.results)
+            if classify_job.label_counts is None:
+                return "No label counts"
+
+            labels = cast(
+                dict[str, int], classify_job.label_counts
+            )  # TODO: API has a bug in the shape of the response, so we need to cast it to the correct type
+            return "\n".join(
+                [
+                    f"label: [primary]{label}[/primary] (count: [primary]{count}[/primary])"
+                    for label, count in labels.items()
+                ]
+            )
+
+        return ""
+    except Exception as e:
+        log_debug("Error parsing results for evals list", error=e)
+        return "Internal error"
 
 
 def deep_get(dictionary: dict[str, Any] | None, keys: List[str], default: T) -> T:
@@ -84,15 +135,15 @@ def deep_get(dictionary: dict[str, Any] | None, keys: List[str], default: T) -> 
     return cast(T, cur)
 
 
-def _get_model_to_evaluate_name(job: EvaluationJob) -> str:
+def _get_model_name(job: EvaluationJob, field: str) -> str:
     """
     Get the name of the model to evaluate.
 
     Sometimes the parameters.model_to_evaluate is a dict, other times it's a string.
     """
-    model_to_evaluate: str | dict[str, Any] = deep_get(job.parameters, ["model_to_evaluate"], "")
+    model: str | dict[str, Any] = deep_get(job.parameters, [field], "")
 
-    if isinstance(model_to_evaluate, dict):
-        return deep_get(model_to_evaluate, ["model"], "")
+    if isinstance(model, dict):
+        return deep_get(model, ["model"], "")
 
-    return model_to_evaluate
+    return model

--- a/src/together/lib/cli/api/evals/retrieve.py
+++ b/src/together/lib/cli/api/evals/retrieve.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from cyclopts import Parameter
-from rich.markup import escape as escape_rich_markup
 
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.components.model_dump import print_model_dump
 
 
 async def retrieve(
@@ -22,9 +22,4 @@ async def retrieve(
         console.print_json(openapi_dumps(response).decode("utf-8"))
         return
 
-    wid = response.workflow_id or evaluation_id
-    console.print(
-        f"[dim]Eval[/dim] [bold]{escape_rich_markup(str(wid))}[/bold] — "
-        f"[dim]status[/dim] [bold]{escape_rich_markup(str(response.status))}[/bold] — "
-        f"[dim]type[/dim] [bold]{escape_rich_markup(str(response.type))}[/bold]"
-    )
+    print_model_dump(response)

--- a/src/together/lib/cli/api/evals/status.py
+++ b/src/together/lib/cli/api/evals/status.py
@@ -18,11 +18,7 @@ async def status(
     """Get the status and results of a specific evaluation job."""
     response = await show_loading_status("Retrieving eval status...", config.client.evals.status(evaluation_id))
     if config.json:
-        console.print_json(openapi_dumps(response).decode("utf-8"))
-    else:
-        console.print(f"Status: [bold]{response.status}[/bold]")
+        console.print_json(openapi_dumps({"status": response.status}).decode("utf-8"))
+        return
 
-        if response.results:
-            # TODO: Add a pretty print for the results
-            console.print("\nResults")
-            console.print_json(openapi_dumps(response.results).decode("utf-8"))
+    console.print(f"Status: {response.status}")

--- a/src/together/lib/cli/components/model_dump.py
+++ b/src/together/lib/cli/components/model_dump.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, cast
+from datetime import datetime
+
+from rich.table import Table
+
+from together import BaseModel
+from together.lib.utils.tools import format_datetime
+from together.lib.cli.utils._console import console
+
+
+def print_model_dump(model: BaseModel) -> None:
+    console.print(_pretty_print_results(dump_sorted_model(model), expand=True))
+
+
+def _pretty_print_results(results: Any, expand: bool = False) -> Table:
+    table = Table(show_header=False, box=None, padding=(0, 1, 0, 0), expand=expand)
+    table.add_column("Key", style="dim")
+    table.add_column("Value", justify="left")
+    if isinstance(results, dict):
+        for key, value in cast(dict[str, Any], results).items():
+            if isinstance(value, dict) or isinstance(value, list):
+                table.add_row(_humanize_key(key), _pretty_print_results(value))
+            else:
+                table.add_row(_humanize_key(key), _colorize_value(value))
+    elif isinstance(results, list):
+        for item in cast(list[Any], results):
+            table.add_row("-", _pretty_print_results(item))
+    elif isinstance(results, BaseModel):
+        table.add_row("", _pretty_print_results(results.model_dump()))
+    else:
+        table.add_row("", _colorize_value(results))
+    return table
+
+
+def _humanize_key(key: str) -> str:
+    return f"{key.replace('_', ' ').title()}:"
+
+
+def _colorize_value(value: Any) -> str:
+    if value is None:
+        return "[dim italic]n/a[/dim italic]"
+    if isinstance(value, bool):
+        return "[bold green]True[/bold green]" if value else "[bold red]False[/bold red]"
+    if isinstance(value, float):
+        return f"[bold blue]{value:g}[/bold blue]"
+    if isinstance(value, int):
+        return f"[bold blue]{value:d}[/bold blue]"
+    if isinstance(value, datetime):
+        return f"[bold blue]{format_datetime(value)}[/bold blue]"
+
+    value = str(value)
+    value = value.replace("\n", "\\n")
+    value = value.replace("\t", "\\t")
+
+    return f"[bold blue]{value}[/bold blue]"
+
+
+def dump_sorted_model(model: BaseModel) -> dict[str, Any]:
+    """Returns a model dump where the properties are sorted by their type:
+    - ID fields first
+    - Primitives next
+    - Dicts/objects next
+    - Lists last
+    """
+
+    def _sort_items(key: str, value: Any) -> int:
+        # Returns a sort key: 0 for ID fields, 1 for primitives, 2 for dicts/objects, 3 for lists
+        if key.endswith("_id"):
+            return 0
+        elif isinstance(value, dict) or isinstance(value, BaseModel):
+            return 2
+        elif isinstance(value, list):
+            return 3
+        else:
+            return 1
+
+    return dict(sorted(model.model_dump().items(), key=lambda kv: _sort_items(kv[0], kv[1])))

--- a/src/together/lib/cli/utils/_console.py
+++ b/src/together/lib/cli/utils/_console.py
@@ -30,4 +30,4 @@ custom_theme = Theme(
     }
 )
 
-console = Console(theme=custom_theme)
+console = Console(theme=custom_theme, highlight=False)

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -65,3 +65,69 @@ ENDPOINTS_UPDATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
 [dim]-[/dim] Change the auto-stop timeout for an endpoint:
   [primary]tg endpoints update ENDPOINT_ID --inactive-timeout 30[/primary]
 """
+
+## Evals API commands
+
+EVALS_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Look at the examples for creating an evaluation job:
+  [primary]tg evals create --help[/primary]
+
+[dim]-[/dim] List all evaluation jobs:
+  [primary]tg evals ls[/primary]
+
+[dim]-[/dim] Check the status of an evaluation job:
+  [primary]tg evals status <eval-id>[/primary]
+
+[dim]-[/dim] Get details of an evaluation job:
+  [primary]tg evals <eval-id>[/primary]
+"""
+
+EVALS_CREATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Run a classification evaluation:
+  [primary]tg evals create \\
+    --type classify \\
+    --judge-model deepseek-ai/DeepSeek-V3.1 \\
+    --judge-model-source serverless \\
+    --judge-system-template "You are a helpful assistant" \\
+    --input-data-file-path ./data.jsonl \\
+    --model-to-evaluate deepseek-ai/DeepSeek-V3.1 \\
+    --model-to-evaluate-source serverless \\
+    --model-to-evaluate-system-template "Respond to the following comment. You can be informal but maintain a respectful tone." \\
+    --model-to-evaluate-input-template "Here's a comment I saw online. How would you respond to it?\\n\\n{{question}}" \\
+    --labels 'Toxic,Non-toxic' \\
+    --pass-labels 'Non-toxic'[/primary]
+
+[dim]-[/dim] Run a score evaluation:
+  [primary]tg evals create \\
+    --type score \\
+    --judge-model deepseek-ai/DeepSeek-V3.1 \\
+    --judge-model-source serverless \\
+    --judge-system-template "Rate the given response on a scale from 1 to 10, where 1 is generic and 10 is unique." \\
+    --input-data-file-path ./data.jsonl  \\
+    --model-to-evaluate deepseek-ai/DeepSeek-V3.1 \\
+    --model-to-evaluate-source serverless \\
+    --model-to-evaluate-system-template "You are a helpful assistant." \\
+    --model-to-evaluate-input-template $'Please respond:\\n\\n{{prompt}}' \\
+    --model-to-evaluate-max-tokens 512 \\
+    --model-to-evaluate-temperature 0.7 \\
+    --min-score 1 \\
+    --max-score 10 \\
+    --pass-threshold 7
+    [/primary]
+
+[dim]-[/dim] Run a compare evaluation:
+  [primary]tg evals create \\
+    --type compare \\
+    --judge-model deepseek-ai/DeepSeek-V3.1 \\
+    --judge-model-source serverless \\
+    --judge-system-template "You are an expert judge. Given the user task and two model responses, say which is better and why." \\
+    --input-data-file-path ./examples/eval_compare_sample.jsonl \\
+    --model-a deepseek-ai/DeepSeek-V3.1 \\
+    --model-a-source serverless \\
+    --model-a-system-template "You are a helpful assistant." \\
+    --model-a-input-template $'Answer the following:\\n\\n{{prompt}}' \\
+    --model-b deepseek-ai/DeepSeek-V3.1 \\
+    --model-b-source serverless \\
+    --model-b-system-template "You are a concise assistant." \\
+    --model-b-input-template $'Answer the following:\\n\\n{{prompt}}'[/primary]
+"""


### PR DESCRIPTION
This adds help example outputs for the top level and the create flow.

Also this improves the outputs of the commands and create a generic component I will reuse for large payload responses.

command | output
---|---
`tg evals create` |  <img width="923" height="316" alt="image" src="https://github.com/user-attachments/assets/9c139213-0fc4-46b5-bacc-6ca31b54a32e" />
`tg evals status` |  <img width="867" height="31" alt="image" src="https://github.com/user-attachments/assets/7a2e8b6c-69fc-4852-b30c-17669aa3b1ff" />
`tg evals ls` | <img width="735" height="466" alt="image" src="https://github.com/user-attachments/assets/657b322b-d74f-4869-8bba-7d3a256cbf50" />
`tg evals retrieve` | <img width="1120" height="609" alt="image" src="https://github.com/user-attachments/assets/061af506-e267-49c3-8bb0-a349faa20b3d" />
`tg evals --help` |  <img width="740" height="432" alt="image" src="https://github.com/user-attachments/assets/b32eb06b-bf01-47e9-9e6a-6c19b54b22e4" />
`tg evals create --help` | <img width="793" height="748" alt="image" src="https://github.com/user-attachments/assets/9b7e2241-1158-4dfb-843d-2c47ce9aa227" />



