### PR TITLE
slim fine-tune JSONL check to structural validation only

### DIFF
--- a/src/together/lib/utils/files.py
+++ b/src/together/lib/utils/files.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import csv
 import json
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict
 from pathlib import Path
 from traceback import format_exc
 
@@ -12,27 +12,10 @@ from tqdm import tqdm
 from together.types import FilePurpose
 from together.lib.constants import (
     MIN_SAMPLES,
-    MAX_IMAGE_BYTES,
     NUM_BYTES_IN_GB,
     MAX_FILE_SIZE_GB,
-    MAX_IMAGES_PER_EXAMPLE,
-    JSONL_EXTRA_COLUMNS_MAP,
-    MAX_BASE64_IMAGE_LENGTH,
     PARQUET_EXPECTED_COLUMNS,
-    REQUIRED_COLUMNS_MESSAGE,
-    JSONL_REQUIRED_COLUMNS_MAP,
-    POSSIBLE_ROLES_CONVERSATION,
-    DatasetFormat,
 )
-
-# MessageContent is a string or a list of dicts with 'type': 'text' or 'image_url', and 'text' or 'image_url.url'
-# Example: "Hello" or [
-#   {"type": "text", "text": "Hello"},
-#   {"type": "image_url", "image_url": {
-#     "url": "data:image/jpeg;base64,..."
-#   }}
-# ]
-MessageContent = Union[str, List[Dict[str, Any]]]
 
 
 class InvalidFileFormatError(ValueError):
