### PR TITLE
ENG-87659 - convert blobs to zstd from gzip before push

### DIFF
--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -667,16 +667,11 @@ class Jig:
         if builder:
             # Build via docker-container builder so `push` can output zstd from the buildkit cache.
             cmd = [
-                "docker",
-                "buildx",
-                "build",
-                "--builder",
-                builder,
-                "--platform",
-                "linux/amd64",
+                "docker", "buildx", "build",
+                "--builder", builder,
+                "--platform", "linux/amd64",
                 "--load",
-                "-t",
-                image,
+                "-t", image,
             ]
         else:
             cmd = ["docker", "build", "--platform", "linux/amd64", "-t", image]
@@ -706,17 +701,14 @@ class Jig:
         # Warmup bakes layers into the local daemon image, bypassing the buildx cache. Detect
         # that via the label stamped by _build_warm_image and push the daemon image directly
         # (gzip) in that case, since a buildx rebuild would produce the pre-warmup image.
-        builder = None if _image_is_warmed(image) else _ensure_zstd_builder()
+        warmed = _image_is_warmed(image)
+        builder = None if warmed else _ensure_zstd_builder()
         if builder:
             # Repackage cached layers from `build` as zstd in a single upload.
             cmd = [
-                "docker",
-                "buildx",
-                "build",
-                "--builder",
-                builder,
-                "--platform",
-                "linux/amd64",
+                "docker", "buildx", "build",
+                "--builder", builder,
+                "--platform", "linux/amd64",
                 "--push",
                 "--output",
                 f"type=image,name={image},compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true",
@@ -726,10 +718,13 @@ class Jig:
             cmd.append(".")
             ok = subprocess.run(cmd).returncode == 0
         else:
-            console.print(
-                "\N{WARNING SIGN} buildx not available; falling back to gzip push. "
-                "Install docker buildx for faster image pull times."
-            )
+            # Only warn when we genuinely fell back due to missing buildx — not when warmup
+            # or JIG_DISABLE_BUILDX deliberately routed us here.
+            if not warmed and not os.getenv("JIG_DISABLE_BUILDX"):
+                console.print(
+                    "\N{WARNING SIGN} buildx not available; falling back to gzip push. "
+                    "Install docker buildx for faster image pull times."
+                )
             ok = subprocess.run(["docker", "push", image]).returncode == 0
         if not ok:
             raise JigError("Push failed")
@@ -761,13 +756,9 @@ class Jig:
 
         console.print(f"Building and pushing {image}")
         cmd = [
-            "docker",
-            "buildx",
-            "build",
-            "--builder",
-            builder,
-            "--platform",
-            "linux/amd64",
+            "docker", "buildx", "build",
+            "--builder", builder,
+            "--platform", "linux/amd64",
             "--push",
             "--output",
             f"type=image,name={image},compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true",

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -679,6 +679,7 @@ class Jig:
                 "linux/amd64",
                 "--push",
                 "--output",
+                 "--metadata-file", f"{PATH}/{image}-metadata.json"
                 f"type=image,name={image},{BUILDX_OUTPUT_OPTS}",
             ]
             if self.config.image.dockerfile_path != "Dockerfile":

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -543,6 +543,17 @@ class Jig:
         image = self.image(tag)
         if tag != "latest":
             return image
+        registry = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", image],
+            capture_output=True,
+            text=True,
+        )
+        if registry.returncode == 0:
+            for line in registry.stdout.splitlines():
+                if line.startswith("Digest:"):
+                    sha = line.split(":", 1)[1].strip()
+                    if sha.startswith("sha256:"):
+                        return f"{image}@{sha}"
         daemon = subprocess.run(
             ["docker", "inspect", "--format={{json .RepoDigests}}", image],
             capture_output=True,
@@ -555,17 +566,6 @@ class Jig:
                         return str(digest)
             except (json.JSONDecodeError, TypeError):
                 pass
-        registry = subprocess.run(
-            ["docker", "buildx", "imagetools", "inspect", image],
-            capture_output=True,
-            text=True,
-        )
-        if registry.returncode == 0:
-            for line in registry.stdout.splitlines():
-                if line.startswith("Digest:"):
-                    sha = line.split(":", 1)[1].strip()
-                    if sha.startswith("sha256:"):
-                        return f"{image}@{sha}"
         raise JigError(f"No registry digest found for {image}. Make sure the image was pushed to registry first")
 
     def sync_secrets_from_deployment(self) -> None:

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -539,34 +539,31 @@ class Jig:
     def image(self, tag: str) -> str:
         return f"{self.registry()}{self.name}:{tag}"
 
+    def _metadata_path(self, tag: str) -> Path:
+        """Path for buildx --metadata-file output, used to recover the pushed digest cross-process."""
+        return self.config._path.parent / f".jig-{self.name}-{tag}.metadata.json"
+
     def image_with_digest(self, tag: str = "latest") -> str:
         image = self.image(tag)
-        if tag != "latest":
-            return image
-        registry = subprocess.run(
-            ["docker", "buildx", "imagetools", "inspect", image],
-            capture_output=True,
-            text=True,
-        )
-        if registry.returncode == 0:
-            for line in registry.stdout.splitlines():
-                if line.startswith("Digest:"):
-                    sha = line.split(":", 1)[1].strip()
-                    if sha.startswith("sha256:"):
-                        return f"{image}@{sha}"
-        daemon = subprocess.run(
+        try:
+            digest = json.loads(self._metadata_path(tag).read_text()).get("containerimage.digest")
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            digest = None
+        if digest:
+            return f"{image}@{digest}"
+        r = subprocess.run(
             ["docker", "inspect", "--format={{json .RepoDigests}}", image],
             capture_output=True,
             text=True,
         )
-        if daemon.returncode == 0 and (repo_digests := daemon.stdout.strip()) and repo_digests != "null":
+        if r.returncode == 0 and (repo_digests := r.stdout.strip()) and repo_digests != "null":
             try:
-                for digest in json.loads(repo_digests):
-                    if digest.startswith(self.registry()):
-                        return str(digest)
+                for d in json.loads(repo_digests):
+                    if d.startswith(self.registry()):
+                        return str(d)
             except (json.JSONDecodeError, TypeError):
                 pass
-        raise JigError(f"No registry digest found for {image}. Make sure the image was pushed to registry first")
+        raise JigError(f"Could not find digest for {image}. Build and push the image first.")
 
     def sync_secrets_from_deployment(self) -> None:
         """Sync remote secrets into local state if secrets have never been tracked.
@@ -626,8 +623,12 @@ class Jig:
             )
 
         console.print(f"Building {image}")
-        builder = None if warmup else _ensure_zstd_builder()
-        if builder:
+        if warmup or os.getenv("JIG_DISABLE_BUILDX"):
+            cmd = ["docker", "build", "--platform", "linux/amd64", "-t", image]
+        else:
+            builder = _ensure_zstd_builder()
+            if not builder:
+                raise JigError("`docker buildx` is required to build images.")
             cmd = [
                 "docker",
                 "buildx",
@@ -640,8 +641,6 @@ class Jig:
                 "-t",
                 image,
             ]
-        else:
-            cmd = ["docker", "build", "--platform", "linux/amd64", "-t", image]
         if self.config.image.dockerfile_path != "Dockerfile":
             cmd.extend(["-f", self.config.image.dockerfile_path])
 
@@ -665,10 +664,14 @@ class Jig:
             raise JigError("Registry login failed")
 
         console.print(f"Pushing {image}")
+        self._metadata_path(tag).unlink(missing_ok=True)
         # Skip buildx for warmup-baked images: a buildx rebuild would drop the warmup layer.
-        warmed = _image_is_warmed(image)
-        builder = None if warmed else _ensure_zstd_builder()
-        if builder:
+        if _image_is_warmed(image) or os.getenv("JIG_DISABLE_BUILDX"):
+            ok = subprocess.run(["docker", "push", image]).returncode == 0
+        else:
+            builder = _ensure_zstd_builder()
+            if not builder:
+                raise JigError("`docker buildx` is required to build images.")
             cmd = [
                 "docker",
                 "buildx",
@@ -679,20 +682,14 @@ class Jig:
                 "linux/amd64",
                 "--push",
                 "--output",
-                 "--metadata-file", f"{PATH}/{image}-metadata.json"
                 f"type=image,name={image},{BUILDX_OUTPUT_OPTS}",
+                "--metadata-file",
+                str(self._metadata_path(tag)),
             ]
             if self.config.image.dockerfile_path != "Dockerfile":
                 cmd.extend(["-f", self.config.image.dockerfile_path])
             cmd.append(".")
             ok = subprocess.run(cmd).returncode == 0
-        else:
-            if not warmed and not os.getenv("JIG_DISABLE_BUILDX"):
-                console.print(
-                    "\N{WARNING SIGN} buildx not available; falling back to gzip push. "
-                    "Install docker buildx for faster image pull times."
-                )
-            ok = subprocess.run(["docker", "push", image]).returncode == 0
         if not ok:
             raise JigError("Push failed")
         console.print("\N{CHECK MARK} Pushed")
@@ -702,14 +699,16 @@ class Jig:
 
         Used by deploy when warmup isn't requested: layers go from the buildkit cache
         straight to the registry as zstd, skipping the daemon-side export entirely.
-        Falls back to separate build + push when buildx isn't available.
+        Falls back to separate build + push when JIG_DISABLE_BUILDX is set.
         """
         image = self.image(tag)
-        builder = _ensure_zstd_builder()
-        if not builder:
+        if os.getenv("JIG_DISABLE_BUILDX"):
             self.build(tag, False, docker_args)
             self.push(tag)
             return
+        builder = _ensure_zstd_builder()
+        if not builder:
+            raise JigError("`docker buildx` is required to build images.")
 
         host = self.registry().split("/")[0]
         login_cmd = ["docker", "login", host, "--username", "user", "--password-stdin"]
@@ -722,6 +721,7 @@ class Jig:
             )
 
         console.print(f"Building and pushing {image}")
+        self._metadata_path(tag).unlink(missing_ok=True)
         cmd = [
             "docker",
             "buildx",
@@ -733,6 +733,8 @@ class Jig:
             "--push",
             "--output",
             f"type=image,name={image},{BUILDX_OUTPUT_OPTS}",
+            "--metadata-file",
+            str(self._metadata_path(tag)),
         ]
         if self.config.image.dockerfile_path != "Dockerfile":
             cmd.extend(["-f", self.config.image.dockerfile_path])

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -636,9 +636,12 @@ class Jig:
         has_buildx = subprocess.run(["docker", "buildx", "version"], capture_output=True).returncode == 0
         if has_buildx:
             cmd = [
-                "docker", "buildx", "build",
+                "docker",
+                "buildx",
+                "build",
                 "--push",
-                "--platform", "linux/amd64",
+                "--platform",
+                "linux/amd64",
                 "--output",
                 f"type=image,name={image},compression=zstd,force-compression=true,oci-mediatypes=true",
                 "-",

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -51,6 +51,7 @@ DEBUG = os.getenv("TOGETHER_DEBUG", "").strip()[:1] in ("y", "1", "t")
 
 WARMUP_ENV_NAME = os.getenv("WARMUP_ENV_NAME", "TORCHINDUCTOR_CACHE_DIR")
 WARMUP_DEST = os.getenv("WARMUP_DEST", "torch_cache")
+BUILDX_OUTPUT_OPTS = "compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true"
 
 _TRACK_POLL_INTERVAL = 3
 _TRACK_TIMEOUT = 600
@@ -488,38 +489,6 @@ LABEL jig.warmed=true"""
     console.print("\N{CHECK MARK} Final image with cache built")
 
 
-def _image_is_warmed(image: str) -> bool:
-    """True if the local daemon image carries the jig.warmed label set by _build_warm_image."""
-    r = subprocess.run(
-        ["docker", "image", "inspect", image, "--format", '{{index .Config.Labels "jig.warmed"}}'],
-        capture_output=True,
-        text=True,
-    )
-    return r.returncode == 0 and r.stdout.strip() == "true"
-
-
-def _ensure_zstd_builder(name: str = "jig-zstd") -> str | None:
-    """Return the name of a docker-container buildx builder, creating one if needed.
-
-    The default 'docker' buildx driver pushes through the docker daemon, which on
-    legacy (non-containerd) image stores silently downgrades zstd to gzip. A
-    docker-container builder has its own buildkit instance and honors zstd.
-    Returns None if buildx is unavailable or the builder cannot be created.
-    """
-    if os.getenv("JIG_DISABLE_BUILDX"):
-        return None
-    if subprocess.run(["docker", "buildx", "version"], capture_output=True).returncode != 0:
-        return None
-    ls = subprocess.run(["docker", "buildx", "ls"], capture_output=True, text=True)
-    if name in (ls.stdout or ""):
-        return name
-    create = subprocess.run(
-        ["docker", "buildx", "create", "--name", name, "--driver", "docker-container"],
-        capture_output=True,
-    )
-    return name if create.returncode == 0 else None
-
-
 # == Jig ==
 
 
@@ -574,7 +543,6 @@ class Jig:
         image = self.image(tag)
         if tag != "latest":
             return image
-        # Prefer the local daemon (cheap, no network) when the image is there.
         daemon = subprocess.run(
             ["docker", "inspect", "--format={{json .RepoDigests}}", image],
             capture_output=True,
@@ -587,8 +555,6 @@ class Jig:
                         return str(digest)
             except (json.JSONDecodeError, TypeError):
                 pass
-        # Fall back to a registry lookup. Used when deploy ran build_and_push, which skips
-        # --load, so the image isn't in the local daemon.
         registry = subprocess.run(
             ["docker", "buildx", "imagetools", "inspect", image],
             capture_output=True,
@@ -660,12 +626,8 @@ class Jig:
             )
 
         console.print(f"Building {image}")
-        # Skip buildx when warmup is requested: _build_warm_image rebuilds via plain `docker build`
-        # which doesn't populate the jig-zstd cache, and push() falls back to `docker push` anyway,
-        # so the buildkit cache work and the --load export would just be thrown away.
         builder = None if warmup else _ensure_zstd_builder()
         if builder:
-            # Build via docker-container builder so `push` can output zstd from the buildkit cache.
             cmd = [
                 "docker",
                 "buildx",
@@ -703,13 +665,10 @@ class Jig:
             raise JigError("Registry login failed")
 
         console.print(f"Pushing {image}")
-        # Warmup bakes layers into the local daemon image, bypassing the buildx cache. Detect
-        # that via the label stamped by _build_warm_image and push the daemon image directly
-        # (gzip) in that case, since a buildx rebuild would produce the pre-warmup image.
+        # Skip buildx for warmup-baked images: a buildx rebuild would drop the warmup layer.
         warmed = _image_is_warmed(image)
         builder = None if warmed else _ensure_zstd_builder()
         if builder:
-            # Repackage cached layers from `build` as zstd in a single upload.
             cmd = [
                 "docker",
                 "buildx",
@@ -720,15 +679,13 @@ class Jig:
                 "linux/amd64",
                 "--push",
                 "--output",
-                f"type=image,name={image},compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true",
+                f"type=image,name={image},{BUILDX_OUTPUT_OPTS}",
             ]
             if self.config.image.dockerfile_path != "Dockerfile":
                 cmd.extend(["-f", self.config.image.dockerfile_path])
             cmd.append(".")
             ok = subprocess.run(cmd).returncode == 0
         else:
-            # Only warn when we genuinely fell back due to missing buildx — not when warmup
-            # or JIG_DISABLE_BUILDX deliberately routed us here.
             if not warmed and not os.getenv("JIG_DISABLE_BUILDX"):
                 console.print(
                     "\N{WARNING SIGN} buildx not available; falling back to gzip push. "
@@ -774,7 +731,7 @@ class Jig:
             "linux/amd64",
             "--push",
             "--output",
-            f"type=image,name={image},compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true",
+            f"type=image,name={image},{BUILDX_OUTPUT_OPTS}",
         ]
         if self.config.image.dockerfile_path != "Dockerfile":
             cmd.extend(["-f", self.config.image.dockerfile_path])
@@ -801,8 +758,7 @@ class Jig:
             console.print(f"Deploying configured image {deployment_image}")
         else:
             if warmup:
-                # Warmup needs a local image to docker-run for cache generation, so keep the
-                # build (with --load) + push (gzip via daemon, since the warmup label is set) path.
+                # warmup needs the image locally, so we can't use buildx — fall back to the plain docker build + push path.
                 self.build(tag, True, docker_args)
                 self.push(tag)
             else:
@@ -1636,3 +1592,38 @@ def jig_volumes_delete_cli(
 ) -> None:
     """Delete a volume."""
     _run_jig_cmd(config, toml_config, lambda jig: volumes_delete(jig, name))
+
+
+# == Helpers ==
+
+
+def _image_is_warmed(image: str) -> bool:
+    """True if the local daemon image carries the jig.warmed label set by _build_warm_image."""
+    r = subprocess.run(
+        ["docker", "image", "inspect", image, "--format", '{{index .Config.Labels "jig.warmed"}}'],
+        capture_output=True,
+        text=True,
+    )
+    return r.returncode == 0 and r.stdout.strip() == "true"
+
+
+def _ensure_zstd_builder(name: str = "jig-zstd") -> str | None:
+    """Return the name of a docker-container buildx builder, creating one if needed.
+
+    The default 'docker' buildx driver pushes through the docker daemon, which on
+    legacy (non-containerd) image stores silently downgrades zstd to gzip. A
+    docker-container builder has its own buildkit instance and honors zstd.
+    Returns None if buildx is unavailable or the builder cannot be created.
+    """
+    if os.getenv("JIG_DISABLE_BUILDX"):
+        return None
+    if subprocess.run(["docker", "buildx", "version"], capture_output=True).returncode != 0:
+        return None
+    ls = subprocess.run(["docker", "buildx", "ls"], capture_output=True, text=True)
+    if name in (ls.stdout or ""):
+        return name
+    create = subprocess.run(
+        ["docker", "buildx", "create", "--name", name, "--driver", "docker-container"],
+        capture_output=True,
+    )
+    return name if create.returncode == 0 else None

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -667,11 +667,16 @@ class Jig:
         if builder:
             # Build via docker-container builder so `push` can output zstd from the buildkit cache.
             cmd = [
-                "docker", "buildx", "build",
-                "--builder", builder,
-                "--platform", "linux/amd64",
+                "docker",
+                "buildx",
+                "build",
+                "--builder",
+                builder,
+                "--platform",
+                "linux/amd64",
                 "--load",
-                "-t", image,
+                "-t",
+                image,
             ]
         else:
             cmd = ["docker", "build", "--platform", "linux/amd64", "-t", image]
@@ -706,9 +711,13 @@ class Jig:
         if builder:
             # Repackage cached layers from `build` as zstd in a single upload.
             cmd = [
-                "docker", "buildx", "build",
-                "--builder", builder,
-                "--platform", "linux/amd64",
+                "docker",
+                "buildx",
+                "build",
+                "--builder",
+                builder,
+                "--platform",
+                "linux/amd64",
                 "--push",
                 "--output",
                 f"type=image,name={image},compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true",
@@ -756,9 +765,13 @@ class Jig:
 
         console.print(f"Building and pushing {image}")
         cmd = [
-            "docker", "buildx", "build",
-            "--builder", builder,
-            "--platform", "linux/amd64",
+            "docker",
+            "buildx",
+            "build",
+            "--builder",
+            builder,
+            "--platform",
+            "linux/amd64",
             "--push",
             "--output",
             f"type=image,name={image},compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true",

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -477,7 +477,8 @@ def _build_warm_image(base_image: str) -> None:
     # generate cache dockerfile - copy cache to same location used during warmup
     final_dockerfile = f"""FROM {base_image}
 COPY {cache_dir.name} /app/{WARMUP_DEST}
-ENV {WARMUP_ENV_NAME}=/app/{WARMUP_DEST}"""
+ENV {WARMUP_ENV_NAME}=/app/{WARMUP_DEST}
+LABEL jig.warmed=true"""
 
     console.print("\N{FIRE} Building final image with cache...")
     final_cmd = ["docker", "build", "--platform", "linux/amd64", "-t", base_image, "-f", "-", "."]
@@ -485,6 +486,38 @@ ENV {WARMUP_ENV_NAME}=/app/{WARMUP_DEST}"""
     if subprocess.run(final_cmd, input=final_dockerfile, text=True).returncode != 0:
         raise JigError("\N{FIRE EXTINGUISHER} Cache image build failed")
     console.print("\N{CHECK MARK} Final image with cache built")
+
+
+def _image_is_warmed(image: str) -> bool:
+    """True if the local daemon image carries the jig.warmed label set by _build_warm_image."""
+    r = subprocess.run(
+        ["docker", "image", "inspect", image, "--format", '{{index .Config.Labels "jig.warmed"}}'],
+        capture_output=True,
+        text=True,
+    )
+    return r.returncode == 0 and r.stdout.strip() == "true"
+
+
+def _ensure_zstd_builder(name: str = "jig-zstd") -> str | None:
+    """Return the name of a docker-container buildx builder, creating one if needed.
+
+    The default 'docker' buildx driver pushes through the docker daemon, which on
+    legacy (non-containerd) image stores silently downgrades zstd to gzip. A
+    docker-container builder has its own buildkit instance and honors zstd.
+    Returns None if buildx is unavailable or the builder cannot be created.
+    """
+    if os.getenv("JIG_DISABLE_BUILDX"):
+        return None
+    if subprocess.run(["docker", "buildx", "version"], capture_output=True).returncode != 0:
+        return None
+    ls = subprocess.run(["docker", "buildx", "ls"], capture_output=True, text=True)
+    if name in (ls.stdout or ""):
+        return name
+    create = subprocess.run(
+        ["docker", "buildx", "create", "--name", name, "--driver", "docker-container"],
+        capture_output=True,
+    )
+    return name if create.returncode == 0 else None
 
 
 # == Jig ==
@@ -541,15 +574,32 @@ class Jig:
         image = self.image(tag)
         if tag != "latest":
             return image
-        try:
-            cmd = ["docker", "inspect", "--format={{json .RepoDigests}}", image]
-            if (repo_digests := _run(cmd).stdout.strip()) and repo_digests != "null":
+        # Prefer the local daemon (cheap, no network) when the image is there.
+        daemon = subprocess.run(
+            ["docker", "inspect", "--format={{json .RepoDigests}}", image],
+            capture_output=True,
+            text=True,
+        )
+        if daemon.returncode == 0 and (repo_digests := daemon.stdout.strip()) and repo_digests != "null":
+            try:
                 for digest in json.loads(repo_digests):
                     if digest.startswith(self.registry()):
                         return str(digest)
-        except subprocess.CalledProcessError as e:
-            msg = e.stderr.strip() if e.stderr else "Docker command failed"
-            raise JigError(f"Failed to get digest for {image}: {msg}") from e
+            except (json.JSONDecodeError, TypeError):
+                pass
+        # Fall back to a registry lookup. Used when deploy ran build_and_push, which skips
+        # --load, so the image isn't in the local daemon.
+        registry = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", image],
+            capture_output=True,
+            text=True,
+        )
+        if registry.returncode == 0:
+            for line in registry.stdout.splitlines():
+                if line.startswith("Digest:"):
+                    sha = line.split(":", 1)[1].strip()
+                    if sha.startswith("sha256:"):
+                        return f"{image}@{sha}"
         raise JigError(f"No registry digest found for {image}. Make sure the image was pushed to registry first")
 
     def sync_secrets_from_deployment(self) -> None:
@@ -610,13 +660,33 @@ class Jig:
             )
 
         console.print(f"Building {image}")
-        cmd = ["docker", "build", "--platform", "linux/amd64", "-t", image, "."]
+        # Skip buildx when warmup is requested: _build_warm_image rebuilds via plain `docker build`
+        # which doesn't populate the jig-zstd cache, and push() falls back to `docker push` anyway,
+        # so the buildkit cache work and the --load export would just be thrown away.
+        builder = None if warmup else _ensure_zstd_builder()
+        if builder:
+            # Build via docker-container builder so `push` can output zstd from the buildkit cache.
+            cmd = [
+                "docker",
+                "buildx",
+                "build",
+                "--builder",
+                builder,
+                "--platform",
+                "linux/amd64",
+                "--load",
+                "-t",
+                image,
+            ]
+        else:
+            cmd = ["docker", "build", "--platform", "linux/amd64", "-t", image]
         if self.config.image.dockerfile_path != "Dockerfile":
             cmd.extend(["-f", self.config.image.dockerfile_path])
 
         extra_args = docker_args or os.getenv("DOCKER_BUILD_EXTRA_ARGS", "")
         if extra_args:
             cmd.extend(shlex.split(extra_args))
+        cmd.append(".")
         if subprocess.run(cmd).returncode != 0:
             raise JigError("Build failed")
 
@@ -633,20 +703,28 @@ class Jig:
             raise JigError("Registry login failed")
 
         console.print(f"Pushing {image}")
-        has_buildx = subprocess.run(["docker", "buildx", "version"], capture_output=True).returncode == 0
-        if has_buildx:
+        # Warmup bakes layers into the local daemon image, bypassing the buildx cache. Detect
+        # that via the label stamped by _build_warm_image and push the daemon image directly
+        # (gzip) in that case, since a buildx rebuild would produce the pre-warmup image.
+        builder = None if _image_is_warmed(image) else _ensure_zstd_builder()
+        if builder:
+            # Repackage cached layers from `build` as zstd in a single upload.
             cmd = [
                 "docker",
                 "buildx",
                 "build",
-                "--push",
+                "--builder",
+                builder,
                 "--platform",
                 "linux/amd64",
+                "--push",
                 "--output",
-                f"type=image,name={image},compression=zstd,force-compression=true,oci-mediatypes=true",
-                "-",
+                f"type=image,name={image},compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true",
             ]
-            ok = subprocess.run(cmd, input=f"FROM {image}\n", text=True).returncode == 0
+            if self.config.image.dockerfile_path != "Dockerfile":
+                cmd.extend(["-f", self.config.image.dockerfile_path])
+            cmd.append(".")
+            ok = subprocess.run(cmd).returncode == 0
         else:
             console.print(
                 "\N{WARNING SIGN} buildx not available; falling back to gzip push. "
@@ -656,6 +734,53 @@ class Jig:
         if not ok:
             raise JigError("Push failed")
         console.print("\N{CHECK MARK} Pushed")
+
+    def build_and_push(self, tag: str = "latest", docker_args: str | None = None) -> None:
+        """One-shot build + push via a single buildx invocation (no --load).
+
+        Used by deploy when warmup isn't requested: layers go from the buildkit cache
+        straight to the registry as zstd, skipping the daemon-side export entirely.
+        Falls back to separate build + push when buildx isn't available.
+        """
+        image = self.image(tag)
+        builder = _ensure_zstd_builder()
+        if not builder:
+            self.build(tag, False, docker_args)
+            self.push(tag)
+            return
+
+        host = self.registry().split("/")[0]
+        login_cmd = ["docker", "login", host, "--username", "user", "--password-stdin"]
+        if subprocess.run(login_cmd, input=self.together.api_key, text=True).returncode != 0:
+            raise JigError("Registry login failed")
+
+        if not _dockerfile(self.config):
+            console.print(
+                f"\N{INFORMATION SOURCE} Using existing {self.config.image.dockerfile_path} (not managed by jig)"
+            )
+
+        console.print(f"Building and pushing {image}")
+        cmd = [
+            "docker",
+            "buildx",
+            "build",
+            "--builder",
+            builder,
+            "--platform",
+            "linux/amd64",
+            "--push",
+            "--output",
+            f"type=image,name={image},compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true",
+        ]
+        if self.config.image.dockerfile_path != "Dockerfile":
+            cmd.extend(["-f", self.config.image.dockerfile_path])
+        extra_args = docker_args or os.getenv("DOCKER_BUILD_EXTRA_ARGS", "")
+        if extra_args:
+            cmd.extend(shlex.split(extra_args))
+        cmd.append(".")
+        if subprocess.run(cmd).returncode != 0:
+            raise JigError("Build+push failed")
+        console.print("\N{CHECK MARK} Built and pushed")
 
     def deploy(
         self,
@@ -671,8 +796,13 @@ class Jig:
         elif deployment_image := self.config.deploy.image:
             console.print(f"Deploying configured image {deployment_image}")
         else:
-            self.build(tag, warmup, docker_args)
-            self.push(tag)
+            if warmup:
+                # Warmup needs a local image to docker-run for cache generation, so keep the
+                # build (with --load) + push (gzip via daemon, since the warmup label is set) path.
+                self.build(tag, True, docker_args)
+                self.push(tag)
+            else:
+                self.build_and_push(tag, docker_args)
             deployment_image = self.image_with_digest(tag)
 
         if build_only:

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -633,7 +633,24 @@ class Jig:
             raise JigError("Registry login failed")
 
         console.print(f"Pushing {image}")
-        if subprocess.run(["docker", "push", image]).returncode != 0:
+        has_buildx = subprocess.run(["docker", "buildx", "version"], capture_output=True).returncode == 0
+        if has_buildx:
+            cmd = [
+                "docker", "buildx", "build",
+                "--push",
+                "--platform", "linux/amd64",
+                "--output",
+                f"type=image,name={image},compression=zstd,force-compression=true,oci-mediatypes=true",
+                "-",
+            ]
+            ok = subprocess.run(cmd, input=f"FROM {image}\n", text=True).returncode == 0
+        else:
+            console.print(
+                "\N{WARNING SIGN} buildx not available; falling back to gzip push. "
+                "Install docker buildx for faster image pull times."
+            )
+            ok = subprocess.run(["docker", "push", image]).returncode == 0
+        if not ok:
             raise JigError("Push failed")
         console.print("\N{CHECK MARK} Pushed")
 


### PR DESCRIPTION
10% to 35% pull time improvement on some images, depending on cluster(how good network is).

What changed:
- if `buildx` is available create a buildkit builder
- `jig build` builds the image with zstd compression instead of default gzip
- `jig push` pushes the image that was built with the the buildkit
- `jig deploy` builds the image with buildx and directly pushes to registry(won't be locally available if not pulled)
- `--warmup` flag makes builds fallback to default gzip build(it is possible to make it work with buildx but that's future work if we want to make it nicely)
