### PR TITLE
fix: ENG-89582 use regular print for jig volumes progress update

### DIFF
--- a/src/together/lib/cli/api/beta/jig/_uploader.py
+++ b/src/together/lib/cli/api/beta/jig/_uploader.py
@@ -11,7 +11,7 @@ from typing import Any
 from pathlib import Path
 
 import httpx
-from rich import print
+from rich import print as rich_print
 
 from together import Together
 from together.lib.utils import log_debug
@@ -77,9 +77,11 @@ class Uploader:
             if speed_kbps > 1024:
                 speed_str = f"{(speed_kbps / 1024):.1f} MB/s - "
 
-        msg = f"\r{spinner} {percent}% - {speed_str}{display_file} {size_str} ({self.completed_files}/{self.total_files} files)"
+        msg = f"{spinner} {percent}% - {speed_str}{display_file} {size_str} ({self.completed_files}/{self.total_files} files)"
 
-        # \r moves cursor to start of line, \033[K clears from cursor to end of line
+        # \r moves cursor to start of line, \033[K clears from cursor to end of line.
+        # Use the builtin print (rich's print strips the \r) so the line updates
+        # in-place instead of appending each progress update.
         print(f"\r{msg}\033[K", end="", flush=True)  # noqa: T201
 
     async def increment_progress(self, bytes_count: int, filename: str = "", file_complete: bool = False) -> None:
@@ -131,7 +133,7 @@ class Uploader:
                 await spinner_task
 
         elapsed_time = time.time() - self.start_time
-        print(f"\n\N{CHECK MARK} Upload completed in {elapsed_time:.1f} seconds")
+        rich_print(f"\n\N{CHECK MARK} Upload completed in {elapsed_time:.1f} seconds")
 
     async def upload_file_with_retry(self, file_path: Path, remote_path: str, file_size: int) -> None:
         for attempt in range(MAX_UPLOAD_RETRIES):
@@ -227,7 +229,7 @@ class Uploader:
                     headers=self.client.auth_headers,
                 )
             except Exception as e:
-                print(f"[red]Failed to abort multipart upload request: {repr(e)}[/red]", file=sys.stderr)
+                rich_print(f"[red]Failed to abort multipart upload request: {repr(e)}[/red]", file=sys.stderr)
             raise
 
     async def _upload_parts(

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -1416,14 +1416,7 @@ async def jig_volumes_describe(
     except NotFoundError:
         _jig_fail(f"Volume {name} not found")
     else:
-        if config.json:
-            console.print_json(openapi_dumps(vol).decode("utf-8"))
-        else:
-            console.print(f"[bold dim]ID[/bold dim]         [blue]{vol.id or '—'}[/blue]")
-            console.print(f"[bold dim]Name[/bold dim]       [blue]{vol.name or '—'}[/blue]")
-            console.print(f"[bold dim]Created[/bold dim]     [blue]{vol.created_at or '—'}[/blue]")
-            console.print(f"[bold dim]Updated[/bold dim]     [blue]{vol.updated_at or '—'}[/blue]")
-            console.print(f"[bold dim]Version[/bold dim]      [blue]{vol.current_version!s}[/blue]")
+        console.print_json(openapi_dumps(vol).decode("utf-8"))
 
 
 def dockerfile_cli(


### PR DESCRIPTION
- rich print strips `\r` so progress update doesn't update the spinner in-place, instead it appends a line for each update.
- also, show full json output in jig volumes describe, the info in the table is not enough in this case.