### PR TITLE
MOSH-2469: Add adapter management to endpoints SDK and CLI

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -420,6 +420,12 @@ endpoints_app.command(
     help="List availability zones for deploying models",
 )
 
+### Adapters subcommands
+adapters_app = endpoints_app.command(App(name="adapters", help="Manage LoRA adapters on dedicated endpoints"))
+adapters_app.command((f"{_CLI}.endpoints.adapters.add:add"), help="Add a LoRA adapter to an endpoint")
+adapters_app.command((f"{_CLI}.endpoints.adapters.list:list"), alias="ls", help="List bound adapters")
+adapters_app.command((f"{_CLI}.endpoints.adapters.remove:remove"), help="Remove a LoRA adapter from an endpoint")
+
 ## Evals API commands
 evals_app = app.command(App(name="evals", help="Run and manage model evaluations", help_epilogue=EVALS_HELP_EXAMPLES))
 evals_app.command(

--- a/src/together/lib/cli/api/endpoints/adapters/add.py
+++ b/src/together/lib/cli/api/endpoints/adapters/add.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from cyclopts import Parameter
+
+from together._utils._json import openapi_dumps
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.api.endpoints._utils import handle_endpoint_api_errors
+
+BaseModelParameter = Annotated[str, Parameter(help="The dedicated endpoint name serving the base model")]
+AdapterNameParameter = Annotated[str, Parameter(help="The LoRA adapter model name to add")]
+
+
+@handle_endpoint_api_errors("Adapters")
+async def add(
+    base_model: BaseModelParameter,
+    adapter_name: AdapterNameParameter,
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """Add a LoRA adapter to a dedicated endpoint."""
+    response = await show_loading_status(
+        "Adding adapter...",
+        config.client.endpoints.set_lora_adapter(
+            base_model=base_model,
+            adapter_name=adapter_name,
+        ),
+    )
+
+    if config.json:
+        console.print_json(openapi_dumps(response).decode("utf-8"))
+        return
+
+    console.print("[green]√[/green] Adapter added to endpoint")
+    console.print(f"[dim][primary]Endpoint:[/primary][/dim]\t{base_model}")
+    console.print(f"[dim][primary]Adapter:[/primary][/dim]\t{adapter_name}")

--- a/src/together/lib/cli/api/endpoints/adapters/add.py
+++ b/src/together/lib/cli/api/endpoints/adapters/add.py
@@ -10,23 +10,23 @@ from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
 from together.lib.cli.api.endpoints._utils import handle_endpoint_api_errors
 
-BaseModelParameter = Annotated[str, Parameter(help="The dedicated endpoint name serving the base model")]
-AdapterNameParameter = Annotated[str, Parameter(help="The LoRA adapter model name to add")]
+EndpointIDParameter = Annotated[str, Parameter(help="The dedicated endpoint ID")]
+ModelIDParameter = Annotated[str, Parameter(help="Model ID in endpoint_name:adapter_name format")]
 
 
 @handle_endpoint_api_errors("Adapters")
 async def add(
-    base_model: BaseModelParameter,
-    adapter_name: AdapterNameParameter,
+    endpoint_id: EndpointIDParameter,
+    model_id: ModelIDParameter,
     *,
     config: CLIConfigParameter,
 ) -> None:
     """Add a LoRA adapter to a dedicated endpoint."""
     response = await show_loading_status(
         "Adding adapter...",
-        config.client.endpoints.set_lora_adapter(
-            base_model=base_model,
-            adapter_name=adapter_name,
+        config.client.endpoints.add_adapter(
+            endpoint_id=endpoint_id,
+            model_id=model_id,
         ),
     )
 
@@ -35,5 +35,5 @@ async def add(
         return
 
     console.print("[green]√[/green] Adapter added to endpoint")
-    console.print(f"[dim][primary]Endpoint:[/primary][/dim]\t{base_model}")
-    console.print(f"[dim][primary]Adapter:[/primary][/dim]\t{adapter_name}")
+    console.print(f"[dim][primary]Endpoint:[/primary][/dim]\t{endpoint_id}")
+    console.print(f"[dim][primary]Model ID:[/primary][/dim]\t{model_id}")

--- a/src/together/lib/cli/api/endpoints/adapters/list.py
+++ b/src/together/lib/cli/api/endpoints/adapters/list.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from together._utils._json import openapi_dumps
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+from together.lib.cli.components.list import ListTable
+from together.lib.cli.api.endpoints._utils import handle_endpoint_api_errors
+
+
+@handle_endpoint_api_errors("Adapters")
+async def list(
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """List all LoRA adapters bound to endpoints."""
+    response = await config.client.endpoints.list_adapters()
+
+    bindings = response.get("data", []) if isinstance(response, dict) else []
+
+    if config.json:
+        console.print_json(openapi_dumps(response).decode("utf-8"))
+        return
+
+    EMPTY_MESSAGE = "No adapters are bound to any endpoints.\nTo bind an adapter run:\n  [dim]-[/dim] [primary]tg endpoints adapters add BASE_MODEL ADAPTER_NAME[/primary]"
+    table = ListTable("Adapters", empty_message=EMPTY_MESSAGE)
+    table.add_primary_column("Adapter")
+    table.add_column("Endpoint", ratio=2)
+
+    for binding in bindings:
+        table.add_row(binding.get("adapter_name", ""), binding.get("endpoint_name", ""))
+
+    console.print(table)

--- a/src/together/lib/cli/api/endpoints/adapters/list.py
+++ b/src/together/lib/cli/api/endpoints/adapters/list.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
 
+from typing import Annotated
+
+from cyclopts import Parameter
+
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.list import ListTable
 from together.lib.cli.api.endpoints._utils import handle_endpoint_api_errors
 
+EndpointIDParameter = Annotated[str, Parameter(help="The dedicated endpoint ID")]
+
 
 @handle_endpoint_api_errors("Adapters")
 async def list(
+    endpoint_id: EndpointIDParameter,
     *,
     config: CLIConfigParameter,
 ) -> None:
-    """List all LoRA adapters bound to endpoints."""
-    response = await config.client.endpoints.list_adapters()
+    """List LoRA adapters bound to a dedicated endpoint."""
+    response = await config.client.endpoints.list_adapters(endpoint_id=endpoint_id)
 
     bindings = response.get("data", []) if isinstance(response, dict) else []
 
@@ -21,7 +28,7 @@ async def list(
         console.print_json(openapi_dumps(response).decode("utf-8"))
         return
 
-    EMPTY_MESSAGE = "No adapters are bound to any endpoints.\nTo bind an adapter run:\n  [dim]-[/dim] [primary]tg endpoints adapters add BASE_MODEL ADAPTER_NAME[/primary]"
+    EMPTY_MESSAGE = "No adapters are bound to this endpoint.\nTo add an adapter run:\n  [dim]-[/dim] [primary]tg endpoints adapters add ENDPOINT_ID MODEL_ID[/primary]"
     table = ListTable("Adapters", empty_message=EMPTY_MESSAGE)
     table.add_primary_column("Adapter")
     table.add_column("Endpoint", ratio=2)

--- a/src/together/lib/cli/api/endpoints/adapters/remove.py
+++ b/src/together/lib/cli/api/endpoints/adapters/remove.py
@@ -10,23 +10,23 @@ from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
 from together.lib.cli.api.endpoints._utils import handle_endpoint_api_errors
 
-BaseModelParameter = Annotated[str, Parameter(help="The dedicated endpoint name")]
-AdapterNameParameter = Annotated[str, Parameter(help="The LoRA adapter model name to remove")]
+EndpointIDParameter = Annotated[str, Parameter(help="The dedicated endpoint ID")]
+ModelIDParameter = Annotated[str, Parameter(help="Model ID in endpoint_name:adapter_name format")]
 
 
 @handle_endpoint_api_errors("Adapters")
 async def remove(
-    base_model: BaseModelParameter,
-    adapter_name: AdapterNameParameter,
+    endpoint_id: EndpointIDParameter,
+    model_id: ModelIDParameter,
     *,
     config: CLIConfigParameter,
 ) -> None:
     """Remove a LoRA adapter from a dedicated endpoint."""
     response = await show_loading_status(
         "Removing adapter...",
-        config.client.endpoints.delete_adapter(
-            base_model=base_model,
-            adapter_name=adapter_name,
+        config.client.endpoints.remove_adapter(
+            endpoint_id=endpoint_id,
+            model_id=model_id,
         ),
     )
 

--- a/src/together/lib/cli/api/endpoints/adapters/remove.py
+++ b/src/together/lib/cli/api/endpoints/adapters/remove.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from cyclopts import Parameter
+
+from together._utils._json import openapi_dumps
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.api.endpoints._utils import handle_endpoint_api_errors
+
+BaseModelParameter = Annotated[str, Parameter(help="The dedicated endpoint name")]
+AdapterNameParameter = Annotated[str, Parameter(help="The LoRA adapter model name to remove")]
+
+
+@handle_endpoint_api_errors("Adapters")
+async def remove(
+    base_model: BaseModelParameter,
+    adapter_name: AdapterNameParameter,
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """Remove a LoRA adapter from a dedicated endpoint."""
+    response = await show_loading_status(
+        "Removing adapter...",
+        config.client.endpoints.delete_adapter(
+            base_model=base_model,
+            adapter_name=adapter_name,
+        ),
+    )
+
+    if config.json:
+        console.print_json(openapi_dumps(response).decode("utf-8"))
+        return
+
+    console.print("[green]√[/green] Adapter removed from endpoint")

--- a/src/together/resources/endpoints.py
+++ b/src/together/resources/endpoints.py
@@ -373,7 +373,6 @@ class EndpointsResource(SyncAPIResource):
             cast_to=EndpointListHardwareResponse,
         )
 
-
     def set_lora_adapter(
         self,
         *,

--- a/src/together/resources/endpoints.py
+++ b/src/together/resources/endpoints.py
@@ -406,8 +406,7 @@ class EndpointsResource(SyncAPIResource):
             "/v1/endpoints/lora-adapter",
             body=maybe_transform(
                 {
-                    "base_model": base_model,
-                    "adapter_name": adapter_name,
+                    "model_name": f"{base_model}:{adapter_name}",
                 },
                 dict,
             ),
@@ -795,8 +794,7 @@ class AsyncEndpointsResource(AsyncAPIResource):
             "/v1/endpoints/lora-adapter",
             body=await async_maybe_transform(
                 {
-                    "base_model": base_model,
-                    "adapter_name": adapter_name,
+                    "model_name": f"{base_model}:{adapter_name}",
                 },
                 dict,
             ),

--- a/src/together/resources/endpoints.py
+++ b/src/together/resources/endpoints.py
@@ -374,6 +374,54 @@ class EndpointsResource(SyncAPIResource):
         )
 
 
+    def set_lora_adapter(
+        self,
+        *,
+        adapter_model_name: str,
+        endpoint_name: str,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> object:
+        """Points a LoRA adapter model to a dedicated endpoint.
+
+        After this call, inference requests to the adapter model name will be
+        routed to the specified endpoint.
+
+        Args:
+          adapter_model_name: The LoRA adapter model name (model_output_name from the FT job).
+
+          endpoint_name: The dedicated endpoint name to route adapter inference to.
+              Must be a private dedicated endpoint with LoRA support.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        return self._post(
+            "/v1/endpoints/lora-adapter",
+            body=maybe_transform(
+                {
+                    "adapter_model_name": adapter_model_name,
+                    "endpoint_name": endpoint_name,
+                },
+                dict,
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+            ),
+            cast_to=object,
+        )
+
+
 class AsyncEndpointsResource(AsyncAPIResource):
     @cached_property
     def with_raw_response(self) -> AsyncEndpointsResourceWithRawResponse:
@@ -714,6 +762,53 @@ class AsyncEndpointsResource(AsyncAPIResource):
                 ),
             ),
             cast_to=EndpointListHardwareResponse,
+        )
+
+    async def set_lora_adapter(
+        self,
+        *,
+        adapter_model_name: str,
+        endpoint_name: str,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> object:
+        """Points a LoRA adapter model to a dedicated endpoint.
+
+        After this call, inference requests to the adapter model name will be
+        routed to the specified endpoint.
+
+        Args:
+          adapter_model_name: The LoRA adapter model name (model_output_name from the FT job).
+
+          endpoint_name: The dedicated endpoint name to route adapter inference to.
+              Must be a private dedicated endpoint with LoRA support.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        return await self._post(
+            "/v1/endpoints/lora-adapter",
+            body=await async_maybe_transform(
+                {
+                    "adapter_model_name": adapter_model_name,
+                    "endpoint_name": endpoint_name,
+                },
+                dict,
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+            ),
+            cast_to=object,
         )
 
 

--- a/src/together/resources/endpoints.py
+++ b/src/together/resources/endpoints.py
@@ -373,25 +373,25 @@ class EndpointsResource(SyncAPIResource):
             cast_to=EndpointListHardwareResponse,
         )
 
-    def set_lora_adapter(
+    def add_adapter(
         self,
         *,
-        base_model: str,
-        adapter_name: str,
+        endpoint_id: str,
+        model_id: str,
         extra_headers: Headers | None = None,
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> object:
-        """Points a LoRA adapter model to a dedicated endpoint.
+        """Adds a LoRA adapter to a dedicated endpoint.
 
-        After this call, inference requests to ``base_model:adapter_name``
+        After this call, inference requests to the adapter model name
         will be routed to the specified endpoint.
 
         Args:
-          base_model: The dedicated endpoint name that serves the base model with LoRA support.
+          endpoint_id: The dedicated endpoint ID.
 
-          adapter_name: The LoRA adapter model name (e.g. "user/my-adapter").
+          model_id: Combined identifier in "endpoint_name:adapter_name" format.
 
           extra_headers: Send extra headers
 
@@ -402,11 +402,9 @@ class EndpointsResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         return self._post(
-            "/v1/endpoints/adapters",
+            f"/v1/endpoints/{endpoint_id}/adapters",
             body=maybe_transform(
-                {
-                    "model_id": f"{base_model}:{adapter_name}",
-                },
+                {"model_id": model_id},
                 dict,
             ),
             options=make_request_options(
@@ -421,18 +419,19 @@ class EndpointsResource(SyncAPIResource):
     def list_adapters(
         self,
         *,
+        endpoint_id: str,
         extra_headers: Headers | None = None,
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> object:
-        """Lists all LoRA adapters bound to dedicated endpoints.
+        """Lists LoRA adapters bound to a dedicated endpoint.
 
-        Returns adapters with their model_id (endpoint:adapter format),
-        adapter_name, and endpoint_name.
+        Args:
+          endpoint_id: The dedicated endpoint ID.
         """
         return self._get(
-            "/v1/endpoints/adapters",
+            f"/v1/endpoints/{endpoint_id}/adapters",
             options=make_request_options(
                 extra_headers=extra_headers,
                 extra_query=extra_query,
@@ -442,29 +441,27 @@ class EndpointsResource(SyncAPIResource):
             cast_to=object,
         )
 
-    def delete_adapter(
+    def remove_adapter(
         self,
         *,
-        base_model: str,
-        adapter_name: str,
+        endpoint_id: str,
+        model_id: str,
         extra_headers: Headers | None = None,
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> object:
-        """Unbinds a LoRA adapter from its dedicated endpoint.
+        """Removes a LoRA adapter from a dedicated endpoint.
 
         Args:
-          base_model: The dedicated endpoint name.
+          endpoint_id: The dedicated endpoint ID.
 
-          adapter_name: The LoRA adapter model name.
+          model_id: Combined identifier in "endpoint_name:adapter_name" format.
         """
         return self._delete(
-            "/v1/endpoints/adapters",
+            f"/v1/endpoints/{endpoint_id}/adapters",
             body=maybe_transform(
-                {
-                    "model_id": f"{base_model}:{adapter_name}",
-                },
+                {"model_id": model_id},
                 dict,
             ),
             options=make_request_options(
@@ -819,40 +816,27 @@ class AsyncEndpointsResource(AsyncAPIResource):
             cast_to=EndpointListHardwareResponse,
         )
 
-    async def set_lora_adapter(
+    async def add_adapter(
         self,
         *,
-        base_model: str,
-        adapter_name: str,
+        endpoint_id: str,
+        model_id: str,
         extra_headers: Headers | None = None,
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> object:
-        """Points a LoRA adapter model to a dedicated endpoint.
-
-        After this call, inference requests to ``base_model:adapter_name``
-        will be routed to the specified endpoint.
+        """Adds a LoRA adapter to a dedicated endpoint.
 
         Args:
-          base_model: The dedicated endpoint name that serves the base model with LoRA support.
+          endpoint_id: The dedicated endpoint ID.
 
-          adapter_name: The LoRA adapter model name (e.g. "user/my-adapter").
-
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
+          model_id: Combined identifier in "endpoint_name:adapter_name" format.
         """
         return await self._post(
-            "/v1/endpoints/adapters",
+            f"/v1/endpoints/{endpoint_id}/adapters",
             body=await async_maybe_transform(
-                {
-                    "model_id": f"{base_model}:{adapter_name}",
-                },
+                {"model_id": model_id},
                 dict,
             ),
             options=make_request_options(
@@ -867,14 +851,15 @@ class AsyncEndpointsResource(AsyncAPIResource):
     async def list_adapters(
         self,
         *,
+        endpoint_id: str,
         extra_headers: Headers | None = None,
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> object:
-        """Lists all LoRA adapters bound to dedicated endpoints."""
+        """Lists LoRA adapters bound to a dedicated endpoint."""
         return await self._get(
-            "/v1/endpoints/adapters",
+            f"/v1/endpoints/{endpoint_id}/adapters",
             options=make_request_options(
                 extra_headers=extra_headers,
                 extra_query=extra_query,
@@ -884,23 +869,21 @@ class AsyncEndpointsResource(AsyncAPIResource):
             cast_to=object,
         )
 
-    async def delete_adapter(
+    async def remove_adapter(
         self,
         *,
-        base_model: str,
-        adapter_name: str,
+        endpoint_id: str,
+        model_id: str,
         extra_headers: Headers | None = None,
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> object:
-        """Unbinds a LoRA adapter from its dedicated endpoint."""
+        """Removes a LoRA adapter from a dedicated endpoint."""
         return await self._delete(
-            "/v1/endpoints/adapters",
+            f"/v1/endpoints/{endpoint_id}/adapters",
             body=await async_maybe_transform(
-                {
-                    "model_id": f"{base_model}:{adapter_name}",
-                },
+                {"model_id": model_id},
                 dict,
             ),
             options=make_request_options(

--- a/src/together/resources/endpoints.py
+++ b/src/together/resources/endpoints.py
@@ -377,8 +377,8 @@ class EndpointsResource(SyncAPIResource):
     def set_lora_adapter(
         self,
         *,
-        adapter_model_name: str,
-        endpoint_name: str,
+        base_model: str,
+        adapter_name: str,
         extra_headers: Headers | None = None,
         extra_query: Query | None = None,
         extra_body: Body | None = None,
@@ -386,14 +386,13 @@ class EndpointsResource(SyncAPIResource):
     ) -> object:
         """Points a LoRA adapter model to a dedicated endpoint.
 
-        After this call, inference requests to the adapter model name will be
-        routed to the specified endpoint.
+        After this call, inference requests to ``base_model:adapter_name``
+        will be routed to the specified endpoint.
 
         Args:
-          adapter_model_name: The LoRA adapter model name (model_output_name from the FT job).
+          base_model: The dedicated endpoint name that serves the base model with LoRA support.
 
-          endpoint_name: The dedicated endpoint name to route adapter inference to.
-              Must be a private dedicated endpoint with LoRA support.
+          adapter_name: The LoRA adapter model name (e.g. "user/my-adapter").
 
           extra_headers: Send extra headers
 
@@ -407,8 +406,8 @@ class EndpointsResource(SyncAPIResource):
             "/v1/endpoints/lora-adapter",
             body=maybe_transform(
                 {
-                    "adapter_model_name": adapter_model_name,
-                    "endpoint_name": endpoint_name,
+                    "base_model": base_model,
+                    "adapter_name": adapter_name,
                 },
                 dict,
             ),
@@ -767,8 +766,8 @@ class AsyncEndpointsResource(AsyncAPIResource):
     async def set_lora_adapter(
         self,
         *,
-        adapter_model_name: str,
-        endpoint_name: str,
+        base_model: str,
+        adapter_name: str,
         extra_headers: Headers | None = None,
         extra_query: Query | None = None,
         extra_body: Body | None = None,
@@ -776,14 +775,13 @@ class AsyncEndpointsResource(AsyncAPIResource):
     ) -> object:
         """Points a LoRA adapter model to a dedicated endpoint.
 
-        After this call, inference requests to the adapter model name will be
-        routed to the specified endpoint.
+        After this call, inference requests to ``base_model:adapter_name``
+        will be routed to the specified endpoint.
 
         Args:
-          adapter_model_name: The LoRA adapter model name (model_output_name from the FT job).
+          base_model: The dedicated endpoint name that serves the base model with LoRA support.
 
-          endpoint_name: The dedicated endpoint name to route adapter inference to.
-              Must be a private dedicated endpoint with LoRA support.
+          adapter_name: The LoRA adapter model name (e.g. "user/my-adapter").
 
           extra_headers: Send extra headers
 
@@ -797,8 +795,8 @@ class AsyncEndpointsResource(AsyncAPIResource):
             "/v1/endpoints/lora-adapter",
             body=await async_maybe_transform(
                 {
-                    "adapter_model_name": adapter_model_name,
-                    "endpoint_name": endpoint_name,
+                    "base_model": base_model,
+                    "adapter_name": adapter_name,
                 },
                 dict,
             ),

--- a/src/together/resources/endpoints.py
+++ b/src/together/resources/endpoints.py
@@ -403,10 +403,68 @@ class EndpointsResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         return self._post(
-            "/v1/endpoints/lora-adapter",
+            "/v1/endpoints/adapters",
             body=maybe_transform(
                 {
-                    "model_name": f"{base_model}:{adapter_name}",
+                    "model_id": f"{base_model}:{adapter_name}",
+                },
+                dict,
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+            ),
+            cast_to=object,
+        )
+
+    def list_adapters(
+        self,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> object:
+        """Lists all LoRA adapters bound to dedicated endpoints.
+
+        Returns adapters with their model_id (endpoint:adapter format),
+        adapter_name, and endpoint_name.
+        """
+        return self._get(
+            "/v1/endpoints/adapters",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+            ),
+            cast_to=object,
+        )
+
+    def delete_adapter(
+        self,
+        *,
+        base_model: str,
+        adapter_name: str,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> object:
+        """Unbinds a LoRA adapter from its dedicated endpoint.
+
+        Args:
+          base_model: The dedicated endpoint name.
+
+          adapter_name: The LoRA adapter model name.
+        """
+        return self._delete(
+            "/v1/endpoints/adapters",
+            body=maybe_transform(
+                {
+                    "model_id": f"{base_model}:{adapter_name}",
                 },
                 dict,
             ),
@@ -791,10 +849,58 @@ class AsyncEndpointsResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         return await self._post(
-            "/v1/endpoints/lora-adapter",
+            "/v1/endpoints/adapters",
             body=await async_maybe_transform(
                 {
-                    "model_name": f"{base_model}:{adapter_name}",
+                    "model_id": f"{base_model}:{adapter_name}",
+                },
+                dict,
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+            ),
+            cast_to=object,
+        )
+
+    async def list_adapters(
+        self,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> object:
+        """Lists all LoRA adapters bound to dedicated endpoints."""
+        return await self._get(
+            "/v1/endpoints/adapters",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+            ),
+            cast_to=object,
+        )
+
+    async def delete_adapter(
+        self,
+        *,
+        base_model: str,
+        adapter_name: str,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> object:
+        """Unbinds a LoRA adapter from its dedicated endpoint."""
+        return await self._delete(
+            "/v1/endpoints/adapters",
+            body=await async_maybe_transform(
+                {
+                    "model_id": f"{base_model}:{adapter_name}",
                 },
                 dict,
             ),


### PR DESCRIPTION
## Summary

Adds LoRA adapter management methods to the Python SDK and CLI, scoped to endpoints.

### SDK (`src/together/resources/endpoints.py`)

Three methods on both `EndpointsResource` (sync) and `AsyncEndpointsResource`:

```python
client.endpoints.add_adapter(endpoint_id="...", model_id="endpoint:adapter")
client.endpoints.list_adapters(endpoint_id="...")
client.endpoints.remove_adapter(endpoint_id="...", model_id="endpoint:adapter")
```

All hit `POST/GET/DELETE /v1/endpoints/{endpoint_id}/adapters`.

### CLI (`src/together/lib/cli/api/endpoints/adapters/`)

```
tg endpoints adapters add ENDPOINT_ID MODEL_ID
tg endpoints adapters list ENDPOINT_ID
tg endpoints adapters remove ENDPOINT_ID MODEL_ID
```

Registered as a subcommand group under `endpoints` in CLI init.

## Changes

- `src/together/resources/endpoints.py` — 6 methods (3 sync + 3 async)
- `src/together/lib/cli/__init__.py` — adapter subcommand registration
- `src/together/lib/cli/api/endpoints/adapters/` — `add.py`, `list.py`, `remove.py`

## Related PRs

- DE backend: togethercomputer/together-dedicated-endpoints#480 (merged)
- OpenAPI: togethercomputer/openapi#300
- Web UI: togethercomputer/together-web#7795
- Docs: togethercomputer/mintlify-docs#878
- Inference routing: togethercomputer/inference-pop#1971 (merged)

## Test plan

- [ ] `client.endpoints.add_adapter(endpoint_id="x", model_id="ep:adapter")` sends POST with `{"model_id": "ep:adapter"}`
- [ ] `client.endpoints.list_adapters(endpoint_id="x")` returns list
- [ ] `client.endpoints.remove_adapter(endpoint_id="x", model_id="ep:adapter")` sends DELETE
- [ ] Async variants work identically
- [ ] CLI commands invoke correct SDK methods