### PR TITLE
feat(cli): add `get` as alias for `retrieve` subcommands

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -340,7 +340,7 @@ files_app.command(
     help_epilogue=FILES_UPLOAD_HELP_EXAMPLES,
 )
 files_app.command(f"{_CLI}.files.list:list", alias="ls", help="List your files")
-files_app.command(f"{_CLI}.files.retrieve:retrieve", help="Get file details")
+files_app.command(f"{_CLI}.files.retrieve:retrieve", alias="get", help="Get file details")
 files_app.command(f"{_CLI}.files.retrieve_content:retrieve_content", help="Download file contents", show=False)
 files_app.command(
     f"{_CLI}.files.retrieve_content:retrieve_content",
@@ -367,7 +367,7 @@ fine_tuning_app.command(
     help_epilogue=FINE_TUNING_CREATE_HELP_EXAMPLES,
 )
 fine_tuning_app.command((f"{_CLI}.fine_tuning.list:list"), alias="ls", help="List fine-tuning jobs")
-fine_tuning_app.command((f"{_CLI}.fine_tuning.retrieve:retrieve"), help="Get fine-tuning job details")
+fine_tuning_app.command((f"{_CLI}.fine_tuning.retrieve:retrieve"), alias="get", help="Get fine-tuning job details")
 fine_tuning_app.command((f"{_CLI}.fine_tuning.cancel:cancel"), help="Cancel a fine-tuning job")
 fine_tuning_app.command((f"{_CLI}.fine_tuning.list_events:list_events"), help="List events for a fine-tuning job")
 fine_tuning_app.command(
@@ -399,7 +399,7 @@ endpoints_app.command(
     help="Create a new endpoint",
     help_epilogue=ENDPOINTS_CREATE_HELP_EXAMPLES,
 )
-endpoints_app.command((f"{_CLI}.endpoints.retrieve:retrieve"), help="Get endpoint details")
+endpoints_app.command((f"{_CLI}.endpoints.retrieve:retrieve"), alias="get", help="Get endpoint details")
 endpoints_app.command((f"{_CLI}.endpoints.stop:stop"), help="Stop an endpoint")
 endpoints_app.command((f"{_CLI}.endpoints.start:start"), help="Start an endpoint")
 endpoints_app.command((f"{_CLI}.endpoints.delete:delete"), alias="-d", help="Delete an endpoint")
@@ -418,7 +418,7 @@ evals_app.command(
     (f"{_CLI}.evals.create:create"), alias="-c", help="Create a new eval job", help_epilogue=EVALS_CREATE_HELP_EXAMPLES
 )
 evals_app.command((f"{_CLI}.evals.list:list"), alias="ls", help="List eval jobs")
-evals_app.command((f"{_CLI}.evals.retrieve:retrieve"), help="Get eval job details")
+evals_app.command((f"{_CLI}.evals.retrieve:retrieve"), alias="get", help="Get eval job details")
 evals_app.command((f"{_CLI}.evals.status:status"), help="Get an eval job's status")
 
 ## Telemetry API commands
@@ -444,7 +444,7 @@ clusters_app.command(
     help="Create a new cluster",
     help_epilogue=BETA_CLUSTERS_CREATE_HELP_EXAMPLES,
 )
-clusters_app.command((f"{_CLI}.beta.clusters.retrieve:retrieve"), help="Get cluster details")
+clusters_app.command((f"{_CLI}.beta.clusters.retrieve:retrieve"), alias="get", help="Get cluster details")
 clusters_app.command(
     (f"{_CLI}.beta.clusters.update:update"),
     help="Update a cluster",
@@ -481,6 +481,7 @@ storage_app.command(
 )
 storage_app.command(
     (f"{_CLI}.beta.clusters.storage.retrieve:retrieve"),
+    alias="get",
     help="Get storage volume details",
 )
 storage_app.command((f"{_CLI}.beta.clusters.storage.delete:delete"), help="Delete a storage volume", alias="-d")
@@ -587,7 +588,7 @@ storage_app.command(
 storage_app.command((f"{_CLI}.beta.jig.jig:jig_volumes_delete_cli"), name="delete", help="Delete a volume", alias="-d")
 storage_app.command(
     (f"{_CLI}.beta.jig.jig:jig_volumes_describe"),
-    alias="retrieve",
+    alias=("retrieve", "get"),
     name="describe",
     help="Get volume details",
 )

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -75,6 +75,7 @@ def _canonical_telemetry_command(cmd: str) -> str:
     parts = ["list" if p == "ls" else p for p in parts]
     parts = ["delete" if p == "-d" else p for p in parts]
     parts = ["create" if p == "-c" else p for p in parts]
+    parts = ["retrieve" if p == "get" else p for p in parts]
     return " ".join(parts)
 
 
@@ -88,6 +89,7 @@ def preparse_tokens(app: App, tokens: list[str]) -> tuple[str, list[str], bool, 
     The ``list`` alias ``ls`` is normalized to ``list`` in the returned command path.
     The ``delete`` alias ``-d`` is normalized to ``delete`` in the returned command path.
     The ``create`` alias ``-c`` is normalized to ``create`` in the returned command path.
+    The ``retrieve`` alias ``get`` is normalized to ``retrieve`` in the returned command path.
     Implicit ``retrieve`` for most commands is applied here so telemetry matches execution.
 
     Requires the root cyclopts :class:`~cyclopts.App` so positional values are not mistaken

--- a/tests/cli/test_files.py
+++ b/tests/cli/test_files.py
@@ -125,6 +125,13 @@ class TestFilesRetrieve:
         assert "newer.jsonl" in result.output
         assert "fine-tune" in result.output
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_get_alias(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/files/file-meta").mock(return_value=httpx.Response(200, json=FILE_ROW_NEWER))
+        result = cli_runner.invoke(["files", "get", "file-meta"])
+        assert result.exit_code == 0
+        assert "newer.jsonl" in result.output
+
 
 class TestFilesRetrieveContent:
     def test_retrieve_content_no_options(self, cli_runner: CliRunner) -> None:

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -249,6 +249,16 @@ def test_parse_command_and_flags_normalizes_ls_alias_to_list() -> None:
     assert is_beta is False
 
 
+def test_parse_command_and_flags_normalizes_get_alias_to_retrieve() -> None:
+    from together.lib.cli import app
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
+
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["files", "get", "file-meta"])
+    assert cmd == "files retrieve"
+    assert "id" in flags
+    assert is_beta is False
+
+
 def test_parse_command_and_flags_normalizes_minus_d_alias_to_delete() -> None:
     from together.lib.cli import app
     from together.lib.cli.utils._preparse_tokens import preparse_tokens


### PR DESCRIPTION
A top error we see is: `UnknownCommandError Unknown command "get".`

This adds an alias to improve agentic usages.