### PR TITLE
Rename dedicated-endpoint "Inference Name" to "Endpoint string" for consistency

### DIFF
--- a/src/together/lib/cli/api/beta/endpoints/deploy.py
+++ b/src/together/lib/cli/api/beta/endpoints/deploy.py
@@ -51,7 +51,7 @@ EndpointParameter = Annotated[
         help="""Endpoint that will contain the deployment.
 
 - Pass an existing endpoint name or ID (ep_...) to add a deployment to it.
-- Pass a new name to create the endpoint first. This name becomes the endpoint's immutable inference name.""",
+- Pass a new name to create the endpoint first. This name becomes the endpoint's immutable endpoint string.""",
     ),
     PromptParameter(instructions="What name would you like to use for your endpoint?", message="Endpoint Name"),
 ]

--- a/src/together/lib/cli/api/beta/endpoints/retrieve.py
+++ b/src/together/lib/cli/api/beta/endpoints/retrieve.py
@@ -162,7 +162,7 @@ def render_header(endpoint: Endpoint, ab_experiments: list[AbExperiment], shadow
     header_table = Table(expand=True, show_header=False, show_edge=False, show_lines=False, box=None, pad_edge=False)
     header_table.add_column("Key", justify="right", style="dim")
     header_table.add_column("Value", justify="left", ratio=4)
-    header_table.add_row("  Inference Name", endpoint.name)
+    header_table.add_row("  Endpoint string", endpoint.name)
     header_table.add_row("  Endpoint ID", endpoint.id)
     header_table.add_row("  Created at", format_datetime(endpoint.created_at))
     if endpoint.updated_at:


### PR DESCRIPTION
## Rationale

For a dedicated endpoint, the value `<project_slug>/<endpoint_name>` that you pass as the `model` parameter to send inference requests is being standardized as the **"endpoint string"**. The web console already labels it "Endpoint string", and the Together AI docs are being updated to match. The CLI, however, still called it "Inference Name" / "inference name". This PR aligns the CLI wording.

## Changed (hand-written CLI, endpoint context)

- `src/together/lib/cli/api/beta/endpoints/deploy.py:54` — `endpoint` parameter help text:
  - before: `...This name becomes the endpoint's immutable inference name.`
  - after: `...This name becomes the endpoint's immutable endpoint string.`
- `src/together/lib/cli/api/beta/endpoints/retrieve.py:165` — endpoint detail table label:
  - before: `header_table.add_row("  Inference Name", endpoint.name)`
  - after: `header_table.add_row("  Endpoint string", endpoint.name)`
  - (leading spaces preserved for column alignment.)

## Intentionally NOT changed

**Model "inference name" (a different concept).** A model has its own inference-addressable name; renaming it to "endpoint string" would be wrong.
- `src/together/lib/cli/api/beta/models/_utils.py:106` — `_print_detail_line("Inference Name", model.name)` (hand-written, model context).
- `src/together/resources/beta/models/models.py:207,771` — "model metadata such as its inference name" (generated, model context).

**Generated SDK docstrings (endpoint context, but Stainless-generated).** These come from the OpenAPI spec and would be overwritten on the next SDK regeneration, so editing them here is not durable. They need a fix at the OpenAPI/Stainless source. File:line references for follow-up:
- `src/together/types/beta/endpoints/deployment_create_params.py:25` — "Returned as a project- and endpoint-qualified inference name."
- `src/together/resources/beta/endpoints/deployments.py:87,491` — "endpoint-qualified inference name."
- `src/together/resources/beta/endpoints/endpoints.py:250,824` — "Updates mutable endpoint fields such as its inference name, ..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)