### PR TITLE
feat(cli): move ssh command under tg beta clusters

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -67,6 +67,7 @@ from together.lib.cli.utils._help_examples import (
     BETA_CLUSTERS_STORAGE_UPDATE_HELP_EXAMPLES,
     BETA_CLUSTERS_GET_CREDENTIALS_HELP_EXAMPLES,
     BETA_CLUSTERS_REMEDIATIONS_CREATE_HELP_EXAMPLES,
+    BETA_CLUSTERS_SSH_HELP_EXAMPLES,
 )
 from together.lib.cli.utils._help_formatter import help_formatter
 from together.lib.cli.utils._preparse_tokens import preparse_tokens
@@ -476,6 +477,11 @@ clusters_app.command(
     (f"{_CLI}.beta.clusters.get_credentials:get_credentials"),
     help="Get credentials for a cluster",
     help_epilogue=BETA_CLUSTERS_GET_CREDENTIALS_HELP_EXAMPLES,
+)
+clusters_app.command(
+    (f"{_CLI}.beta.clusters.ssh:ssh"),
+    help="SSH into a cluster via an OIDC-signed certificate",
+    help_epilogue=BETA_CLUSTERS_SSH_HELP_EXAMPLES,
 )
 
 ### Clusters > Storage API commands

--- a/src/together/lib/cli/api/beta/clusters/ssh.py
+++ b/src/together/lib/cli/api/beta/clusters/ssh.py
@@ -1,0 +1,234 @@
+"""`tg beta clusters ssh` — SSH into a Together cluster using a short-lived,
+OIDC-signed SSH certificate. No API key, no long-lived SSH key, no
+control-plane contact: every coordinate is derived from the cluster's Dex URL.
+
+Flow:
+    1. OIDC login against the cluster's Dex issuer (browser, PKCE) -> id_token
+    2. generate an ephemeral SSH keypair
+    3. POST the public key + id_token to the cluster's step-ca `/ssh/sign`
+       -> short-lived SSH user certificate (principal = email)
+    4. exec `ssh` through the bastion to the target host
+
+The host trusts step-ca's CA and maps the cert's email principal to the POSIX
+login, so no `authorized_keys` or per-user key distribution is involved.
+"""
+
+from __future__ import annotations
+
+import os
+import ssl
+import json as json_lib
+import base64
+import hashlib
+import secrets
+import tempfile
+import subprocess
+import webbrowser
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Optional, Annotated, cast
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing_extensions import override
+
+from cyclopts import Parameter
+
+from together import TogetherError
+from together.lib.cli.utils._console import console
+
+_CERT_ALGO = {
+    "ecdsa": "ecdsa-sha2-nistp256-cert-v01@openssh.com",
+    "ed25519": "ssh-ed25519-cert-v01@openssh.com",
+}
+
+
+def _http_json(
+    url: str,
+    data: Optional[dict[str, Any]] = None,
+    ctx: Optional[ssl.SSLContext] = None,
+) -> dict[str, Any]:
+    """GET (data=None) or form-POST JSON helper using stdlib only."""
+    if data is None:
+        req = urllib.request.Request(url, method="GET")
+    else:
+        body = urllib.parse.urlencode(data).encode()
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    with urllib.request.urlopen(req, context=ctx) as resp:
+        return cast("dict[str, Any]", json_lib.loads(resp.read().decode()))
+
+
+def _derive(dex_url: str) -> tuple[str, str]:
+    """Derive (ca_url, bastion) from the cluster's Dex issuer URL.
+
+    A Dex issuer looks like `https://dex.<base>/<cluster-id>`, from which:
+        ca_url  = https://dex.<base>/step-<cluster-id>
+        bastion = ssh.<cluster-id>.<base>
+    """
+    u = urllib.parse.urlparse(dex_url)
+    if not u.scheme or not u.hostname or not u.path.strip("/"):
+        raise TogetherError("DEX_URL must look like https://dex.<base>/<cluster-id>")
+    cluster_id = u.path.strip("/").split("/")[0]
+    base = u.hostname[4:] if u.hostname.startswith("dex.") else u.hostname
+    return f"{u.scheme}://{u.hostname}/step-{cluster_id}", f"ssh.{cluster_id}.{base}"
+
+
+def _pkce_login(issuer: str, client_id: str, redirect_uri: str, scope: str) -> str:
+    """Authorization-code + PKCE flow against Dex. Returns the raw id_token."""
+    disc = _http_json(issuer.rstrip("/") + "/.well-known/openid-configuration")
+    verifier = secrets.token_urlsafe(64)
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    state = secrets.token_urlsafe(16)
+    parsed = urllib.parse.urlparse(redirect_uri)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+        "state": state,
+        "nonce": secrets.token_urlsafe(16),
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    auth_url = disc["authorization_endpoint"] + "?" + urllib.parse.urlencode(params)
+    captured: dict[str, str] = {}
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            q = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            if "code" in q:
+                captured["code"] = q["code"][0]
+                captured["state"] = q.get("state", [""])[0]
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"Login complete. You can close this tab.")
+            else:
+                self.send_response(400)
+                self.end_headers()
+
+        @override
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: ARG002
+            # Silence the default per-request logging to stderr.
+            pass
+
+    server = HTTPServer((parsed.hostname or "localhost", parsed.port or 80), _Handler)
+    console.print(f"[dim]Opening browser for login: {issuer}[/dim]")
+    if not webbrowser.open(auth_url):
+        console.print(f"Open this URL to log in:\n{auth_url}")
+    server.handle_request()
+    server.server_close()
+
+    if not captured.get("code") or captured.get("state") != state:
+        raise TogetherError("OIDC login failed (no code or state mismatch)")
+    tok = _http_json(
+        disc["token_endpoint"],
+        data={
+            "grant_type": "authorization_code",
+            "code": captured["code"],
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+            "code_verifier": verifier,
+        },
+    )
+    if "id_token" not in tok:
+        raise TogetherError(f"token endpoint returned no id_token: {tok}")
+    return str(tok["id_token"])
+
+
+def _sign(ca_url: str, ott: str, pub_blob: str, ctx: Optional[ssl.SSLContext]) -> str:
+    """POST to step-ca /ssh/sign. Returns the base64 cert blob."""
+    body = json_lib.dumps({"publicKey": pub_blob, "OTT": ott, "certType": "user"}).encode()
+    req = urllib.request.Request(ca_url.rstrip("/") + "/ssh/sign", data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, context=ctx) as resp:
+            out = json_lib.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        raise TogetherError(f"step-ca /ssh/sign failed ({e.code}): {e.read().decode()[:300]}") from e
+    if "crt" not in out:
+        raise TogetherError(f"step-ca returned no crt: {out}")
+    return str(out["crt"])
+
+
+def _gen_keypair(tmpdir: str, key_type: str) -> tuple[str, str]:
+    """ssh-keygen an ephemeral keypair. Returns (key_path, pubkey_blob)."""
+    key_path = os.path.join(tmpdir, "id")
+    subprocess.run(
+        ["ssh-keygen", "-t", key_type, "-f", key_path, "-N", "", "-q", "-C", "together-ssh"],
+        check=True,
+    )
+    with open(key_path + ".pub") as f:
+        return key_path, f.read().split()[1]
+
+
+async def ssh(
+    dex_url: Annotated[str, Parameter(help="Cluster Dex issuer URL: https://dex.<base>/<cluster-id>")],
+    *ssh_args: Annotated[
+        str,
+        Parameter(allow_leading_hyphen=True, help="Extra args / remote command passed through to ssh"),
+    ],
+    login: Annotated[str, Parameter(name=["--login", "-l"], help="POSIX login / SSH username on the cluster")],
+    host: Annotated[
+        str,
+        Parameter(
+            help="Target host on the cluster (any hostname reachable through the bastion; e.g. slurm-login or a worker)"
+        ),
+    ] = "slurm-login",
+    ca_url: Annotated[Optional[str], Parameter(help="Override step-ca URL (derived from DEX_URL)")] = None,
+    bastion: Annotated[Optional[str], Parameter(help="Override bastion host (derived from DEX_URL)")] = None,
+    client_id: Annotated[str, Parameter(help="Dex public client id")] = "together-cli",
+    redirect_uri: Annotated[
+        str, Parameter(help="OIDC redirect URI (registered on the Dex client)")
+    ] = "http://localhost:3000/login-callback",
+    scope: Annotated[str, Parameter(help="OIDC scopes")] = "openid email",
+    key_type: Annotated[str, Parameter(help="Ephemeral key type (ecdsa is KMS-compatible)")] = "ecdsa",
+    ca_root: Annotated[Optional[str], Parameter(help="step-ca root cert (PEM) for TLS")] = None,
+    insecure: Annotated[bool, Parameter(negative=False, help="Skip step-ca TLS verification")] = False,
+    id_token_file: Annotated[
+        Optional[str], Parameter(help="Use a pre-obtained id_token instead of the browser flow")
+    ] = None,
+) -> None:
+    """SSH into a Together cluster, identified only by its Dex URL.
+
+    DEX_URL is the cluster's Dex issuer (https://dex.<base>/<cluster-id>); the
+    step-ca endpoint and bastion are derived from it. Logs into Dex, has step-ca
+    sign an ephemeral key, then SSHes through the bastion as --login. Never
+    contacts the control plane. Anything after DEX_URL is passed through to ssh.
+    """
+    issuer = dex_url
+    derived_ca_url, derived_bastion = _derive(dex_url)
+    ca_url = ca_url or derived_ca_url
+    bastion = bastion or derived_bastion
+
+    if insecure:
+        ca_ctx: Optional[ssl.SSLContext] = ssl._create_unverified_context()
+    elif ca_root:
+        ca_ctx = ssl.create_default_context(cafile=ca_root)
+    else:
+        ca_ctx = None
+
+    if id_token_file:
+        with open(id_token_file) as f:
+            ott = f.read().strip()
+    else:
+        ott = _pkce_login(issuer, client_id, redirect_uri, scope)
+
+    with tempfile.TemporaryDirectory(prefix="together-ssh-") as tmp:
+        key_path, pub_blob = _gen_keypair(tmp, key_type)
+        crt = _sign(ca_url, ott, pub_blob, ca_ctx)
+        cert_path = key_path + "-cert.pub"
+        with open(cert_path, "w") as f:
+            f.write(f"{_CERT_ALGO[key_type]} {crt} together-ssh\n")
+
+        common = ["-i", key_path, "-o", f"CertificateFile={cert_path}", "-o", "IdentitiesOnly=yes"]
+        # Bastion hop is the internet-facing edge and its hostname is unique per
+        # cluster, so it keeps normal host-key verification (proxy uses `common`
+        # only). The inner hop runs through the bastion, already inside the
+        # cluster, and targets generic names (slurm-login, workers) whose host
+        # keys both churn on pod restarts and collide across clusters. Skip
+        # host-key checking on that inner hop only.
+        proxy = "ssh " + " ".join(common) + f" -W %h:%p {login}@{bastion}"
+        inner_insecure = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
+        cmd = ["ssh"] + common + inner_insecure + ["-o", f"ProxyCommand={proxy}", f"{login}@{host}"] + list(ssh_args)
+        console.print(f"[dim]Connecting to {host} via {bastion} as {login}...[/dim]")
+        os.execvp("ssh", cmd)

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -276,6 +276,23 @@ BETA_CLUSTERS_HELP_EXAMPLES = """[dim]Examples:[/dim]
 [dim]-[/dim] Manage node remediations:
   [primary]tg beta clusters remediations ls <cluster-id>[/primary]
   [primary]tg beta clusters remediations create <cluster-id> <instance-id> --mode VM_ONLY[/primary]
+
+[dim]-[/dim] SSH into a cluster (OIDC-signed certificate):
+  [primary]tg beta clusters ssh https://dex.<base>/<cluster-id> --login <user>[/primary]
+"""
+
+BETA_CLUSTERS_SSH_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] SSH to the default slurm-login host:
+  [primary]tg beta clusters ssh https://dex.<base>/<cluster-id> --login <user>[/primary]
+
+[dim]-[/dim] SSH to a specific worker node:
+  [primary]tg beta clusters ssh https://dex.<base>/<cluster-id> --login <user> --host worker-0[/primary]
+
+[dim]-[/dim] Run a remote command:
+  [primary]tg beta clusters ssh https://dex.<base>/<cluster-id> --login <user> -- squeue[/primary]
+
+[dim]-[/dim] Skip the browser flow with a pre-obtained id_token:
+  [primary]tg beta clusters ssh https://dex.<base>/<cluster-id> --login <user> --id-token-file ./token[/primary]
 """
 
 BETA_CLUSTERS_CREATE_HELP_EXAMPLES = """[dim]Examples:[/dim]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Moves the OIDC-signed SSH command from a top-level `tg ssh` to `tg beta clusters ssh`, grouping it with the other cluster management commands.

## Changes

- Add `src/together/lib/cli/api/beta/clusters/ssh.py` (moved from planned top-level `api/ssh.py`)
- Register under `clusters_app` in CLI init instead of the root app
- Add `BETA_CLUSTERS_SSH_HELP_EXAMPLES` and include SSH in the beta clusters help epilogue

## Usage

```bash
tg beta clusters ssh https://dex.<base>/<cluster-id> --login <user>
tg beta clusters ssh https://dex.<base>/<cluster-id> --login <user> --host worker-0
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59da205a-3b06-45cb-b24b-7d14fbceca48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59da205a-3b06-45cb-b24b-7d14fbceca48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

