### PR TITLE
fix: Ensure deploy CLI command works with existing endpoint

### DIFF
--- a/src/together/lib/cli/api/beta/endpoints/_utils/_resolve_model.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_resolve_model.py
@@ -358,15 +358,19 @@ async def resolve_endpoint(config: CLIConfigParameter, endpoint_id_or_name: str)
     if endpoint_id_or_name.startswith("ep_"):
         return await config.client.beta.endpoints.retrieve(id=endpoint_id_or_name)
 
+    bare_name = endpoint_id_or_name.rsplit("/", 1)[-1]
+    # Exact name filter avoids missing endpoints beyond the first list page.
+    endpoints = await config.client.beta.endpoints.list(filter=f'name="{bare_name}"')
+
     me = await config.client.whoami()
-    if endpoint_id_or_name.startswith(f"{me.project_slug}/") is False:
-        endpoint_id_or_name = f"{me.project_slug}/{endpoint_id_or_name}"
+    qualified_name = (
+        endpoint_id_or_name
+        if endpoint_id_or_name.startswith(f"{me.project_slug}/")
+        else f"{me.project_slug}/{bare_name}"
+    )
 
-    # TODO: loop through pagination
-    endpoints = await config.client.beta.endpoints.list()
-
-    for endpoint in endpoints.data:
-        if endpoint.name == endpoint_id_or_name:
+    for endpoint in endpoints.data or []:
+        if endpoint.name == qualified_name or endpoint.name.rsplit("/", 1)[-1] == bare_name:
             return endpoint
 
     raise ValueError(f"Endpoint {endpoint_id_or_name} not found.")

--- a/src/together/lib/cli/api/beta/endpoints/deploy.py
+++ b/src/together/lib/cli/api/beta/endpoints/deploy.py
@@ -9,7 +9,7 @@ from rich.panel import Panel
 from rich.table import Table
 from cyclopts.validators import Number
 
-from together import APIError, omit
+from together import ConflictError, omit
 from together.types.beta import Model, Endpoint, DeploymentAutoscalingParam
 from together._utils._json import openapi_dumps
 from together.types.beta.models import Config
@@ -31,6 +31,7 @@ from together.types.beta.endpoints.deployment_create_params import (
 )
 from together.lib.cli.api.beta.endpoints._utils._resolve_model import (
     MODEL_PATH_RE,
+    resolve_endpoint,
     construct_model_path,
     resolve_model_and_config,
 )
@@ -358,24 +359,9 @@ async def _find_or_create_endpoint(config: CLIConfigParameter, endpoint_input: s
         endpoint = await config.client.beta.endpoints.retrieve(id=endpoint_input)
         return endpoint, False
 
-    # If the user gave us an endpoint name, we need to try to create it.
-    # The API will fail if the name conflicts, in which case we know the intent is to reuse
-    # an existing endpoint.
-    #
-    # The exception block will then search through the endpoints for the matching name.
+    # Create first; on name conflict, reuse the existing endpoint.
     try:
         endpoint = await config.client.beta.endpoints.create(name=endpoint_input)
         return endpoint, True
-    except APIError as e:
-        me = await config.client.whoami()
-        # Endpoint names in API include the project slug, so we add it if the user did not provide it.
-        endpoint_name = (
-            f"{me.project_slug}/{endpoint_input}" if not endpoint_input.startswith(me.project_slug) else endpoint_input
-        )
-        if "already exists" in e.message.lower():
-            # TODO: Paginate through the endpoints and find the matching name.
-            endpoints = await config.client.beta.endpoints.list()
-            for endpoint in endpoints.data:
-                if endpoint.name == endpoint_name:
-                    return endpoint, False
-        raise e
+    except ConflictError:
+        return await resolve_endpoint(config, endpoint_input), False

--- a/tests/cli/test_beta_endpoints.py
+++ b/tests/cli/test_beta_endpoints.py
@@ -301,8 +301,14 @@ class TestBetaEndpointsList:
 
         output = " ".join(result.output.split())
         assert result.exit_code == 0
-        assert "ls: List project, organization, or public endpoints" in output
+        # Agent formatter: "ls: …"; human/Rich formatter: "ls …" (no colon).
+        assert "List project, organization, or public endpoints" in output
+        assert (
+            "ls: List project, organization, or public endpoints" in output
+            or "ls List project, organization, or public endpoints" in output
+        )
         assert "list: List project, organization, or public endpoints" not in output
+        assert "list List project, organization, or public endpoints" not in output
 
     @pytest.mark.parametrize("command", ["list", "ls"])
     @pytest.mark.respx(base_url=base_url)

--- a/tests/cli/test_beta_endpoints.py
+++ b/tests/cli/test_beta_endpoints.py
@@ -233,6 +233,67 @@ class TestBetaEndpointsDeploy:
         assert result.exit_code == 0, result.output
         assert create_deployment_route.call_count == 1
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_deploy_reuses_endpoint_when_name_already_exists(
+        self, respx_mock: MockRouter, cli_runner: CliRunner
+    ) -> None:
+        _mock_model_and_config(respx_mock)
+        respx_mock.post("/projects/proj/endpoints").mock(
+            return_value=httpx.Response(
+                409,
+                json={
+                    "code": 6,
+                    "message": "Already Exists",
+                    "details": [
+                        {
+                            "@type": "type.googleapis.com/common.errors.v1.ProblemDetail",
+                            "type": "https://api.together.ai/problems/already-exists",
+                            "title": "Already Exists",
+                            "status": 409,
+                            "detail": "Already Exists",
+                        }
+                    ],
+                },
+            )
+        )
+        respx_mock.get("/whoami").mock(return_value=httpx.Response(200, json=_whoami_body()))
+        list_route = respx_mock.get("/projects/proj/endpoints").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [_endpoint_body(name="my-project/test")],
+                    "next_cursor": None,
+                },
+            )
+        )
+        create_deployment_route = respx_mock.post("/projects/proj/endpoints/ep_1/deployments").mock(
+            return_value=httpx.Response(200, json=_deployment_body())
+        )
+
+        result = cli_runner.invoke(
+            [
+                "beta",
+                "endpoints",
+                "deploy",
+                "--project",
+                "proj",
+                "--endpoint",
+                "test",
+                "--model",
+                "ml_1",
+                "--config",
+                "cr_1",
+                "--deployment-name",
+                "my-dep",
+                "--json",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert create_deployment_route.call_count == 1
+        assert "filter=name%3D%22test%22" in str(cast(Call, list_route.calls[0]).request.url)
+
 
 class TestBetaEndpointsList:
     def test_list_alias_is_hidden_from_help(self, cli_runner: CliRunner) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "together"
-version = "2.26.1"
+version = "2.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This fixes a bug where matching on name failed if the endpoint was past the first page.