### PR TITLE
chore: Add example usage for clusters commands

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -35,13 +35,20 @@ from together.lib.cli.utils._help_examples import (
     FINE_TUNING_HELP_EXAMPLES,
     EVALS_CREATE_HELP_EXAMPLES,
     FILES_UPLOAD_HELP_EXAMPLES,
+    BETA_CLUSTERS_HELP_EXAMPLES,
     MODELS_UPLOAD_HELP_EXAMPLES,
     ENDPOINTS_CREATE_HELP_EXAMPLES,
     ENDPOINTS_UPDATE_HELP_EXAMPLES,
     ENDPOINTS_HARDWARE_HELP_EXAMPLES,
     FINE_TUNING_CREATE_HELP_EXAMPLES,
+    BETA_CLUSTERS_CREATE_HELP_EXAMPLES,
+    BETA_CLUSTERS_UPDATE_HELP_EXAMPLES,
     FINE_TUNING_DOWNLOAD_HELP_EXAMPLES,
+    BETA_CLUSTERS_STORAGE_HELP_EXAMPLES,
     FILES_RETRIEVE_CONTENT_HELP_EXAMPLES,
+    BETA_CLUSTERS_STORAGE_CREATE_HELP_EXAMPLES,
+    BETA_CLUSTERS_STORAGE_UPDATE_HELP_EXAMPLES,
+    BETA_CLUSTERS_GET_CREDENTIALS_HELP_EXAMPLES,
 )
 from together.lib.cli.utils._help_formatter import help_formatter
 from together.lib.cli.utils._preparse_tokens import preparse_tokens
@@ -412,20 +419,50 @@ beta_root_app = App(name="beta", help="Experimental and beta features")
 beta_app = app.command(beta_root_app)
 
 ### Clusters API commands
-clusters_app = beta_app.command(App(name="clusters", help="Create and manage GPU clusters"))
+clusters_app = beta_app.command(
+    App(name="clusters", help="Create and manage GPU clusters", help_epilogue=BETA_CLUSTERS_HELP_EXAMPLES)
+)
 clusters_app.command((f"{_CLI}.beta.clusters.list:list"), alias="ls", help="List your clusters")
-clusters_app.command((f"{_CLI}.beta.clusters.create:create"), alias="-c", help="Create a new cluster")
+clusters_app.command(
+    (f"{_CLI}.beta.clusters.create:create"),
+    alias="-c",
+    help="Create a new cluster",
+    help_epilogue=BETA_CLUSTERS_CREATE_HELP_EXAMPLES,
+)
 clusters_app.command((f"{_CLI}.beta.clusters.retrieve:retrieve"), help="Get cluster details")
-clusters_app.command((f"{_CLI}.beta.clusters.update:update"), help="Update a cluster")
+clusters_app.command(
+    (f"{_CLI}.beta.clusters.update:update"),
+    help="Update a cluster",
+    help_epilogue=BETA_CLUSTERS_UPDATE_HELP_EXAMPLES,
+)
 clusters_app.command((f"{_CLI}.beta.clusters.delete:delete"), alias="-d", help="Delete a cluster")
 clusters_app.command((f"{_CLI}.beta.clusters.list_regions:list_regions"), help="List regions for deploying clusters")
-clusters_app.command((f"{_CLI}.beta.clusters.get_credentials:get_credentials"), help="Get credentials for a cluster")
+clusters_app.command(
+    (f"{_CLI}.beta.clusters.get_credentials:get_credentials"),
+    help="Get credentials for a cluster",
+    help_epilogue=BETA_CLUSTERS_GET_CREDENTIALS_HELP_EXAMPLES,
+)
 
 ### Clusters > Storage API commands
