### PR TITLE
feat: prompt for preemptible GPUs in interactive cluster create wizard

### DIFF
--- a/src/together/lib/cli/api/beta/clusters/create.py
+++ b/src/together/lib/cli/api/beta/clusters/create.py
@@ -129,6 +129,9 @@ async def create(
         if num_gpus is None:
             n = input("Clusters: Cluster GPUs count (8-64): ").strip()
             params["num_gpus"] = int(n) if n else 8
+        if num_preemptible_gpus is None:
+            n = input("Clusters: Cluster preemptible GPUs count [0]: ").strip()
+            params["num_preemptible_gpus"] = int(n) if n else 0
         if not billing_type:
             params["billing_type"] = input("Clusters: Cluster billing type [ON_DEMAND]: ").strip() or "ON_DEMAND"
         if not nvidia_driver_version:


### PR DESCRIPTION
The interactive `together beta clusters create` wizard never asked for preemptible GPUs, even though the `--num-preemptible-gpus` flag already worked. This adds the missing prompt to the guided flow.

**What/Why:** The guided create flow collected name, GPU type, region, GPU count, billing, etc. but skipped preemptible GPUs entirely, so users on the wizard couldn't set them without dropping to flags.

**How:**

- **Wizard prompt** — added an optional `Cluster preemptible GPUs count [0]:` prompt after the GPU-count question, gated on the flag being unset and defaulting to 0.

Ticket: [TCL-7205](https://linear.app/together-ai/issue/TCL-7205)