### PR TITLE
feat(jig): jig deploy --image

### DIFF
--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -667,7 +667,10 @@ class Jig:
         if warmup:
             _build_warm_image(image)
 
-    def push(self, tag: str = "latest") -> None:
+    def push(self, tag: str = "latest", source_image: str | None = None) -> None:
+        if source_image and not tag:
+            last = source_image.rsplit("/", 1)[-1]
+            tag = last.rsplit(":", 1)[1] if ":" in last else "latest"
         image = self.image(tag)
         host = self.registry().split("/")[0]
         login_cmd = ["docker", "login", host, "--username", "user", "--password-stdin"]
@@ -676,8 +679,12 @@ class Jig:
 
         console.print(f"Pushing {image}")
         self._metadata_path(tag).unlink(missing_ok=True)
+        if source_image:
+            if subprocess.run(["docker", "tag", source_image, image]).returncode != 0:
+                raise JigError(f"Failed to retag {source_image}")
+            ok = subprocess.run(["docker", "push", image]).returncode == 0
         # Skip buildx for warmup-baked images: a buildx rebuild would drop the warmup layer.
-        if _image_is_warmed(image) or os.getenv("JIG_DISABLE_BUILDX"):
+        elif _image_is_warmed(image) or os.getenv("JIG_DISABLE_BUILDX"):
             ok = subprocess.run(["docker", "push", image]).returncode == 0
         else:
             builder = _ensure_zstd_builder()
@@ -1187,9 +1194,9 @@ def build(jig: Jig, tag: str, warmup: bool, docker_args: str | None) -> None:
     jig.build(tag, warmup, docker_args)
 
 
-def push(jig: Jig, tag: str) -> None:
+def push(jig: Jig, tag: str, source_image: str | None = None) -> None:
     """Push image to registry"""
