### PR TITLE
MOSH-2945: raise if file exists

### DIFF
--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -644,7 +644,7 @@ class MultipartUploadManager(SyncAPIResource):
             return self._complete_upload(url, upload_id, file_id, completed_parts)
 
         # If the server says the file already exists, raise the error to the files.upload resource
-        # This should be silently handled by fetching down the file and returning it
+        # This should be loudly handled by raising a ValueError and outputting the existing file ID
         except FileAlreadyExistsError as e:
             raise e
         except Exception as e:
@@ -1051,7 +1051,7 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
             return await self._complete_upload(url, upload_id, file_id, completed_parts)
 
         # If the server says the file already exists, raise the error to the files.upload resource
-        # This should be silently handled by fetching down the file and returning it
+        # This should be loudly handled by raising a ValueError and outputting the existing file ID
         except FileAlreadyExistsError as e:
             raise e
         except Exception as e:

--- a/src/together/resources/files.py
+++ b/src/together/resources/files.py
@@ -183,7 +183,10 @@ class FilesResource(SyncAPIResource):
                 purpose=result.purpose,
             )
         except FileAlreadyExistsError as e:
-            return self.retrieve(e.file_id)
+            res = self.retrieve(e.file_id)
+            raise ValueError(
+                f"File already exists under ID: {res.id}. If you want to overwrite it, please delete the existing file first."
+            ) from e
 
     def content(
         self,
@@ -366,7 +369,10 @@ class AsyncFilesResource(AsyncAPIResource):
                 purpose=result.purpose,
             )
         except FileAlreadyExistsError as e:
-            return await self.retrieve(e.file_id)
+            res = await self.retrieve(e.file_id)
+            raise ValueError(
+                f"File already exists under ID: {res.id}. If you want to overwrite it, please delete the existing file first."
+            ) from e
 
     async def content(
         self,


### PR DESCRIPTION
## This PR

Now raises an error if the file already exists. This also outputs a File ID but in a form an error, and guides a user to reupload a file if necessary.