@@ -116,412 +99,6 @@ def check_file(
     report_dict.update(data_report_dict)
 
     return report_dict
-
-
-def _check_conversation_type(messages: List[Dict[str, str | int | MessageContent]], idx: int) -> None:
-    """Check that the conversation has correct type.
-
-    Args:
-        messages: The messages in the conversation.
-            Can be any type, this function ensures that the messages are a list of dictionaries.
-        idx: Line number in the file.
-
-    Raises:
-        InvalidFileFormatError: If the conversation type is invalid.
-    """
-    # if not isinstance(messages, list):
-    #     raise InvalidFileFormatError(
-    #         message=f"Invalid format on line {idx + 1} of the input file. "
-    #         f"The `messages` column must be a list. Found {type(messages)}",
-    #         line_number=idx + 1,
-    #         error_source="key_value",
-    #     )
-    if len(messages) == 0:
-        raise InvalidFileFormatError(
-            message=f"Invalid format on line {idx + 1} of the input file. The `messages` column must not be empty.",
-            line_number=idx + 1,
-            error_source="key_value",
-        )
-
-    for message in messages:
-        if not isinstance(cast(Any, message), dict):
-            raise InvalidFileFormatError(
-                message=f"Invalid format on line {idx + 1} of the input file. "
-                f"The `messages` column must be a list of dicts. Found {type(message)}",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        for column in REQUIRED_COLUMNS_MESSAGE:
-            if column not in message:
-                raise InvalidFileFormatError(
-                    message=f"Missing required column `{column}` in message on line {idx + 1}.",
-                    line_number=idx + 1,
-                    error_source="key_value",
-                )
-
-        if message["role"] != "assistant" and "content" not in message:
-            raise InvalidFileFormatError(
-                message=f"Missing required column `content` in message on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        if "content" not in message and "tool_calls" not in message:
-            raise InvalidFileFormatError(
-                message=f"Missing required column `content` or `tool_calls` in message on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-
-def _check_conversation_roles(require_assistant_role: bool, assistant_role_exists: bool, idx: int) -> None:
-    """Check that the conversation has correct roles.
-
-    Args:
-        require_assistant_role: Whether to require at least one assistant role.
-        assistant_role_exists: Whether an assistant role exists in the conversation.
-        idx: Line number in the file.
-
-    Raises:
-        InvalidFileFormatError: If the conversation roles are invalid.
-    """
-    if require_assistant_role and not assistant_role_exists:
-        raise InvalidFileFormatError(
-            message=f"Invalid format on line {idx + 1} of the input file. "
-            "At least one message with the assistant role must be present in the example.",
-            line_number=idx + 1,
-            error_source="key_value",
-        )
-
-
-def _check_message_weight(message: Dict[str, str | int | MessageContent], idx: int) -> int | None:
-    """Check that the message has a weight with the correct type and value.
-
-    Args:
-        message: The message to check.
-        idx: Line number in the file.
-
-    Raises:
-        InvalidFileFormatError: If the message weight is invalid.
-    """
-    if "weight" in message:
-        weight = message["weight"]
-        if not isinstance(weight, int):
-            raise InvalidFileFormatError(
-                message=f"Weight must be an integer on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-        if weight not in {0, 1}:
-            raise InvalidFileFormatError(
-                message=f"Weight must be either 0 or 1 on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-        return weight
-
-    return None
-
-
-def _check_message_role(message: Dict[str, str | int | MessageContent], idx: int) -> str:
-    """Check that the message has correct roles.
-
-    Args:
-        message: The message to check.
-        idx: Line number in the file.
-
-    Returns:
-        str: The role of the current message.
-
-    Raises:
-        InvalidFileFormatError: If the message role is invalid.
-    """
-    if not isinstance(message["role"], str):
-        raise InvalidFileFormatError(
-            message=f"Invalid role `{message['role']}` in conversation on line {idx + 1}. "
-            f"Role must be a string. Found {type(message['role'])}",
-            line_number=idx + 1,
-            error_source="key_value",
-        )
-
-    if message["role"] not in POSSIBLE_ROLES_CONVERSATION:
-        raise InvalidFileFormatError(
-            message=f"Invalid role `{message['role']}` in conversation on line {idx + 1}. "
-            f"Possible roles: {', '.join(POSSIBLE_ROLES_CONVERSATION)}",
-            line_number=idx + 1,
-            error_source="key_value",
-        )
-    return message["role"]
-
-
-def _check_message_content(message_content: str | int | MessageContent, role: str, idx: int) -> tuple[bool, int]:
-    """Check that the message content has the correct type.
-    Message content can be either a) a string or b) an OpenAI-style multimodal list of content items
-    Example:
-        a) "Hello", or
-        b) [
-             {"type": "text", "text": "Hello"},
-             {"type": "image_url", "image_url": {
-                "url": "data:image/jpeg;base64,..."
-             }}
-           ]
-
-    Args:
-        message_content: The message content to check.
-        role: The role of the message.
-        idx: Line number in the file.
-
-    Returns:
-        tuple[bool, int]: A tuple with message is multimodal and the number of images in the message content.
-    """
-    # Text-only message content
-    if isinstance(message_content, str):
-        return False, 0
-
-    # Multimodal message content
-    if isinstance(message_content, list):
-        num_images = 0
-        for item in message_content:
-            if not isinstance(cast(Any, item), dict):
-                raise InvalidFileFormatError(
-                    "The dataset is malformed, the `content` field must be a list of dicts.",
-                    line_number=idx + 1,
-                    error_source="key_value",
-                )
-            if "type" not in item:
-                raise InvalidFileFormatError(
-                    "The dataset is malformed, the `content` field must be a list of dicts with a `type` field.",
-                    line_number=idx + 1,
-                    error_source="key_value",
-                )
-
-            if item["type"] == "text":
-                if "text" not in item or not isinstance(item["text"], str):
-                    raise InvalidFileFormatError(
-                        "The dataset is malformed, the `text` field must be present in the `content` item field and be"
-                        f" a string. Got '{item.get('text')!r}' instead.",
-                        line_number=idx + 1,
-                        error_source="key_value",
-                    )
-            elif item["type"] == "image_url":
-                if role != "user":
-                    raise InvalidFileFormatError(
-                        "The dataset is malformed, only user messages can contain images.",
-                        line_number=idx + 1,
-                        error_source="key_value",
-                    )
-
-                if "image_url" not in item or not isinstance(item["image_url"], dict):
-                    raise InvalidFileFormatError(
-                        "The dataset is malformed, the `image_url` field must be present in the `content` field and "
-                        f"be a dictionary. Got {item.get('image_url')!r} instead.",
-                        line_number=idx + 1,
-                        error_source="key_value",
-                    )
-
-                image_data = cast(Any, item["image_url"]).get("url")
-                if not image_data or not isinstance(image_data, str):
-                    raise InvalidFileFormatError(
-                        "The dataset is malformed, the `url` field must be present in the `image_url` field and be "
-                        f"a string. Got {image_data!r} instead.",
-                        line_number=idx + 1,
-                        error_source="key_value",
-                    )
-
-                if not any(image_data.startswith(f"data:image/{fmt};base64,") for fmt in ["jpeg", "png", "webp"]):
-                    raise InvalidFileFormatError(
-                        "The dataset is malformed, the `url` field must be either a JPEG, PNG or WEBP base64-encoded "
-                        "image in 'data:image/<format>;base64,<base64_encoded_image>' format. "
-                        f"Got '{image_data[:100]}...' instead.",
-                        line_number=idx + 1,
-                    )
-
-                if len(image_data) > MAX_BASE64_IMAGE_LENGTH:
-                    raise InvalidFileFormatError(
-                        "The dataset is malformed, the `url` field must contain base64-encoded image "
-                        f"that is less than {MAX_IMAGE_BYTES // (1024**2)}MB, found ~{len(image_data) * 3 // 4} bytes.",
-                        line_number=idx + 1,
-                        error_source="key_value",
-                    )
-
-                num_images += 1
-            else:
-                raise InvalidFileFormatError(
-                    "The dataset is malformed, the `type` field must be either 'text' or 'image_url'. "
-                    f"Got {item['type']!r}.",
-                    line_number=idx + 1,
-                    error_source="key_value",
-                )
-
-        if num_images > MAX_IMAGES_PER_EXAMPLE:
-            raise InvalidFileFormatError(
-                f"The dataset is malformed, the `content` field must contain at most "
-                f"{MAX_IMAGES_PER_EXAMPLE} images, found {num_images}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        # We still consider text-only messages in such format as multimodal, even if they don't have any images
-        # included - so we can process datasets with rather sparse images (i.e. not in each sample) consistently.
-        return True, num_images
-
-    raise InvalidFileFormatError(
-        f"Invalid content type on line {idx + 1} of the input file. Expected string or multimodal list of dicts, "
-        f"found {type(message_content)}",
-        line_number=idx + 1,
-        error_source="key_value",
-    )
-
-
-def validate_messages(
-    messages: List[Dict[str, str | int | MessageContent]],
-    idx: int,
-    require_assistant_role: bool = True,
-) -> None:
-    """Validate the messages column.
-
-    Args:
-        messages: List of message dictionaries to validate.
-        idx: Line number in the file.
-        require_assistant_role: Whether to require at least one assistant role.
-
-    Raises:
-        InvalidFileFormatError: If the messages are invalid.
-    """
-    _check_conversation_type(messages, idx)
-
-    assistant_role_exists = False
-
-    messages_are_multimodal: bool | None = None
-    total_number_of_images = 0
-
-    for message in messages:
-        message_weight = _check_message_weight(message, idx)
-        role = _check_message_role(message, idx)
-        assistant_role_exists |= role == "assistant"
-        if "content" not in message or not message.get("content"):
-            continue
-        is_multimodal, number_of_images = _check_message_content(message["content"], role=role, idx=idx)
-        # Multimodal validation
-        if number_of_images > 0 and message_weight is not None and message_weight != 0:
-            raise InvalidFileFormatError(
-                "Messages with images cannot have non-zero weights.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-        if messages_are_multimodal is None:
-            # Detect the format of the messages in the conversation.
-            messages_are_multimodal = is_multimodal
-        elif messages_are_multimodal != is_multimodal:
-            # Due to the format limitation, we cannot mix multimodal and text only messages in the same sample.
-            raise InvalidFileFormatError(
-                "Messages in the conversation must be either all in multimodal or all in text-only format.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-        total_number_of_images += number_of_images
-
-    if total_number_of_images > MAX_IMAGES_PER_EXAMPLE:
-        raise InvalidFileFormatError(
-            f"The dataset is malformed, the `messages` must contain at most {MAX_IMAGES_PER_EXAMPLE} images. "
-            f"Found {total_number_of_images} images.",
-            line_number=idx + 1,
-            error_source="key_value",
-        )
-
-    _check_conversation_roles(require_assistant_role, assistant_role_exists, idx)
-
-
-def validate_preference_openai(example: Dict[str, Any], idx: int = 0) -> None:
-    """Validate the OpenAI preference dataset format.
-
-    Args:
-        example (dict): Input entry to be checked.
-        idx (int): Line number in the file.
-
-    Raises:
-        InvalidFileFormatError: If the dataset format is invalid.
-    """
-    if not isinstance(example["input"], dict):
-        raise InvalidFileFormatError(
-            message="The dataset is malformed, the `input` field must be a dictionary.",
-            line_number=idx + 1,
-            error_source="key_value",
-        )
-
-    if "messages" not in example["input"]:
-        raise InvalidFileFormatError(
-            message="The dataset is malformed, the `input` dictionary must contain a `messages` field.",
-            line_number=idx + 1,
-            error_source="key_value",
-        )
-
-    messages: List[Dict[str, str | int | MessageContent]] = cast(Any, example["input"]["messages"])
-    validate_messages(messages, idx, require_assistant_role=False)
-
-    if example["input"]["messages"][-1]["role"] == "assistant":
-        raise InvalidFileFormatError(
-            message=f"The last message in the input conversation must not be from the assistant on line {idx + 1}.",
-            line_number=idx + 1,
-            error_source="key_value",
-        )
-
-    keys = ["preferred_output", "non_preferred_output"]
-
-    for key in keys:
-        if key not in example:
-            raise InvalidFileFormatError(
-                message=f"The dataset is malformed, the `{key}` field must be present in the input dictionary on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        if not isinstance(example[key], list):
-            raise InvalidFileFormatError(
-                message=f"The dataset is malformed, the `{key}` field must be a list on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        if len(example[key]) != 1:
-            raise InvalidFileFormatError(
-                message=f"The dataset is malformed, the `{key}` list must contain exactly one message on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        if not isinstance(example[key][0], dict):
-            raise InvalidFileFormatError(
-                message=f"The dataset is malformed, the first element of `{key}` must be a dictionary on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        if "role" not in example[key][0]:
-            raise InvalidFileFormatError(
-                message=f"The dataset is malformed, the first element of `{key}` must have a 'role' field on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        if example[key][0]["role"] != "assistant":
-            raise InvalidFileFormatError(
-                message=f"The dataset is malformed, the first element of `{key}` must have the 'assistant' role on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        contains_response_field = "content" in example[key][0] or "tool_calls" in example[key][0]
-        if not contains_response_field:
-            raise InvalidFileFormatError(
-                message=f"The dataset is malformed, the first element of `{key}` must have a 'content' or 'tool_calls' field on line {idx + 1}.",
-                line_number=idx + 1,
-                error_source="key_value",
-            )
-
-        if "content" in example[key][0]:
-            _check_message_content(example[key][0]["content"], role="assistant", idx=idx)
 
 
 def _check_utf8(file: Path) -> Dict[str, Any]:
@@ -631,110 +208,97 @@ def _check_jsonl(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
 
     DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
 
-    dataset_format = None
-    with file.open() as f:
-        idx = -1
-        try:
-            for idx, line in tqdm(
-                enumerate(f),
-                desc="Validating file",
-                unit=" lines",
-                disable=bool(DISABLE_TQDM),
-            ):
-                json_line = json.loads(line)
+    if purpose == "eval":
+        with file.open() as f:
+            idx = -1
+            try:
+                for idx, line in tqdm(
+                    enumerate(f),
+                    desc="Validating file",
+                    unit=" lines",
+                    disable=bool(DISABLE_TQDM),
+                ):
+                    json_line = json.loads(line)
 
-                if not isinstance(json_line, dict):
-                    raise InvalidFileFormatError(
-                        message=(
-                            f"Error parsing file. Invalid format on line {idx + 1} of the input file. "
-                            "Datasets must follow text, conversational, or instruction format. For more"
-                            "information, see https://docs.together.ai/docs/fine-tuning-data-preparation"
-                        ),
-                        line_number=idx + 1,
-                        error_source="line_type",
-                    )
-                # In evals, we don't check the format of the dataset.
-                if purpose != "eval":
-                    current_format = None
-                    for possible_format in JSONL_REQUIRED_COLUMNS_MAP:
-                        if all(column in json_line for column in JSONL_REQUIRED_COLUMNS_MAP[possible_format]):
-                            if current_format is None:
-                                current_format = possible_format
-                            elif current_format != possible_format:  # type: ignore[unreachable]
-                                raise InvalidFileFormatError(
-                                    message="Found multiple dataset formats in the input file. "
-                                    f"Got {current_format} and {possible_format} on line {idx + 1}.",
-                                    line_number=idx + 1,
-                                    error_source="format",
-                                )
-
-                            # Check that there are no extra columns
-                            for column in cast(List[str], json_line.keys()):
-                                if (
-                                    column
-                                    not in JSONL_REQUIRED_COLUMNS_MAP[possible_format]
-                                    + JSONL_EXTRA_COLUMNS_MAP[possible_format]
-                                ):
-                                    raise InvalidFileFormatError(
-                                        message=f'Found extra column "{column}" in the line {idx + 1}.',
-                                        line_number=idx + 1,
-                                        error_source="format",
-                                    )
-
-                    if current_format is None:
+                    if not isinstance(json_line, dict):
                         raise InvalidFileFormatError(
                             message=(
-                                f"Error parsing file. Could not detect a format for the line {idx + 1} with the columns:\n"
-                                f"{json_line.keys()}"
+                                f"Error parsing file. Invalid format on line {idx + 1} of the input file. "
+                                "Datasets must follow text, conversational, or instruction format. For more "
+                                "information, see https://docs.together.ai/docs/fine-tuning-data-preparation"
                             ),
                             line_number=idx + 1,
-                            error_source="format",
+                            error_source="line_type",
                         )
-                    if current_format == DatasetFormat.PREFERENCE_OPENAI:
-                        validate_preference_openai(cast(Dict[str, Any], json_line), idx)
-                    elif current_format == DatasetFormat.CONVERSATION:
-                        message_column = JSONL_REQUIRED_COLUMNS_MAP[DatasetFormat.CONVERSATION][0]
-                        require_assistant = purpose != "eval"
-                        message: List[Dict[str, str | int | MessageContent]] = cast(Any, json_line[message_column])
-                        validate_messages(
-                            message,
-                            idx,
-                            require_assistant_role=require_assistant,
-                        )
-                    else:
-                        for column in JSONL_REQUIRED_COLUMNS_MAP[current_format]:
-                            role = "assistant" if column in {"completion"} else "user"
-                            _check_message_content(cast(Any, json_line[column]), role=role, idx=idx)
+                report_dict.update(_check_samples_count(file, report_dict, idx))
+                report_dict["load_json"] = True
 
-                    if dataset_format is None:
-                        dataset_format = current_format
-                    elif current_format != dataset_format:  # type: ignore[unreachable]
+            except InvalidFileFormatError as e:
+                report_dict["load_json"] = False
+                report_dict["is_check_passed"] = False
+                report_dict["message"] = e.message
+                if e.line_number is not None:
+                    report_dict["line_number"] = e.line_number
+                if e.error_source is not None:
+                    report_dict[e.error_source] = False
+            except ValueError:
+                report_dict["load_json"] = False
+                if idx < 0:
+                    report_dict["message"] = "Unable to decode file. File may be empty or in an unsupported format. "
+                else:
+                    report_dict["message"] = f"Error parsing json payload. Unexpected format on line {idx + 1}."
+                report_dict["is_check_passed"] = False
+    else:
+        # Fine-tuning (and non-eval): UTF-8, JSON-parse each non-empty line, require a JSON object per line.
+        # Semantic validation runs on the server after upload.
+        with file.open() as f:
+            line_index = -1
+            sample_count = 0
+            try:
+                for line_index, raw_line in tqdm(
+                    enumerate(f),
+                    desc="Validating file",
+                    unit=" lines",
+                    disable=bool(DISABLE_TQDM),
+                ):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    json_line = json.loads(line)
+
+                    if not isinstance(json_line, dict):
                         raise InvalidFileFormatError(
-                            message="All samples in the dataset must have the same dataset format. "
-                            f"Got {dataset_format} for the first line and {current_format} "
-                            f"for the line {idx + 1}.",
-                            line_number=idx + 1,
-                            error_source="format",
+                            message=(
+                                f"Error parsing file. Invalid format on line {line_index + 1} of the input file. "
+                                "Each line must be a JSON object. Dataset requirements are described at "
+                                "https://docs.together.ai/docs/fine-tuning-data-preparation. "
+                                "Full validation runs on the server after upload."
+                            ),
+                            line_number=line_index + 1,
+                            error_source="line_type",
                         )
-            report_dict.update(_check_samples_count(file, report_dict, idx))
+                    sample_count += 1
 
-            report_dict["load_json"] = True
+                report_dict.update(
+                    _check_samples_count(file, report_dict, sample_count - 1 if sample_count else -1)
+                )
+                report_dict["load_json"] = True
 
-        except InvalidFileFormatError as e:
-            report_dict["load_json"] = False
-            report_dict["is_check_passed"] = False
-            report_dict["message"] = e.message
-            if e.line_number is not None:
-                report_dict["line_number"] = e.line_number
-            if e.error_source is not None:
-                report_dict[e.error_source] = False
-        except ValueError:
-            report_dict["load_json"] = False
-            if idx < 0:
-                report_dict["message"] = "Unable to decode file. File may be empty or in an unsupported format. "
-            else:
-                report_dict["message"] = f"Error parsing json payload. Unexpected format on line {idx + 1}."
-            report_dict["is_check_passed"] = False
+            except InvalidFileFormatError as e:
+                report_dict["load_json"] = False
+                report_dict["is_check_passed"] = False
+                report_dict["message"] = e.message
+                if e.line_number is not None:
+                    report_dict["line_number"] = e.line_number
+                if e.error_source is not None:
+                    report_dict[e.error_source] = False
+            except ValueError:
+                report_dict["load_json"] = False
+                if line_index < 0:
+                    report_dict["message"] = "Unable to decode file. File may be empty or in an unsupported format. "
+                else:
+                    report_dict["message"] = f"Error parsing json payload. Unexpected format on line {line_index + 1}."
+                report_dict["is_check_passed"] = False
 
     if "text_field" not in report_dict:
         report_dict["text_field"] = True

--- a/src/together/lib/utils/files.py
+++ b/src/together/lib/utils/files.py
@@ -279,9 +279,7 @@ def _check_jsonl(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
                         )
                     sample_count += 1
 
-                report_dict.update(
-                    _check_samples_count(file, report_dict, sample_count - 1 if sample_count else -1)
-                )
+                report_dict.update(_check_samples_count(file, report_dict, sample_count - 1 if sample_count else -1))
                 report_dict["load_json"] = True
 
             except InvalidFileFormatError as e:

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -3,6 +3,8 @@ import json
 from typing import Any, Dict, List
 from pathlib import Path
 
+import pytest
+
 from together.lib.utils.files import check_file
 
 
@@ -232,13 +234,122 @@ def test_check_jsonl_invalid_json(tmp_path: Path):
     assert "Error parsing file." in report["message"]
 
 
-def test_check_jsonl_missing_required_field(tmp_path: Path):
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(
+            [
+                {"prompt": "Translate the following sentence.", "completion": "Hello, world!"},
+                {"prompt": "Summarize the text."},
+            ],
+            id="missing_required_field",
+        ),
+        pytest.param(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant", "content": "Hi! How can I help you?"},
+                    ]
+                },
+                {"text": "How are you?"},
+            ],
+            id="inconsistent_dataset_format",
+        ),
+        pytest.param(
+            [{"messages": [{"role": "invalid_role", "content": "Hi"}]}],
+            id="invalid_role",
+        ),
+        pytest.param(
+            [{"messages": [{"role": "user", "content": "Hi"}]}],
+            id="missing_assistant_role",
+        ),
+        pytest.param(
+            [{"text": 123}],
+            id="invalid_value_type",
+        ),
+        pytest.param(
+            [{"messages": [{"role": "user", "content": "Hi"}, {"content": "Hello"}]}],
+            id="missing_role_in_conversation",
+        ),
+        pytest.param(
+            [{"messages": [{"role": "user"}]}],
+            id="missing_content_in_conversation",
+        ),
+        pytest.param(
+            [{"messages": [{"role": "assistant"}]}],
+            id="missing_content_or_tool_calls_in_conversation",
+        ),
+        pytest.param(
+            [
+                {
+                    "messages": [
+                        "Hi!",
+                        {"role": "user", "content": "Hi"},
+                        {"role": "assistant"},
+                    ]
+                }
+            ],
+            id="wrong_turn_type",
+        ),
+        pytest.param(
+            [{"text": "Hello, world!", "extra_column": "extra"}],
+            id="extra_column",
+        ),
+        pytest.param(
+            [{"messages": []}],
+            id="empty_messages",
+        ),
+        pytest.param(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "Hello", "weight": 1.0},
+                        {"role": "assistant", "content": "Hi there!", "weight": 0},
+                    ]
+                }
+            ],
+            id="invalid_weight_float",
+        ),
+        pytest.param(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "Hello", "weight": 2},
+                        {"role": "assistant", "content": "Hi there!", "weight": 0},
+                    ]
+                }
+            ],
+            id="invalid_weight_value",
+        ),
+        pytest.param(
+            [
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "Hello"},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": "<malformed_base64_image>"},
+                                },
+                            ],
+                        },
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Hi there!"}],
+                        },
+                    ]
+                }
+            ],
+            id="invalid_multimodal_content",
+        ),
+    ],
+)
+def test_check_jsonl_semantic_errors_pass_structural_check(tmp_path: Path, content: List[Dict[str, Any]]):
     # Semantic checks run on the server; client only verifies JSON objects per line.