-storage_app = clusters_app.command(App(name="storage", help="Manage cluster storage volumes", group="Subcommands"))
+storage_app = clusters_app.command(
+    App(
+        name="storage",
+        help="Manage cluster storage volumes",
+        group="Subcommands",
+        help_epilogue=BETA_CLUSTERS_STORAGE_HELP_EXAMPLES,
+    )
+)
 storage_app.command((f"{_CLI}.beta.clusters.storage.list:list"), alias="ls", help="List storage volumes for a cluster")
 storage_app.command(
-    (f"{_CLI}.beta.clusters.storage.create:create"), alias="-c", help="Create a new storage volume for a cluster"
+    (f"{_CLI}.beta.clusters.storage.create:create"),
+    alias="-c",
+    help="Create a new storage volume for a cluster",
+    help_epilogue=BETA_CLUSTERS_STORAGE_CREATE_HELP_EXAMPLES,
+)
+storage_app.command(
+    (f"{_CLI}.beta.clusters.storage.update:update"),
+    help="Resize a storage volume",
+    help_epilogue=BETA_CLUSTERS_STORAGE_UPDATE_HELP_EXAMPLES,
 )
 storage_app.command(
     (f"{_CLI}.beta.clusters.storage.retrieve:retrieve"),

--- a/src/together/lib/cli/api/beta/clusters/storage/update.py
+++ b/src/together/lib/cli/api/beta/clusters/storage/update.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from cyclopts import Parameter
+
+from together._utils._json import openapi_dumps
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+
+
+async def update(
+    volume_id: str,
+    size_tib: Annotated[int, Parameter(help="New size of the storage volume in TiB")],
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """Update a storage volume (resize)."""
+    response = await config.client.beta.clusters.storage.update(
+        volume_id=volume_id,
+        size_tib=size_tib,
+    )
+
+    if config.json:
+        console.print_json(openapi_dumps(response).decode("utf-8"))
+    else:
+        console.print("[blue]Storage volume updated successfully[/blue]")
+        console.print(f"[primary]Volume ID:[/primary] {response.volume_id}")

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -228,3 +228,103 @@ EVALS_CREATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
     --model-b-system-template "You are a concise assistant." \\
     --model-b-input-template $'Answer the following:\\n\\n{{prompt}}'[/primary]
 """
+
+## Beta clusters API commands
+
+BETA_CLUSTERS_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] List clusters and regions:
+  [primary]tg beta clusters list[/primary]
+  [primary]tg beta clusters list-regions[/primary]
+
+[dim]-[/dim] Write kubeconfig for a cluster (default ~/.kube/config):
+  [primary]tg beta clusters get-credentials <cluster-id>[/primary]
+
+[dim]-[/dim] Print kubeconfig to stdout:
+  [primary]tg beta clusters get-credentials <cluster-id> --file -[/primary]
+
+[dim]-[/dim] Non-interactive cluster create (see [primary]tg beta clusters create --help[/primary] for flags):
+  [primary]tg beta clusters create --non-interactive \\
+    --name my-cluster --cluster-type KUBERNETES --gpu-type H100_SXM \\
+    --region us-central-8 --num-gpus 8 --billing-type ON_DEMAND \\
+    --nvidia-driver-version 565 --cuda-version 12.6 --volume <volume-id>[/primary]
+
+[dim]-[/dim] Update or delete a cluster:
+  [primary]tg beta clusters update <cluster-id> --num-gpus 16 --cluster-type KUBERNETES[/primary]
+  [primary]tg beta clusters delete <cluster-id>[/primary]
+"""
+
+BETA_CLUSTERS_CREATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Create interactively (prompts for region, GPUs, drivers, etc.):
+  [primary]tg beta clusters create[/primary]
+
+[dim]-[/dim] Create without prompts (supply every required field):
+  [primary]tg beta clusters create --non-interactive \\
+    --name my-cluster \\
+    --cluster-type KUBERNETES \\
+    --gpu-type H100_SXM \\
+    --region us-central-8 \\
+    --num-gpus 8 \\
+    --billing-type ON_DEMAND \\
+    --nvidia-driver-version 565 \\
+    --cuda-version 12.6 \\
+    --volume <volume-id>[/primary]
+"""
+
+BETA_CLUSTERS_GET_CREDENTIALS_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Merge cluster kubeconfig into the default file ([primary]~/.kube/config[/primary]):
+  [primary]tg beta clusters get-credentials <cluster-id>[/primary]
+
+[dim]-[/dim] Write to a specific path:
+  [primary]tg beta clusters get-credentials <cluster-id> --file ./my-kubeconfig[/primary]
+
+[dim]-[/dim] Print kubeconfig to stdout (no file write):
+  [primary]tg beta clusters get-credentials <cluster-id> --file -[/primary]
+
+[dim]-[/dim] Use a custom context name in the merged kubeconfig:
+  [primary]tg beta clusters get-credentials <cluster-id> --context-name my-prod-k8s[/primary]
+
+[dim]-[/dim] On name conflicts with an existing kubeconfig, replace the entry:
+  [primary]tg beta clusters get-credentials <cluster-id> --overwrite-existing[/primary]
+
+[dim]-[/dim] Set this cluster as the default kube context after merge:
+  [primary]tg beta clusters get-credentials <cluster-id> --set-default-context[/primary]
+"""
+
+BETA_CLUSTERS_UPDATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Change GPU count:
+  [primary]tg beta clusters update <cluster-id> --num-gpus 16[/primary]
+
+[dim]-[/dim] Change cluster type:
+  [primary]tg beta clusters update <cluster-id> --cluster-type KUBERNETES[/primary]
+
+[dim]-[/dim] Update both:
+  [primary]tg beta clusters update <cluster-id> --num-gpus 16 --cluster-type KUBERNETES[/primary]
+"""
+
+BETA_CLUSTERS_STORAGE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] List storage volumes:
+  [primary]tg beta clusters storage list[/primary]
+
+[dim]-[/dim] Create or resize a volume (see subcommand help for options):
+  [primary]tg beta clusters storage create --region us-east-1 --size-tib 1 --volume-name my-data[/primary]
+  [primary]tg beta clusters storage update <volume-id> --size-tib 4[/primary]
+
+[dim]-[/dim] Use a volume when creating a cluster:
+  [primary]tg beta clusters create --non-interactive ... --volume <volume-id>[/primary]
+"""
+
+BETA_CLUSTERS_STORAGE_CREATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Create a 1 TiB volume in a region ([primary]tg beta clusters list-regions[/primary] lists regions):
+  [primary]tg beta clusters storage create \\
+    --region us-east-1 \\
+    --size-tib 1 \\
+    --volume-name my-training-data[/primary]
+
+[dim]-[/dim] Attach the volume when creating a cluster:
+  [primary]tg beta clusters create --non-interactive ... --volume <volume-id>[/primary]
+"""
+
+BETA_CLUSTERS_STORAGE_UPDATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Grow a volume to 4 TiB:
+  [primary]tg beta clusters storage update <volume-id> --size-tib 4[/primary]
+"""

--- a/tests/cli/test_json_mode_pipeable_to_jq.py
+++ b/tests/cli/test_json_mode_pipeable_to_jq.py
@@ -153,6 +153,7 @@ class TestJSONMode:
     def test_beta_clusters_storage_json_mode(self) -> None:
         beta_clusters_storage = JSONValidator(("beta", "clusters", "storage"))
         beta_clusters_storage.run_and_assert("create --region us-east-1 --size-tib 1 --volume-name test-volume")
+        beta_clusters_storage.run_and_assert("update storage-123 --size-tib 4")
         beta_clusters_storage.run_and_assert("delete storage-123")
         beta_clusters_storage.run_and_assert("list")
         beta_clusters_storage.run_and_assert("retrieve storage-123")


### PR DESCRIPTION
command | output
---|---
`tg beta clusters` | <img width="721" height="617" alt="image" src="https://github.com/user-attachments/assets/cd9f6ef1-c867-44e7-8499-f415b19b1eeb" />
`tg beta clusters create` | <img width="724" height="566" alt="image" src="https://github.com/user-attachments/assets/fb1b1cb3-03c6-4f76-a41b-91da37efb6d7" />
`tg beta clusters get-credentials` | <img width="721" height="558" alt="image" src="https://github.com/user-attachments/assets/fa279da2-c75a-4b43-87a1-8e58c67cebd4" />
`tg beta clusters update` | <img width="722" height="364" alt="image" src="https://github.com/user-attachments/assets/896bd784-e0b8-4c98-8be9-abadd54715cf" />
`tg beta clusters storage` | <img width="725" height="374" alt="image" src="https://github.com/user-attachments/assets/e6da57d4-db26-4fde-bcaf-be41dcef5789" />
`tg beta clusters storage create` | <img width="722" height="363" alt="image" src="https://github.com/user-attachments/assets/2f4aad22-958f-4891-87d5-8967f68aeebf" />
`tg beta clusters storage update` | <img width="720" height="257" alt="image" src="https://github.com/user-attachments/assets/e1d35d84-a003-482b-801b-10f220b8f33c" />


