### PR TITLE
Add early_stopping params to fine_tuning.create()

### DIFF
--- a/src/together/resources/fine_tuning.py
+++ b/src/together/resources/fine_tuning.py
@@ -115,6 +115,10 @@ class FineTuningResource(SyncAPIResource):
         wandb_name: str | None = None,
         wandb_entity: str | None = None,
         random_seed: int | None = None,
+        early_stopping_enabled: bool = False,
+        early_stopping_patience: int | None = None,
+        early_stopping_min_delta: float | None = None,
+        early_stopping_warmup_evals: int | None = None,
         verbose: bool = False,
         model_limits: FinetuneTrainingLimits | None = None,
         train_on_inputs: bool | Literal["auto"] | None = None,
@@ -173,6 +177,15 @@ class FineTuningResource(SyncAPIResource):
             random_seed (int, optional): Random seed for reproducible training (e.g. 42). When set, the same seed produces
                 the same run (e.g. data shuffle, init). If not provided (None), the server uses its default seed (42).
                 Defaults to None.
+            early_stopping_enabled (bool, optional): Stop training early when validation eval_loss stops improving.
+                Requires a validation_file, and n_evals must be at least
+                early_stopping_patience + early_stopping_warmup_evals + 1. Defaults to False.
+            early_stopping_patience (int, optional): Consecutive non-improving evals to tolerate before stopping.
+                Only applies when early_stopping_enabled is True. Defaults to None (server default 2).
+            early_stopping_min_delta (float, optional): Minimum eval_loss decrease to count as an improvement.
+                Only applies when early_stopping_enabled is True. Defaults to None (server default 0.0).
+            early_stopping_warmup_evals (int, optional): Initial evals to skip before counting patience.
+                Only applies when early_stopping_enabled is True. Defaults to None (server default 1).
             verbose (bool, optional): whether to print the job parameters before submitting a request.
                 Defaults to False.
             model_limits (FinetuneTrainingLimits, optional): Limits for the hyperparameters the model in Fine-tuning.
@@ -248,6 +261,10 @@ class FineTuningResource(SyncAPIResource):
             wandb_name=wandb_name,
             wandb_entity=wandb_entity,
             random_seed=random_seed,
+            early_stopping_enabled=early_stopping_enabled,
+            early_stopping_patience=early_stopping_patience,
+            early_stopping_min_delta=early_stopping_min_delta,
+            early_stopping_warmup_evals=early_stopping_warmup_evals,
             train_on_inputs=train_on_inputs,
             training_method=training_method,
             dpo_beta=dpo_beta,
@@ -750,6 +767,10 @@ class AsyncFineTuningResource(AsyncAPIResource):
         wandb_name: str | None = None,
         wandb_entity: str | None = None,
         random_seed: int | None = None,
+        early_stopping_enabled: bool = False,
+        early_stopping_patience: int | None = None,
+        early_stopping_min_delta: float | None = None,
+        early_stopping_warmup_evals: int | None = None,
         verbose: bool = False,
         model_limits: FinetuneTrainingLimits | None = None,
         train_on_inputs: bool | Literal["auto"] | None = None,
@@ -807,6 +828,15 @@ class AsyncFineTuningResource(AsyncAPIResource):
             random_seed (int, optional): Random seed for reproducible training (e.g. 42). When set, the same seed produces
                 the same run (e.g. data shuffle, init). If not provided (None), the server uses its default seed (42).
                 Defaults to None.
+            early_stopping_enabled (bool, optional): Stop training early when validation eval_loss stops improving.
+                Requires a validation_file, and n_evals must be at least
+                early_stopping_patience + early_stopping_warmup_evals + 1. Defaults to False.
+            early_stopping_patience (int, optional): Consecutive non-improving evals to tolerate before stopping.
+                Only applies when early_stopping_enabled is True. Defaults to None (server default 2).
+            early_stopping_min_delta (float, optional): Minimum eval_loss decrease to count as an improvement.
+                Only applies when early_stopping_enabled is True. Defaults to None (server default 0.0).
+            early_stopping_warmup_evals (int, optional): Initial evals to skip before counting patience.
+                Only applies when early_stopping_enabled is True. Defaults to None (server default 1).
             verbose (bool, optional): whether to print the job parameters before submitting a request.
                 Defaults to False.
             model_limits (FinetuneTrainingLimits, optional): Limits for the hyperparameters the model in Fine-tuning.