-    file = tmp_path / "missing_field.jsonl"
-    content = [
-        {"prompt": "Translate the following sentence.", "completion": "Hello, world!"},
-        {"prompt": "Summarize the text."},
-    ]
+    file = tmp_path / "semantic_error.jsonl"
     with file.open("w") as f:
         f.write("\n".join(json.dumps(item) for item in content))
 
@@ -246,142 +357,6 @@ def test_check_jsonl_missing_required_field(tmp_path: Path):
 
     assert report["is_check_passed"]
     assert report["num_samples"] == len(content)
-
-
-def test_check_jsonl_inconsistent_dataset_format(tmp_path: Path):
-    file = tmp_path / "inconsistent_format.jsonl"
-    content = [
-        {
-            "messages": [
-                {"role": "user", "content": "Hi"},
-                {"role": "assistant", "content": "Hi! How can I help you?"},
-            ]
-        },
-        {"text": "How are you?"},
-    ]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-
-    assert report["is_check_passed"]
-    assert report["num_samples"] == len(content)
-
-
-def test_check_jsonl_invalid_role(tmp_path: Path):
-    file = tmp_path / "invalid_role.jsonl"
-    content = [{"messages": [{"role": "invalid_role", "content": "Hi"}]}]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_assistant_role_exists(tmp_path: Path):
-    file = tmp_path / "assistant_role_exists.jsonl"
-    content = [{"messages": [{"role": "user", "content": "Hi"}]}]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_invalid_value_type(tmp_path: Path):
-    file = tmp_path / "invalid_value_type.jsonl"
-    content = [{"text": 123}]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_missing_role_in_conversation(tmp_path: Path):
-    file = tmp_path / "missing_field_in_conversation.jsonl"
-    content = [
-        {
-            "messages": [
-                {"role": "user", "content": "Hi"},
-                {"content": "Hello"},
-            ]
-        }
-    ]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_missing_content_in_conversation(tmp_path: Path):
-    file = tmp_path / "missing_content_in_conversation.jsonl"
-    content = [{"messages": [{"role": "user"}]}]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_missing_content_or_tool_calls_in_conversation(tmp_path: Path):
-    file = tmp_path / "missing_content_or_tool_calls_in_conversation.jsonl"
-    content = [{"messages": [{"role": "assistant"}]}]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_wrong_turn_type(tmp_path: Path):
-    file = tmp_path / "wrong_turn_type.jsonl"
-    content = [
-        {
-            "messages": [
-                "Hi!",
-                {"role": "user", "content": "Hi"},
-                {"role": "assistant"},
-            ]
-        }
-    ]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_extra_column(tmp_path: Path):
-    file = tmp_path / "extra_column.jsonl"
-    content = [{"text": "Hello, world!", "extra_column": "extra"}]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_empty_messages(tmp_path: Path):
-    file = tmp_path / "empty_messages.jsonl"
-    content: List[Dict[str, Any]] = [{"messages": []}]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_valid_weights_all_messages(tmp_path: Path):
@@ -435,73 +410,6 @@ def test_check_jsonl_valid_weights_mixed_with_none(tmp_path: Path):
     report = check_file(file)
     assert report["is_check_passed"]
     assert report["num_samples"] == len(content)
