### PR TITLE
feat(jig): add validation for environment variable and secret collisions

### DIFF
--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -814,9 +814,10 @@ class Jig:
             env_dict["TOGETHER_API_BASE_URL"] = str(self.together.base_url.copy_with(path=""))
 
         if collisions := sorted(set(env_dict) & set(self.state.secrets)):
-            names = ", ".join(collisions)
+            for name in collisions:
+                console.print(f"\N{CROSS MARK} {name} is defined as both secret and environment variable")
             raise JigError(
-                f"Defined as both an environment variable and a secret: {names}. Remove one from pyproject.toml or 'jig secrets unset'."
+                "Remove duplicate environment variable from your config or by using 'jig secrets unset'"
             )
 
         env_list = [{"name": k, "value": v} for k, v in env_dict.items()]

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -813,6 +813,12 @@ class Jig:
         if self.together.base_url.host not in ("api.together.ai", "api.together.xyz"):
             env_dict["TOGETHER_API_BASE_URL"] = str(self.together.base_url.copy_with(path=""))
 
+        if collisions := sorted(set(env_dict) & set(self.state.secrets)):
+            names = ", ".join(collisions)
+            raise JigError(
+                f"Defined as both an environment variable and a secret: {names}. Remove one from pyproject.toml or 'jig secrets unset'."
+            )
+
         env_list = [{"name": k, "value": v} for k, v in env_dict.items()]
         secret_list = [{"name": k, "value_from_secret": v} for k, v in self.state.secrets.items()]
         deploy_data["environment_variables"] = env_list + secret_list

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -816,9 +816,7 @@ class Jig:
         if collisions := sorted(set(env_dict) & set(self.state.secrets)):
             for name in collisions:
                 console.print(f"\N{CROSS MARK} {name} is defined as both secret and environment variable")
-            raise JigError(
-                "Remove duplicate environment variable from your config or by using 'jig secrets unset'"
-            )
+            raise JigError("Remove duplicate environment variable from your config or by using 'jig secrets unset'")
 
         env_list = [{"name": k, "value": v} for k, v in env_dict.items()]
         secret_list = [{"name": k, "value_from_secret": v} for k, v in self.state.secrets.items()]


### PR DESCRIPTION
Previously, defining the same name in `[tool.jig.deploy.environment_variables]` and as a jig secret passed straight through to the deployments API. The apply then fails server-side on the duplicate env var, but only after the request is ACKed, leaving the deployment stuck in Updating with no feedback to the user.

This adds a check in `deploy()` that fails fast, before anything is sent. For example:
```
Defined as both an environment variable and a secret: HF_TOKEN. Remove one from pyproject.toml or 'jig secrets unset'.
```