### PR TITLE
[TCL-7576] Handle OIDC SSH callback port conflicts

### DIFF
--- a/src/together/lib/cli/api/beta/clusters/ssh.py
+++ b/src/together/lib/cli/api/beta/clusters/ssh.py
@@ -19,6 +19,7 @@ import os
 import ssl
 import json as json_lib
 import base64
+import socket
 import hashlib
 import secrets
 import tempfile
@@ -40,6 +41,9 @@ _CERT_ALGO = {
     "ecdsa": "ecdsa-sha2-nistp256-cert-v01@openssh.com",
     "ed25519": "ssh-ed25519-cert-v01@openssh.com",
 }
+_DEFAULT_REDIRECT_HOST = "localhost"
+_DEFAULT_REDIRECT_PATH = "/login-callback"
+_DEFAULT_REDIRECT_PORTS = (3000, 10001, 11110)
 
 
 def _http_json(
@@ -73,24 +77,52 @@ def _derive(dex_url: str) -> tuple[str, str]:
     return f"{u.scheme}://{u.hostname}/step-{cluster_id}", f"ssh.{cluster_id}.{base}"
 
 
-def _pkce_login(issuer: str, client_id: str, redirect_uri: str, scope: str) -> str:
+def _redirect_uri_for_port(port: int) -> str:
+    return f"http://{_DEFAULT_REDIRECT_HOST}:{port}{_DEFAULT_REDIRECT_PATH}"
+
+
+def _localhost_port_in_use(port: int) -> bool:
+    try:
+        with socket.create_connection((_DEFAULT_REDIRECT_HOST, port), timeout=0.2):
+            return True
+    except OSError:
+        return False
+
+
+def _callback_server(
+    redirect_uri: Optional[str],
+    handler: type[BaseHTTPRequestHandler],
+) -> tuple[HTTPServer, str]:
+    if redirect_uri is not None:
+        parsed = urllib.parse.urlparse(redirect_uri)
+        try:
+            return HTTPServer((parsed.hostname or _DEFAULT_REDIRECT_HOST, parsed.port or 80), handler), redirect_uri
+        except OSError as exc:
+            raise TogetherError(f"OIDC callback port is unavailable for {redirect_uri}: {exc}") from exc
+
+    for port in _DEFAULT_REDIRECT_PORTS:
+        if _localhost_port_in_use(port):
+            continue
+
+        candidate_uri = _redirect_uri_for_port(port)
+        try:
+            return HTTPServer((_DEFAULT_REDIRECT_HOST, port), handler), candidate_uri
+        except OSError:
+            continue
+
+    ports = "/".join(str(port) for port in _DEFAULT_REDIRECT_PORTS)
+    raise TogetherError(
+        f"OIDC login needs a local callback port, but {ports} are all in use. "
+        "Free one of them or pass a registered --redirect-uri."
+    )
+
+
+def _pkce_login(issuer: str, client_id: str, redirect_uri: Optional[str], scope: str) -> str:
     """Authorization-code + PKCE flow against Dex. Returns the raw id_token."""
     disc = _http_json(issuer.rstrip("/") + "/.well-known/openid-configuration")
     verifier = secrets.token_urlsafe(64)
     challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
     state = secrets.token_urlsafe(16)
-    parsed = urllib.parse.urlparse(redirect_uri)
-    params = {
-        "response_type": "code",
-        "client_id": client_id,
-        "redirect_uri": redirect_uri,
-        "scope": scope,
-        "state": state,
-        "nonce": secrets.token_urlsafe(16),
-        "code_challenge": challenge,
-        "code_challenge_method": "S256",
-    }
-    auth_url = disc["authorization_endpoint"] + "?" + urllib.parse.urlencode(params)
     captured: dict[str, str] = {}
 
     class _Handler(BaseHTTPRequestHandler):
@@ -111,7 +143,18 @@ def _pkce_login(issuer: str, client_id: str, redirect_uri: str, scope: str) -> s
             # Silence the default per-request logging to stderr.
             pass
 
-    server = HTTPServer((parsed.hostname or "localhost", parsed.port or 80), _Handler)
+    server, redirect_uri = _callback_server(redirect_uri, _Handler)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+        "state": state,
+        "nonce": secrets.token_urlsafe(16),
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    auth_url = disc["authorization_endpoint"] + "?" + urllib.parse.urlencode(params)
     console.print(f"[dim]Opening browser for login: {issuer}[/dim]")
     if not webbrowser.open(auth_url):
         console.print(f"Open this URL to log in:\n{auth_url}")
@@ -177,9 +220,7 @@ async def ssh(
     ca_url: Annotated[Optional[str], Parameter(help="Override step-ca URL (derived from DEX_URL)")] = None,
     bastion: Annotated[Optional[str], Parameter(help="Override bastion host (derived from DEX_URL)")] = None,
     client_id: Annotated[str, Parameter(help="Dex public client id")] = "together-cli",
-    redirect_uri: Annotated[
-        str, Parameter(help="OIDC redirect URI (registered on the Dex client)")
-    ] = "http://localhost:3000/login-callback",
+    redirect_uri: Annotated[Optional[str], Parameter(help="OIDC redirect URI (registered on the Dex client)")] = None,
     scope: Annotated[str, Parameter(help="OIDC scopes")] = "openid email",
     key_type: Annotated[str, Parameter(help="Ephemeral key type (ecdsa is KMS-compatible)")] = "ecdsa",
     ca_root: Annotated[Optional[str], Parameter(help="step-ca root cert (PEM) for TLS")] = None,

--- a/tests/cli/test_beta_clusters.py
+++ b/tests/cli/test_beta_clusters.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 import os
 import json
 import base64
+import socket
 from typing import Any, cast
+from http.server import BaseHTTPRequestHandler
+from typing_extensions import override
 
 import httpx
 import pytest
 from respx import MockRouter
 from respx.models import Call
 
+from together import TogetherError
 from tests.cli.utils import CliRunner
+from together.lib.cli.api.beta.clusters import ssh as ssh_cli
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -53,6 +58,64 @@ _VOLUME_BODY = {
     "size_tib": 2,
     "status": "available",
 }
+
+
+def _reserved_port() -> tuple[socket.socket, int]:
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    sock.listen(1)
+    return sock, int(sock.getsockname()[1])
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        self.send_response(200)
+        self.end_headers()
+
+    @override
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: ARG002
+        pass
+
+
+class TestBetaClustersSSHCallbackServer:
+    def test_localhost_port_in_use_detects_bound_listener(self) -> None:
+        busy_socket, busy_port = _reserved_port()
+
+        try:
+            assert ssh_cli._localhost_port_in_use(busy_port) is True
+        finally:
+            busy_socket.close()
+
+    def test_callback_server_uses_next_registered_port_when_first_is_busy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        busy_socket, busy_port = _reserved_port()
+        free_socket, free_port = _reserved_port()
+        free_socket.close()
+
+        try:
+            monkeypatch.setattr(ssh_cli, "_DEFAULT_REDIRECT_PORTS", (busy_port, free_port))
+
+            server, redirect_uri = ssh_cli._callback_server(None, _CallbackHandler)
+            try:
+                assert redirect_uri == f"http://localhost:{free_port}/login-callback"
+            finally:
+                server.server_close()
+        finally:
+            busy_socket.close()
+
+    def test_callback_server_explains_when_all_registered_ports_are_busy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        first_socket, first_port = _reserved_port()
+        second_socket, second_port = _reserved_port()
+
+        try:
+            monkeypatch.setattr(ssh_cli, "_DEFAULT_REDIRECT_PORTS", (first_port, second_port))
+
+            with pytest.raises(TogetherError, match="callback port"):
+                ssh_cli._callback_server(None, _CallbackHandler)
+        finally:
+            first_socket.close()
+            second_socket.close()
 
 
 def _remediation_body(remediation_id: str = "rem-1", **overrides: Any) -> dict[str, Any]:

--- a/uv.lock
+++ b/uv.lock
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "together"
-version = "2.21.0"
+version = "2.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- Make `tg beta clusters ssh` bind the first available registered OIDC callback port instead of always defaulting to `localhost:3000`.
- Keep `--redirect-uri` as an explicit override and return a clear error if all registered callback ports are busy.
- Add CLI unit coverage for fallback, localhost listener detection, and all-ports-busy behavior.

## Linear
https://linear.app/together-ai/issue/TCL-7576/handle-oidc-ssh-port-conflicts-on-port-3000

## Test plan
- [x] `uv sync --all-extras`
- [x] `./scripts/lint`
- [x] `uv run ruff format --check`
- [x] `uv run pytest tests/cli/test_beta_clusters.py`
- [x] Manual: installed this branch locally, occupied `localhost:3000`, ran `tg beta clusters ssh ... --host invalid-host`, completed OIDC login, and reached SSH (expected `invalid-host` failure)
- [x] Manual: occupied `localhost:3000` and `localhost:10001`, ran without `--redirect-uri`, completed OIDC login, and reached SSH via fallback port (expected `invalid-host` failure)
- [x] Manual: occupied `localhost:3000`, `localhost:10001`, and `localhost:11110`; command returned a clear local callback-port error