-
-
-def test_check_jsonl_invalid_weight_float(tmp_path: Path):
-    file = tmp_path / "invalid_weight_float.jsonl"
-    content = [
-        {
-            "messages": [
-                {"role": "user", "content": "Hello", "weight": 1.0},
-                {"role": "assistant", "content": "Hi there!", "weight": 0},
-            ]
-        }
-    ]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_invalid_weight(tmp_path: Path):
-    file = tmp_path / "invalid_weight.jsonl"
-    content = [
-        {
-            "messages": [
-                {"role": "user", "content": "Hello", "weight": 2},
-                {"role": "assistant", "content": "Hi there!", "weight": 0},
-            ]
-        }
-    ]
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
-
-
-def test_check_jsonl_invalid_multimodal_content(tmp_path: Path):
-    file = tmp_path / "invalid_multimodal_content.jsonl"
-    content = [
-        {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": "Hello"},
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": "<malformed_base64_image>"},
-                        },
-                    ],
-                },
-                {
-                    "role": "assistant",
-                    "content": [{"type": "text", "text": "Hi there!"}],
-                },
-            ]
-        }
-    ]
-
-    with file.open("w") as f:
-        f.write("\n".join(json.dumps(item) for item in content))
-
-    report = check_file(file)
-    assert report["is_check_passed"]
-    assert report["num_samples"] == 1
 
 
 def test_check_csv_valid_general(tmp_path: Path):

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -189,7 +189,6 @@ def test_check_jsonl_valid_conversational_multimodal_single_turn(tmp_path: Path)
 
     report = check_file(file)
 
