### PR TITLE
Move `tg ssh` under `tg beta clusters`

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -335,9 +335,6 @@ async def launcher(
 # Register commands
 _CLI = "together.lib.cli.api"
 
-## SSH (OIDC-signed certificate; no API key, no control-plane contact)
-app.command(f"{_CLI}.ssh:ssh", help="SSH into a cluster via an OIDC-signed certificate")
-
 ## Files API commands
 files_app = app.command(App(name="files", help="Upload and manage files", help_epilogue=FILES_HELP_EXAMPLES))
 files_app.command(
@@ -479,6 +476,10 @@ clusters_app.command(
     (f"{_CLI}.beta.clusters.get_credentials:get_credentials"),
     help="Get credentials for a cluster",
     help_epilogue=BETA_CLUSTERS_GET_CREDENTIALS_HELP_EXAMPLES,
+)
+clusters_app.command(
+    (f"{_CLI}.beta.clusters.ssh:ssh"),
+    help="SSH into a cluster via an OIDC-signed certificate",
 )
 
 ### Clusters > Storage API commands

--- a/src/together/lib/cli/api/beta/clusters/ssh.py
+++ b/src/together/lib/cli/api/beta/clusters/ssh.py
@@ -1,4 +1,4 @@
-"""`together ssh` — SSH into a Together cluster using a short-lived,
+"""`tg beta clusters ssh` — SSH into a Together cluster using a short-lived,
 OIDC-signed SSH certificate. No API key, no long-lived SSH key, no
 control-plane contact: every coordinate is derived from the cluster's Dex URL.
 

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -276,6 +276,9 @@ BETA_CLUSTERS_HELP_EXAMPLES = """[dim]Examples:[/dim]
 [dim]-[/dim] Manage node remediations:
   [primary]tg beta clusters remediations ls <cluster-id>[/primary]
   [primary]tg beta clusters remediations create <cluster-id> <instance-id> --mode VM_ONLY[/primary]
+
+[dim]-[/dim] SSH into a cluster (OIDC-signed certificate; see [primary]tg beta clusters ssh --help[/primary]):
+  [primary]tg beta clusters ssh https://dex.<base>/<cluster-id> --login <username>[/primary]
 """
 
 BETA_CLUSTERS_CREATE_HELP_EXAMPLES = """[dim]Examples:[/dim]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the OIDC-signed SSH command from the top-level CLI (`tg ssh`) into the beta clusters namespace (`tg beta clusters ssh`).

## Changes

- Relocated `ssh.py` from `together.lib.cli.api` to `together.lib.cli.api.beta.clusters`
- Registered the command under `clusters_app` instead of the root `app`
- Updated module docstring and beta clusters help examples

## Usage

```bash
# before
tg ssh https://dex.<base>/<cluster-id> --login <username>

# after
tg beta clusters ssh https://dex.<base>/<cluster-id> --login <username>
```

## Testing

- Verified `tg beta clusters --help` lists `ssh`
- Verified `tg ssh` no longer resolves (falls back to top-level help)
- Verified `tg beta clusters ssh --help` works
- `tests/cli/test_command_telemetry.py` and `tests/cli/test_main.py` pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a42cfa6-e751-4e46-86eb-b5bd8dda7c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a42cfa6-e751-4e46-86eb-b5bd8dda7c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

