### PR TITLE
MOSH-3441: CLI: show resolved <project_slug>/<model_name> output model in fine-tuning retrieve

### DIFF
--- a/src/together/lib/cli/api/fine_tuning/retrieve.py
+++ b/src/together/lib/cli/api/fine_tuning/retrieve.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from together.types import FinetuneResponse
 
 _NEST_INDENT = 4
-_MODELS_PAGE_URL = "https://api.together.ai/models"
 
 
 def _output_model_line(response: FinetuneResponse) -> str | None:
@@ -32,7 +31,7 @@ def _output_model_line(response: FinetuneResponse) -> str | None:
         return None
     object_id = response.api_model_object_id
     if object_id is not None:
-        return f"[link={_MODELS_PAGE_URL}/{object_id}]{name}[/link]"
+        return f"[link=https://api.together.ai/models/{object_id}]{name}[/link]"
     return name
 
 

--- a/src/together/lib/cli/api/fine_tuning/retrieve.py
+++ b/src/together/lib/cli/api/fine_tuning/retrieve.py
@@ -25,14 +25,13 @@ def _output_model_line(response: FinetuneResponse) -> str | None:
     """The server-resolved ``<project_slug>/<model_name>`` output model, linked to its model page.
 
     ``model_object_name`` is resolved on the fly by the API; the page URL keys off the model object
-    id. Returns ``None`` when the job has no resolved output model, so the caller falls back to the
-    raw output name in the response dump.
+    id. Returns ``None`` when the job has no resolved output model.
     """
     name = response.model_object_name
-    if not name:
+    if name is None:
         return None
     object_id = response.api_model_object_id
-    if object_id:
+    if object_id is not None:
         return f"[link={_MODELS_PAGE_URL}/{object_id}]{name}[/link]"
     return name
 
@@ -62,6 +61,8 @@ async def retrieve(
     output_model = _output_model_line(response)
     if output_model is not None:
         console.print(f"[bold]Output model:[/bold] {output_model}")
+        # Shown above already; drop it from the dump so the name isn't printed twice.
+        response.model_object_name = None
 
     print_model_dump(response, show_nulls=False)
 

--- a/src/together/lib/cli/api/fine_tuning/retrieve.py
+++ b/src/together/lib/cli/api/fine_tuning/retrieve.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 from datetime import datetime
 
 from cyclopts import Parameter
@@ -14,7 +14,27 @@ from together.lib.cli.components.loader import show_loading_status
 from together.lib.cli.components.model_dump import print_model_dump
 from together.lib.cli.components.plot_finetune_metrics import METRICS_WIDTH_PADDING, metrics_block_sparklines
 
+if TYPE_CHECKING:
+    from together.types import FinetuneResponse
+
 _NEST_INDENT = 4
+_MODELS_PAGE_URL = "https://api.together.ai/models"
+
+
+def _output_model_line(response: FinetuneResponse) -> str | None:
+    """The server-resolved ``<project_slug>/<model_name>`` output model, linked to its model page.
+
+    ``model_object_name`` is resolved on the fly by the API; the page URL keys off the model object
+    id. Returns ``None`` when the job has no resolved output model, so the caller falls back to the
+    raw output name in the response dump.
+    """
+    name = response.model_object_name
+    if not name:
+        return None
+    object_id = response.api_model_object_id
+    if object_id:
+        return f"[link={_MODELS_PAGE_URL}/{object_id}]{name}[/link]"
+    return name
 
 
 async def retrieve(
@@ -38,6 +58,10 @@ async def retrieve(
     if response.status not in COMPLETED_STATUSES:
         progress_text = generate_progress_bar(response, datetime.now().astimezone(), use_rich=True)
         console.print(progress_text)
+
+    output_model = _output_model_line(response)
+    if output_model is not None:
+        console.print(f"[bold]Output model:[/bold] {output_model}")
 
     print_model_dump(response, show_nulls=False)
 

--- a/src/together/types/finetune_response.py
+++ b/src/together/types/finetune_response.py
@@ -190,6 +190,9 @@ class FinetuneResponse(BaseModel):
     api_model_object_id: Optional[str] = FieldInfo(alias="model_object_id", default=None)
     """Together model registry object ID for the final model weights (e.g. `ml_...`)."""
 
+    model_object_name: Optional[str] = None
+    """Qualified output model name `<project_slug>/<model_name>`, resolved server-side."""
+
     api_model_object_revision_id: Optional[str] = FieldInfo(alias="model_object_revision_id", default=None)
     """Together model registry revision ID for the final model weights (e.g.
 

--- a/tests/cli/test_fine_tuning_retrieve.py
+++ b/tests/cli/test_fine_tuning_retrieve.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from together.types import FinetuneResponse
+from together.lib.cli.api.fine_tuning.retrieve import _output_model_line
+
+
+def _resp(*, model_object_name: str | None, model_object_id: str | None) -> FinetuneResponse:
+    # model_construct keys off aliases: model_object_id -> api_model_object_id.
+    return FinetuneResponse.model_construct(model_object_name=model_object_name, model_object_id=model_object_id)
+
+
+def test_output_model_line_links_by_object_id() -> None:
+    line = _output_model_line(_resp(model_object_name="acme-corp/m", model_object_id="ml_1"))
+    assert line == "[link=https://api.together.ai/models/ml_1]acme-corp/m[/link]"
+
+
+def test_output_model_line_bare_name_without_object_id() -> None:
+    line = _output_model_line(_resp(model_object_name="acme-corp/m", model_object_id=None))
+    assert line == "acme-corp/m"
+
+
+def test_output_model_line_none_when_unresolved() -> None:
+    assert _output_model_line(_resp(model_object_name=None, model_object_id="ml_1")) is None


### PR DESCRIPTION
`tg fine-tuning retrieve` now shows an **Output model** line with the qualified `<project_slug>/<model_name>` name, hyperlinked to the model page (`https://api.together.ai/models/<model_object_id>`). Falls back to the raw response dump when the field is absent.

The value comes from a new **`model_object_name`** field on `FinetuneResponse`, resolved server-side in Shaping (see togethercomputer/together-shaping#4042) — the SDK does no client-side lookup.

Depends on the Shaping change landing (the field is empty until then, so this degrades gracefully). ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)