-    print(report)
     assert report["is_check_passed"]
     assert report["utf8"]
     assert report["num_samples"] == len(content)
@@ -234,7 +233,7 @@ def test_check_jsonl_invalid_json(tmp_path: Path):
 
 
 def test_check_jsonl_missing_required_field(tmp_path: Path):
-    # Create a JSONL file missing a required field
+    # Semantic checks run on the server; client only verifies JSON objects per line.
     file = tmp_path / "missing_field.jsonl"
     content = [
         {"prompt": "Translate the following sentence.", "completion": "Hello, world!"},
@@ -245,12 +244,11 @@ def test_check_jsonl_missing_required_field(tmp_path: Path):
 
     report = check_file(file)
 
-    assert not report["is_check_passed"]
-    assert "Error parsing file. Could not detect a format for the line 2" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == len(content)
 
 
 def test_check_jsonl_inconsistent_dataset_format(tmp_path: Path):
-    # Create a JSONL file with inconsistent dataset formats
     file = tmp_path / "inconsistent_format.jsonl"
     content = [
         {
@@ -259,19 +257,18 @@ def test_check_jsonl_inconsistent_dataset_format(tmp_path: Path):
                 {"role": "assistant", "content": "Hi! How can I help you?"},
             ]
         },
-        {"text": "How are you?"},  # Missing 'messages'
+        {"text": "How are you?"},
     ]
     with file.open("w") as f:
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
 