-    jig.push(tag)
+    jig.push(tag, source_image)
 
 
 def deploy(
@@ -1456,13 +1463,14 @@ def build_cli(
 
 
 def push_cli(
-    tag: Annotated[str, Parameter(help="Image tag")] = "latest",
+    tag: Annotated[Optional[str], Parameter(help="Image tag (defaults to 'latest', or source image's tag when --image is used)")] = None,
+    image: Annotated[Optional[str], Parameter(name="--image", help="Existing local image to retag and push")] = None,
     *,
     config: CLIConfigParameter,
     toml_config: TomlConfigParameter = None,
 ) -> None:
     """Push image to registry."""
-    _run_jig_cmd(config, toml_config, lambda jig: push(jig, tag))
+    _run_jig_cmd(config, toml_config, lambda jig: push(jig, tag or ("" if image else "latest"), image))
 
 
 def deploy_cli(

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -550,11 +550,6 @@ class Jig:
         """Path for buildx --metadata-file output, used to recover the pushed digest cross-process."""
         return self.config._path.parent / f".jig-{self.name}-{tag}.metadata.json"
 
-    def _custom_dockerfile(self) -> str | None:
-        """Configured dockerfile path, or None when it's the default."""
-        path = self.config.image.dockerfile_path
-        return path if path != "Dockerfile" else None
-
     def image_with_digest(self, tag: str = "latest") -> str:
         image = self.image(tag)
         try:
@@ -696,7 +691,7 @@ class Jig:
         elif _image_is_warmed(image) or os.getenv("JIG_DISABLE_BUILDX"):
             ok = subprocess.run(["docker", "push", image]).returncode == 0
         else:
-            ok = _buildx_push(image, self._metadata_path(tag), dockerfile=self._custom_dockerfile())
+            ok = _buildx_push(image, self._metadata_path(tag), dockerfile=self.config.image.dockerfile_path)
         if not ok:
             raise JigError("Push failed")
         console.print("\N{CHECK MARK} Pushed")
@@ -728,7 +723,7 @@ class Jig:
         self._metadata_path(tag).unlink(missing_ok=True)
         extra_args = shlex.split(docker_args or os.getenv("DOCKER_BUILD_EXTRA_ARGS", ""))
         if not _buildx_push(
-            image, self._metadata_path(tag), dockerfile=self._custom_dockerfile(), extra_args=extra_args
+            image, self._metadata_path(tag), dockerfile=self.config.image.dockerfile_path, extra_args=extra_args
         ):
             raise JigError("Build+push failed")
         console.print("\N{CHECK MARK} Built and pushed")
@@ -1657,7 +1652,7 @@ def _image_is_warmed(image: str) -> bool:
 def _buildx_push(
     image: str,
     metadata_file: Path,
-    dockerfile: str | None = None,
+    dockerfile: str,
     context: str = ".",
     extra_args: list[str] | None = None,
 ) -> bool:
@@ -1679,7 +1674,7 @@ def _buildx_push(
         "--metadata-file",
         str(metadata_file),
     ]
-    if dockerfile:
+    if dockerfile != "Dockerfile":
         cmd.extend(["-f", dockerfile])
     cmd.extend(extra_args or [])
     cmd.append(context)

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -16,6 +16,7 @@ import types
 import shutil
 import typing
 import asyncio
+import tempfile
 import subprocess
 import concurrent.futures
 from typing import TYPE_CHECKING, Any, Union, Callable, Optional, Annotated
@@ -549,6 +550,11 @@ class Jig:
         """Path for buildx --metadata-file output, used to recover the pushed digest cross-process."""
         return self.config._path.parent / f".jig-{self.name}-{tag}.metadata.json"
 
+    def _custom_dockerfile(self) -> str | None:
+        """Configured dockerfile path, or None when it's the default."""
+        path = self.config.image.dockerfile_path
+        return path if path != "Dockerfile" else None
+
     def image_with_digest(self, tag: str = "latest") -> str:
         image = self.image(tag)
         try:
@@ -680,34 +686,17 @@ class Jig:
         console.print(f"Pushing {image}")
         self._metadata_path(tag).unlink(missing_ok=True)
         if source_image:
-            if subprocess.run(["docker", "tag", source_image, image]).returncode != 0:
-                raise JigError(f"Failed to retag {source_image}")
-            ok = subprocess.run(["docker", "push", image]).returncode == 0
+            if os.getenv("JIG_DISABLE_BUILDX"):
+                if subprocess.run(["docker", "tag", source_image, image]).returncode != 0:
+                    raise JigError(f"Failed to retag {source_image}")
+                ok = subprocess.run(["docker", "push", image]).returncode == 0
+            else:
+                ok = _push_image_as_zstd(source_image, image, self._metadata_path(tag))
         # Skip buildx for warmup-baked images: a buildx rebuild would drop the warmup layer.
         elif _image_is_warmed(image) or os.getenv("JIG_DISABLE_BUILDX"):
             ok = subprocess.run(["docker", "push", image]).returncode == 0
         else:
-            builder = _ensure_zstd_builder()
-            if not builder:
-                raise JigError("`docker buildx` is required to build images.")
-            cmd = [
-                "docker",
-                "buildx",
-                "build",
-                "--builder",
-                builder,
-                "--platform",
-                "linux/amd64",
-                "--push",
-                "--output",
-                f"type=image,name={image},{BUILDX_OUTPUT_OPTS}",
-                "--metadata-file",
-                str(self._metadata_path(tag)),
-            ]
-            if self.config.image.dockerfile_path != "Dockerfile":
-                cmd.extend(["-f", self.config.image.dockerfile_path])
-            cmd.append(".")
-            ok = subprocess.run(cmd).returncode == 0
+            ok = _buildx_push(image, self._metadata_path(tag), dockerfile=self._custom_dockerfile())
         if not ok:
             raise JigError("Push failed")
         console.print("\N{CHECK MARK} Pushed")
@@ -724,9 +713,6 @@ class Jig:
             self.build(tag, False, docker_args)
             self.push(tag)
             return
-        builder = _ensure_zstd_builder()
-        if not builder:
-            raise JigError("`docker buildx` is required to build images.")
 
         host = self.registry().split("/")[0]
         login_cmd = ["docker", "login", host, "--username", "user", "--password-stdin"]
@@ -740,27 +726,10 @@ class Jig:
 
         console.print(f"Building and pushing {image}")
         self._metadata_path(tag).unlink(missing_ok=True)
-        cmd = [
-            "docker",
-            "buildx",
-            "build",
-            "--builder",
-            builder,
-            "--platform",
-            "linux/amd64",
-            "--push",
-            "--output",
-            f"type=image,name={image},{BUILDX_OUTPUT_OPTS}",
-            "--metadata-file",
-            str(self._metadata_path(tag)),
-        ]
-        if self.config.image.dockerfile_path != "Dockerfile":
-            cmd.extend(["-f", self.config.image.dockerfile_path])
-        extra_args = docker_args or os.getenv("DOCKER_BUILD_EXTRA_ARGS", "")
-        if extra_args:
-            cmd.extend(shlex.split(extra_args))
-        cmd.append(".")
-        if subprocess.run(cmd).returncode != 0:
+        extra_args = shlex.split(docker_args or os.getenv("DOCKER_BUILD_EXTRA_ARGS", ""))
+        if not _buildx_push(
+            image, self._metadata_path(tag), dockerfile=self._custom_dockerfile(), extra_args=extra_args
+        ):
             raise JigError("Build+push failed")
         console.print("\N{CHECK MARK} Built and pushed")
 
@@ -1463,8 +1432,12 @@ def build_cli(
 
 
 def push_cli(
-    tag: Annotated[Optional[str], Parameter(help="Image tag (defaults to 'latest', or source image's tag when --image is used)")] = None,
-    image: Annotated[Optional[str], Parameter(name="--image", help="Existing local image to retag and push")] = None,
+    tag: Annotated[
+        Optional[str], Parameter(help="Image tag (defaults to 'latest', or source image's tag when --image is used)")
+    ] = None,
+    image: Annotated[
+        Optional[str], Parameter(name="--image", help="Existing local image to push (layers re-encoded as zstd)")
+    ] = None,
     *,
     config: CLIConfigParameter,
     toml_config: TomlConfigParameter = None,
@@ -1679,6 +1652,71 @@ def _image_is_warmed(image: str) -> bool:
         text=True,
     )
     return r.returncode == 0 and r.stdout.strip() == "true"
+
+
+def _buildx_push(
+    image: str,
+    metadata_file: Path,
+    dockerfile: str | None = None,
+    context: str = ".",
+    extra_args: list[str] | None = None,
+) -> bool:
+    """Run `docker buildx build --push` through the zstd builder."""
+    builder = _ensure_zstd_builder()
+    if not builder:
+        raise JigError("`docker buildx` is required to build images.")
+    cmd = [
+        "docker",
+        "buildx",
+        "build",
+        "--builder",
+        builder,
+        "--platform",
+        "linux/amd64",
+        "--push",
+        "--output",
+        f"type=image,name={image},{BUILDX_OUTPUT_OPTS}",
+        "--metadata-file",
+        str(metadata_file),
+    ]
+    if dockerfile:
+        cmd.extend(["-f", dockerfile])
+    cmd.extend(extra_args or [])
+    cmd.append(context)
+    return subprocess.run(cmd).returncode == 0
+
+
+def _push_image_as_zstd(source_image: str, image: str, metadata_file: Path) -> bool:
+    """Push a local image with its layers re-encoded as zstd.
+
+    `docker push` through a legacy (non-containerd) image store recompresses
+    layers as gzip, losing the zstd cold-start benefit. Instead, export the
+    image as an OCI layout (`docker save`) and rebuild it through the zstd
+    builder with force-compression, which re-encodes every layer on push.
+    """
+    with tempfile.TemporaryDirectory(prefix="jig-push-") as tmp:
+        layout = Path(tmp) / "oci"
+        layout.mkdir()
+        console.print(f"Exporting {source_image}")
+        save = subprocess.Popen(["docker", "save", source_image], stdout=subprocess.PIPE)
+        tar = subprocess.run(["tar", "-x", "-C", str(layout)], stdin=save.stdout)
+        if save.stdout:
+            save.stdout.close()
+        if save.wait() != 0 or tar.returncode != 0:
+            raise JigError(f"Failed to export {source_image}")
+        index = layout / "index.json"
+        if not index.exists():
+            raise JigError("`docker save` did not produce an OCI layout; Docker 25+ is required for --image")
+        digest = json.loads(index.read_text())["manifests"][0]["digest"]
+        ctx = Path(tmp) / "ctx"
+        ctx.mkdir()
+        (ctx / "Dockerfile").write_text("FROM source-image\n")
+        return _buildx_push(
+            image,
+            metadata_file,
+            context=str(ctx),
+            extra_args=["--build-context", f"source-image=oci-layout://{layout}:source-image@{digest}"],
+        )
 
 
 def _ensure_zstd_builder(name: str = "jig-zstd") -> str | None:


### PR DESCRIPTION
**`src/together/lib/cli/api/beta/jig/jig.py`**

1. `Jig.push()` (line 670): added `source_image` param. If set with empty tag, derives tag from source image (default "latest"). Branches to `docker tag` + `docker push` instead of buildx.
2. `push()` wrapper (line ~1190): forwards `source_image`.
3. `push_cli()` (line ~1458): adds `--image` flag, tag default → `None`. Passes `"latest"` when no image specified, `""` (meaning "derive from source") when image specified without explicit tag.

Usage:
```
jig push                                  # builds & pushes to <upstream>:latest
jig push --tag v1                         # builds & pushes to <upstream>:v1
jig push --image myapp:dev                # retags & pushes <upstream>:dev
jig push --image myapp:dev --tag prod     # retags & pushes <upstream>:prod
jig push --image myapp                    # retags & pushes <upstream>:latest
```