@@ -882,6 +912,10 @@ class AsyncFineTuningResource(AsyncAPIResource):
             wandb_name=wandb_name,
             wandb_entity=wandb_entity,
             random_seed=random_seed,
+            early_stopping_enabled=early_stopping_enabled,
+            early_stopping_patience=early_stopping_patience,
+            early_stopping_min_delta=early_stopping_min_delta,
+            early_stopping_warmup_evals=early_stopping_warmup_evals,
             train_on_inputs=train_on_inputs,
             training_method=training_method,
             dpo_beta=dpo_beta,

--- a/tests/cli/test_fine_tuning.py
+++ b/tests/cli/test_fine_tuning.py
@@ -168,11 +168,6 @@ class TestFineTuningCreate:
         assert "insufficient funds" in result.output
         assert create.calls
 
-    @pytest.mark.xfail(
-        reason="early_stopping_* create params reach the request only once the generated create() is "
-        "regenerated from the OpenAPI spec (openapi -> sdk -> cli flow); xpasses once that lands.",
-        strict=False,
-    )
     @pytest.mark.respx(base_url=base_url, assert_all_called=False)
     def test_create_early_stopping_sends_params(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         respx_mock.get("/fine-tunes/models/limits").mock(return_value=httpx.Response(200, json=_MODEL_LIMITS_BODY))

--- a/tests/unit/test_fine_tuning_resources.py
+++ b/tests/unit/test_fine_tuning_resources.py
@@ -360,3 +360,63 @@ def test_train_on_inputs_not_supported_for_dpo():
             training_method="dpo",
             train_on_inputs=True,
         )
+
+
+def test_early_stopping_request():
+    request, _, _ = create_finetune_request(
+        model_limits=_MODEL_LIMITS,
+        model=_MODEL_NAME,
+        training_file=_TRAINING_FILE,
+        validation_file=_VALIDATION_FILE,
+        n_evals=10,
+        early_stopping_enabled=True,
+        early_stopping_patience=3,
+        early_stopping_min_delta=0.01,
+        early_stopping_warmup_evals=2,
+    )
+
+    assert request.early_stopping_enabled is True
+    assert request.early_stopping_patience == 3
+    assert request.early_stopping_min_delta == 0.01
+    assert request.early_stopping_warmup_evals == 2
+
+
+def test_early_stopping_overrides_omitted_when_unset():
+    # Only the toggle is set; the tuning knobs stay None so the server applies its defaults.
+    request, _, _ = create_finetune_request(
+        model_limits=_MODEL_LIMITS,
+        model=_MODEL_NAME,
+        training_file=_TRAINING_FILE,
+        validation_file=_VALIDATION_FILE,
+        n_evals=10,
+        early_stopping_enabled=True,
+    )
+
+    assert request.early_stopping_enabled is True
+    assert request.early_stopping_patience is None
+    assert request.early_stopping_min_delta is None
+    assert request.early_stopping_warmup_evals is None
+
+
+@pytest.mark.parametrize(
+    "patience, warmup, min_delta, n_evals, match",
+    [
+        (0, 1, 0.0, 10, "patience must be >= 1"),
+        (2, -1, 0.0, 10, "warmup_evals must be >= 0"),
+        (2, 1, -0.1, 10, "min_delta must be >= 0"),
+        (2, 1, 0.0, 3, "n_evals >= patience"),  # 2 + 1 + 1 = 4 > 3
+    ],
+)
+def test_early_stopping_invalid_config(patience: int, warmup: int, min_delta: float, n_evals: int, match: str):
+    with pytest.raises(ValueError, match=match):
+        _ = create_finetune_request(
+            model_limits=_MODEL_LIMITS,
+            model=_MODEL_NAME,
+            training_file=_TRAINING_FILE,
+            validation_file=_VALIDATION_FILE,
+            n_evals=n_evals,
+            early_stopping_enabled=True,
+            early_stopping_patience=patience,
+            early_stopping_min_delta=min_delta,
+            early_stopping_warmup_evals=warmup,
+        )


### PR DESCRIPTION
Add early_stopping_enabled/_patience/_min_delta/_warmup_evals to the sync and async create() and forward them to create_finetune_request, which already accepts and validates these fields. Without this, calling create(early_stopping_enabled=...) raised TypeError, and the CLI --early-stopping-* flags failed for the same reason.