-    assert not report["is_check_passed"]
-    assert "All samples in the dataset must have the same dataset format" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == len(content)
 
 
 def test_check_jsonl_invalid_role(tmp_path: Path):
-    # Create a JSONL file with an invalid role
     file = tmp_path / "invalid_role.jsonl"
     content = [{"messages": [{"role": "invalid_role", "content": "Hi"}]}]
     with file.open("w") as f:
@@ -279,12 +276,11 @@ def test_check_jsonl_invalid_role(tmp_path: Path):
 
     report = check_file(file)
 
-    assert not report["is_check_passed"]
-    assert "Invalid role `invalid_role` in conversation" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_assistant_role_exists(tmp_path: Path):
-    # Create a JSONL file with no assistant role
     file = tmp_path / "assistant_role_exists.jsonl"
     content = [{"messages": [{"role": "user", "content": "Hi"}]}]
     with file.open("w") as f:
@@ -292,20 +288,19 @@ def test_check_jsonl_assistant_role_exists(tmp_path: Path):
 
     report = check_file(file)
 
-    assert not report["is_check_passed"]
-    assert "At least one message with the assistant role must be present" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_invalid_value_type(tmp_path: Path):
-    # Create a JSONL file with an invalid value type
     file = tmp_path / "invalid_value_type.jsonl"
     content = [{"text": 123}]
     with file.open("w") as f:
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "Expected string" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_missing_role_in_conversation(tmp_path: Path):
@@ -322,8 +317,8 @@ def test_check_jsonl_missing_role_in_conversation(tmp_path: Path):
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "Missing required column `role`" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_missing_content_in_conversation(tmp_path: Path):
@@ -333,8 +328,8 @@ def test_check_jsonl_missing_content_in_conversation(tmp_path: Path):
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "Missing required column `content`" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_missing_content_or_tool_calls_in_conversation(tmp_path: Path):
@@ -344,9 +339,8 @@ def test_check_jsonl_missing_content_or_tool_calls_in_conversation(tmp_path: Pat
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "`content`" in report["message"]
-    assert "`tool_calls`" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_wrong_turn_type(tmp_path: Path):
@@ -364,11 +358,8 @@ def test_check_jsonl_wrong_turn_type(tmp_path: Path):
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert (
-        "Invalid format on line 1 of the input file. The `messages` column must be a list of dicts."
-        in report["message"]
-    )
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_extra_column(tmp_path: Path):
@@ -378,8 +369,8 @@ def test_check_jsonl_extra_column(tmp_path: Path):
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "Found extra column" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_empty_messages(tmp_path: Path):
@@ -389,8 +380,8 @@ def test_check_jsonl_empty_messages(tmp_path: Path):
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "The `messages` column must not be empty" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_valid_weights_all_messages(tmp_path: Path):
@@ -460,8 +451,8 @@ def test_check_jsonl_invalid_weight_float(tmp_path: Path):
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "Weight must be an integer" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_invalid_weight(tmp_path: Path):
@@ -478,8 +469,8 @@ def test_check_jsonl_invalid_weight(tmp_path: Path):
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "Weight must be either 0 or 1" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_jsonl_invalid_multimodal_content(tmp_path: Path):
@@ -509,8 +500,8 @@ def test_check_jsonl_invalid_multimodal_content(tmp_path: Path):
         f.write("\n".join(json.dumps(item) for item in content))
 
     report = check_file(file)
-    assert not report["is_check_passed"]
-    assert "field must be either a JPEG, PNG or WEBP" in report["message"]
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 1
 
 
 def test_check_csv_valid_general(tmp_path: Path):

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -1,6 +1,6 @@
 import csv
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 from pathlib import Path
 
 import pytest
@@ -297,7 +297,7 @@ def test_check_jsonl_invalid_json(tmp_path: Path):
             id="extra_column",
         ),
         pytest.param(
-            [{"messages": []}],
+            cast(List[Dict[str, Any]], [{"messages": []}]),
             id="empty_messages",
         ),
         pytest.param(

--- a/tests/unit/test_preference_openai.py
+++ b/tests/unit/test_preference_openai.py
@@ -83,8 +83,8 @@ MISSING_FIELDS_TEST_CASES = [
 ]
 
 
-@pytest.mark.parametrize("field_to_remove, description", MISSING_FIELDS_TEST_CASES)
-def test_check_jsonl_invalid_preference_openai_missing_fields(tmp_path: Path, field_to_remove: str, description: str):
+@pytest.mark.parametrize("field_to_remove")
+def test_check_jsonl_invalid_preference_openai_missing_fields(tmp_path: Path, field_to_remove: str):
     """Test missing required fields in OpenAI preference format."""
     file = tmp_path / f"invalid_preference_openai_missing_{field_to_remove}.jsonl"
     content = [item.copy() for item in _TEST_PREFERENCE_OPENAI_CONTENT]
@@ -260,9 +260,9 @@ STRUCTURAL_ISSUE_TEST_CASES = [
 ]
 
 
-@pytest.mark.parametrize("name, modifier, description", STRUCTURAL_ISSUE_TEST_CASES)
+@pytest.mark.parametrize("name, modifier")
 def test_check_jsonl_invalid_preference_openai_structural_issues(
-    tmp_path: Path, name: ParameterSet, modifier: ParameterSet, description: ParameterSet
+    tmp_path: Path, name: ParameterSet, modifier: ParameterSet
 ):
     """Test various structural issues in OpenAI preference format."""
     file = tmp_path / f"invalid_preference_openai_{name}.jsonl"

--- a/tests/unit/test_preference_openai.py
+++ b/tests/unit/test_preference_openai.py
@@ -62,8 +62,6 @@ def test_check_jsonl_valid_preference_openai(tmp_path: Path):
 
     report = check_file(file)
 
-    print(report)
-
     assert report["is_check_passed"]
     assert report["utf8"]
     assert report["num_samples"] == len(content)
@@ -99,7 +97,7 @@ def test_check_jsonl_invalid_preference_openai_missing_fields(tmp_path: Path, fi
 
     report = check_file(file)
 
-    assert not report["is_check_passed"], f"Test should fail when {description}"
+    assert report["is_check_passed"], "Client-side check is structural only; server validates preference schema"
 
 
 STRUCTURAL_ISSUE_TEST_CASES = [
@@ -278,4 +276,4 @@ def test_check_jsonl_invalid_preference_openai_structural_issues(
 
     report = check_file(file)
 
-    assert not report["is_check_passed"], f"Test should fail with {description}"
+    assert report["is_check_passed"], "Client-side check is structural only; server validates preference schema"

--- a/tests/unit/test_preference_openai.py
+++ b/tests/unit/test_preference_openai.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import json
+from typing import Any
 from pathlib import Path
+from collections.abc import Callable
 
 import pytest
-from _pytest.mark.structures import ParameterSet  # type: ignore
 
 from together.lib.utils.files import check_file
 
@@ -69,21 +72,13 @@ def test_check_jsonl_valid_preference_openai(tmp_path: Path):
 
 
 MISSING_FIELDS_TEST_CASES = [
-    pytest.param("input", "Missing input field", id="missing_input"),
-    pytest.param(
-        "preferred_output",
-        "Missing preferred_output field",
-        id="missing_preferred_output",
-    ),
-    pytest.param(
-        "non_preferred_output",
-        "Missing non_preferred_output field",
-        id="missing_non_preferred_output",
-    ),
+    pytest.param("input", id="missing_input"),
+    pytest.param("preferred_output", id="missing_preferred_output"),
+    pytest.param("non_preferred_output", id="missing_non_preferred_output"),
 ]
 
 
-@pytest.mark.parametrize("field_to_remove")
+@pytest.mark.parametrize("field_to_remove", MISSING_FIELDS_TEST_CASES)
 def test_check_jsonl_invalid_preference_openai_missing_fields(tmp_path: Path, field_to_remove: str):
     """Test missing required fields in OpenAI preference format."""
     file = tmp_path / f"invalid_preference_openai_missing_{field_to_remove}.jsonl"
@@ -103,59 +98,51 @@ def test_check_jsonl_invalid_preference_openai_missing_fields(tmp_path: Path, fi
 STRUCTURAL_ISSUE_TEST_CASES = [
     pytest.param(
         "empty_messages",
-        lambda item: item.update({"input": {"messages": []}}),  # type: ignore
-        "Empty messages array",
+        lambda item: item.update({"input": {"messages": []}}),  # type: ignore[arg-type]
         id="empty_messages",
     ),
     pytest.param(
         "missing_role_preferred",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {"preferred_output": [{"content": "Missing role field"}]}
         ),
-        "Missing role in preferred_output",
         id="missing_role_preferred",
     ),
     pytest.param(
         "missing_role_non_preferred",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {"non_preferred_output": [{"content": "Missing role field"}]}
         ),
-        "Missing role in non_preferred_output",
         id="missing_role_non_preferred",
     ),
     pytest.param(
         "missing_content_preferred",
-        lambda item: item.update({"preferred_output": [{"role": "assistant"}]}),  # type: ignore
-        "Missing content in preferred_output",
+        lambda item: item.update({"preferred_output": [{"role": "assistant"}]}),  # type: ignore[arg-type]
         id="missing_content_preferred",
     ),
     pytest.param(
         "missing_content_non_preferred",
-        lambda item: item.update({"non_preferred_output": [{"role": "assistant"}]}),  # type: ignore
-        "Missing content in non_preferred_output",
+        lambda item: item.update({"non_preferred_output": [{"role": "assistant"}]}),  # type: ignore[arg-type]
         id="missing_content_non_preferred",
     ),
     pytest.param(
         "wrong_output_format_preferred",
-        lambda item: item.update({"preferred_output": "Not an array but a string"}),  # type: ignore
-        "Wrong format for preferred_output",
+        lambda item: item.update({"preferred_output": "Not an array but a string"}),  # type: ignore[arg-type]
         id="wrong_output_format_preferred",
     ),
     pytest.param(
         "wrong_output_format_non_preferred",
-        lambda item: item.update({"non_preferred_output": "Not an array but a string"}),  # type: ignore
-        "Wrong format for non_preferred_output",
+        lambda item: item.update({"non_preferred_output": "Not an array but a string"}),  # type: ignore[arg-type]
         id="wrong_output_format_non_preferred",
     ),
     pytest.param(
         "missing_content",
-        lambda item: item.update({"input": {"messages": [{"role": "user"}]}}),  # type: ignore
-        "Missing content in messages",
+        lambda item: item.update({"input": {"messages": [{"role": "user"}]}}),  # type: ignore[arg-type]
         id="missing_content",
     ),
     pytest.param(
         "multiple_preferred_outputs",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {
                 "preferred_output": [
                     {"role": "assistant", "content": "First response"},
@@ -163,12 +150,11 @@ STRUCTURAL_ISSUE_TEST_CASES = [
                 ]
             }
         ),
-        "Multiple messages in preferred_output",
         id="multiple_preferred_outputs",
     ),
     pytest.param(
         "multiple_non_preferred_outputs",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {
                 "non_preferred_output": [
                     {"role": "assistant", "content": "First response"},
@@ -176,100 +162,90 @@ STRUCTURAL_ISSUE_TEST_CASES = [
                 ]
             }
         ),
-        "Multiple messages in non_preferred_output",
         id="multiple_non_preferred_outputs",
     ),
     pytest.param(
         "empty_preferred_output",
-        lambda item: item.update({"preferred_output": []}),  # type: ignore
-        "Empty preferred_output array",
+        lambda item: item.update({"preferred_output": []}),  # type: ignore[arg-type]
         id="empty_preferred_output",
     ),
     pytest.param(
         "empty_non_preferred_output",
-        lambda item: item.update({"non_preferred_output": []}),  # type: ignore
-        "Empty non_preferred_output array",
+        lambda item: item.update({"non_preferred_output": []}),  # type: ignore[arg-type]
         id="empty_non_preferred_output",
     ),
     pytest.param(
         "non_string_content_in_messages",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {"input": {"messages": [{"role": "user", "content": 123}]}}
         ),
-        "Non-string content in messages",
         id="non_string_content_in_messages",
     ),
     pytest.param(
         "invalid_role_in_messages",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {"input": {"messages": [{"role": "invalid_role", "content": "Hello"}]}}
         ),
-        "Invalid role in messages",
         id="invalid_role_in_messages",
     ),
     pytest.param(
         "invalid_weight_type",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {"input": {"messages": [{"role": "user", "content": "Hello", "weight": "not_an_integer"}]}}
         ),
-        "Invalid weight type",
         id="invalid_weight_type",
     ),
     pytest.param(
         "invalid_weight_value",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {"input": {"messages": [{"role": "user", "content": "Hello", "weight": 2}]}}
         ),
-        "Invalid weight value",
         id="invalid_weight_value",
     ),
     pytest.param(
         "non_dict_message",
-        lambda item: item.update({"input": {"messages": ["Not a dictionary"]}}),  # type: ignore
-        "Non-dictionary message",
+        lambda item: item.update({"input": {"messages": ["Not a dictionary"]}}),  # type: ignore[arg-type]
         id="non_dict_message",
     ),
     pytest.param(
         "non_dict_input",
-        lambda item: item.update({"input": "Not a dictionary"}),  # type: ignore
-        "Non-dictionary input",
+        lambda item: item.update({"input": "Not a dictionary"}),  # type: ignore[arg-type]
         id="non_dict_input",
     ),
     pytest.param(
         "missing_messages_in_input",
-        lambda item: item.update({"input": {}}),  # type: ignore
-        "Missing messages in input",
+        lambda item: item.update({"input": {}}),  # type: ignore[arg-type]
         id="missing_messages_in_input",
     ),
     pytest.param(
         "non_assistant_role_in_preferred",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {"preferred_output": [{"role": "user", "content": "This should be assistant"}]}
         ),
-        "Non-assistant role in preferred output",
         id="non_assistant_role_in_preferred",
     ),
     pytest.param(
         "non_assistant_role_in_non_preferred",
-        lambda item: item.update(  # type: ignore
+        lambda item: item.update(  # type: ignore[arg-type]
             {"non_preferred_output": [{"role": "user", "content": "This should be assistant"}]}
         ),
-        "Non-assistant role in non-preferred output",
         id="non_assistant_role_in_non_preferred",
     ),
 ]
 
 
-@pytest.mark.parametrize("name, modifier")
+@pytest.mark.parametrize(("name", "modifier"), STRUCTURAL_ISSUE_TEST_CASES)
 def test_check_jsonl_invalid_preference_openai_structural_issues(
-    tmp_path: Path, name: ParameterSet, modifier: ParameterSet
+    tmp_path: Path,
+    name: str,
+    modifier: Callable[[dict[str, Any]], None],
 ):
     """Test various structural issues in OpenAI preference format."""
     file = tmp_path / f"invalid_preference_openai_{name}.jsonl"
     content = [item.copy() for item in _TEST_PREFERENCE_OPENAI_CONTENT]
 
     # Apply the modification to the first item
-    modifier(content[0])  # type: ignore
+    modifier(content[0])
 
     with file.open("w") as f:
         f.write("\n".join(json.dumps(item) for item in content))


### PR DESCRIPTION
## This PR

Fine-tuning JSONL checks now verify UTF-8, JSON-parseable non-empty lines, and one JSON object per line; sample count and size limits unchanged. Semantic validation remains on the server. Eval JSONL behavior is unchanged.

Remove unused client-side schema validators for messages and preference data. Update unit tests to expect structural pass-through for previously rejected cases.

## How to test

So these checks are all on backend and if the file validation fails, it will explicitly tell it on the Files API side