### PR TITLE
Allow auto `beta endpoints get` with endpoint/deployment names

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ async with client.beta.realtime.transcription(
 
     async for event in session:
         if isinstance(event, TranscriptDelta):
-            print("interim:", event.text)   # updates while a phrase is spoken
+            print("interim:", event.text)  # updates while a phrase is spoken
         elif isinstance(event, TranscriptCompleted):
-            print("final:", event.text)     # one per finished utterance
+            print("final:", event.text)  # one per finished utterance
 
     transcript = await session.flush()  # finalize whatever was said last
 ```

--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -662,7 +662,7 @@ beta_endpoints_app.command(
 beta_endpoints_app.command(
     (f"{_CLI}.beta.endpoints.retrieve:retrieve"),
     name="get",
-    help="Get endpoint or deployment details by ID",
+    help="Get endpoint or deployment details by name or ID",
     help_epilogue=BETA_ENDPOINTS_GET_HELP_EXAMPLES,
     sort_key=3,
 )

--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -666,9 +666,11 @@ beta_endpoints_app.command(
     help_epilogue=BETA_ENDPOINTS_GET_HELP_EXAMPLES,
     sort_key=3,
 )
-beta_endpoints_app.command(
-    (f"{_CLI}.beta.endpoints.retrieve:retrieve"), show=False
-)  # This is just here to allow the default command to work
+# Explicit `retrieve` stays registered (hidden) for `tg beta endpoints retrieve …`.
+beta_endpoints_app.command((f"{_CLI}.beta.endpoints.retrieve:retrieve"), show=False)
+# Implicit get: `tg beta endpoints <name-or-id>` — cyclopts App.default, not token rewriting.
+# (Nested meta.default is not invoked by the root meta launcher's parse_known_args.)
+beta_endpoints_app.default(beta_endpoints_app["retrieve"].default_command)
 beta_endpoints_app.command(
     (f"{_CLI}.beta.endpoints.update:update"),
     help="Update a deployment's name, autoscaling, or traffic weight",

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_find_endpoint_by_deployment.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_find_endpoint_by_deployment.py
@@ -1,20 +1,50 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
 from together import AsyncClient, omit
 from together.types.beta import Endpoint
 
 
+def _deployment_matches(deployment_id_or_name: str, deployment_id: str, deployment_name: Optional[str]) -> bool:
+    if deployment_id == deployment_id_or_name:
+        return True
+    # IDs only match on the id field — never fall through to name equality.
+    if deployment_id_or_name.startswith("dep_"):
+        return False
+    if deployment_name is None:
+        return False
+    if deployment_name == deployment_id_or_name:
+        return True
+    return deployment_name.rsplit("/", 1)[-1] == deployment_id_or_name.rsplit("/", 1)[-1]
+
+
 async def find_endpoint_by_deployment(
     client: AsyncClient,
-    deployment_id: str,
+    deployment_id_or_name: str,
 ) -> Endpoint:
-    cursor: str | None = None
+    """Find the parent endpoint for a deployment ID (`dep_...`) or deployment name."""
+    cursor: Optional[str] = None
     while True:
         page = await client.beta.endpoints.list(after=cursor or omit)
         for endpoint in page.data:
             for deployment in endpoint.deployments or []:
-                if deployment.id == deployment_id:
+                if _deployment_matches(deployment_id_or_name, deployment.id, deployment.name):
                     return endpoint
         if not page.next_cursor:
             break
         cursor = page.next_cursor
 
-    raise ValueError(f"Deployment {deployment_id} not found in any endpoint.")
+    raise ValueError(f"Deployment {deployment_id_or_name} not found in any endpoint.")
+
+
+async def resolve_deployment_id(
+    client: AsyncClient,
+    deployment_id_or_name: str,
+) -> Tuple[Endpoint, str]:
+    """Resolve a deployment ID or name to ``(parent_endpoint, deployment_id)``."""
+    endpoint = await find_endpoint_by_deployment(client, deployment_id_or_name)
+    for deployment in endpoint.deployments or []:
+        if _deployment_matches(deployment_id_or_name, deployment.id, deployment.name):
+            return endpoint, deployment.id
+    raise ValueError(f"Deployment {deployment_id_or_name} not found in any endpoint.")

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_find_endpoint_by_deployment.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_find_endpoint_by_deployment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Tuple, Optional
 
 from together import AsyncClient, omit
 from together.types.beta import Endpoint

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_find_endpoint_by_deployment.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_find_endpoint_by_deployment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Optional
+from typing import List, Tuple, Optional
 
 from together import AsyncClient, omit
 from together.types.beta import Endpoint
@@ -19,23 +19,52 @@ def _deployment_matches(deployment_id_or_name: str, deployment_id: str, deployme
     return deployment_name.rsplit("/", 1)[-1] == deployment_id_or_name.rsplit("/", 1)[-1]
 
 
-async def find_endpoint_by_deployment(
+async def _collect_deployment_matches(
     client: AsyncClient,
     deployment_id_or_name: str,
-) -> Endpoint:
-    """Find the parent endpoint for a deployment ID (`dep_...`) or deployment name."""
+) -> List[Tuple[Endpoint, str]]:
+    """Return ``(endpoint, deployment_id)`` for every matching deployment across all pages."""
+    matches: List[Tuple[Endpoint, str]] = []
+    # Deployment IDs are unique — stop once we find one. Names can collide across endpoints.
+    match_by_id = deployment_id_or_name.startswith("dep_")
     cursor: Optional[str] = None
     while True:
         page = await client.beta.endpoints.list(after=cursor or omit)
         for endpoint in page.data:
             for deployment in endpoint.deployments or []:
                 if _deployment_matches(deployment_id_or_name, deployment.id, deployment.name):
-                    return endpoint
+                    matches.append((endpoint, deployment.id))
+                    if match_by_id:
+                        return matches
         if not page.next_cursor:
             break
         cursor = page.next_cursor
+    return matches
 
-    raise ValueError(f"Deployment {deployment_id_or_name} not found in any endpoint.")
+
+def _require_unique_deployment_match(
+    deployment_id_or_name: str,
+    matches: List[Tuple[Endpoint, str]],
+) -> Tuple[Endpoint, str]:
+    if not matches:
+        raise ValueError(f"Deployment {deployment_id_or_name} not found in any endpoint.")
+    if len(matches) > 1:
+        raise ValueError(f"""Multiple deployments found for "{deployment_id_or_name}".
+Please specify a deployment ID (dep_...) or a fully qualified deployment name.
+""")
+    return matches[0]
+
+
+async def find_endpoint_by_deployment(
+    client: AsyncClient,
+    deployment_id_or_name: str,
+) -> Endpoint:
+    """Find the parent endpoint for a deployment ID (`dep_...`) or deployment name."""
+    endpoint, _deployment_id = _require_unique_deployment_match(
+        deployment_id_or_name,
+        await _collect_deployment_matches(client, deployment_id_or_name),
+    )
+    return endpoint
 
 
 async def resolve_deployment_id(
@@ -43,8 +72,7 @@ async def resolve_deployment_id(
     deployment_id_or_name: str,
 ) -> Tuple[Endpoint, str]:
     """Resolve a deployment ID or name to ``(parent_endpoint, deployment_id)``."""
-    endpoint = await find_endpoint_by_deployment(client, deployment_id_or_name)
-    for deployment in endpoint.deployments or []:
-        if _deployment_matches(deployment_id_or_name, deployment.id, deployment.name):
-            return endpoint, deployment.id
-    raise ValueError(f"Deployment {deployment_id_or_name} not found in any endpoint.")
+    return _require_unique_deployment_match(
+        deployment_id_or_name,
+        await _collect_deployment_matches(client, deployment_id_or_name),
+    )

--- a/src/together/lib/cli/api/beta/endpoints/retrieve.py
+++ b/src/together/lib/cli/api/beta/endpoints/retrieve.py
@@ -18,12 +18,19 @@ from together.types.beta.endpoints import AbExperiment, ShadowExperiment
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.list import ListTable
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.api.beta.endpoints._utils._resolve_model import resolve_model
-from together.lib.cli.api.beta.endpoints._utils._find_endpoint_by_deployment import find_endpoint_by_deployment
+from together.lib.cli.api.beta.endpoints._utils._resolve_model import resolve_endpoint, resolve_model
+from together.lib.cli.api.beta.endpoints._utils._find_endpoint_by_deployment import resolve_deployment_id
 
 
 async def retrieve(
-    id: Annotated[str, Parameter(help="Endpoint ID (ep_...) or deployment ID (dep_...) to retrieve")],
+    id: Annotated[
+        str,
+        Parameter(
+            help=(
+                "Endpoint name, endpoint ID (ep_...), deployment name, or deployment ID (dep_...) to retrieve"
+            )
+        ),
+    ],
     *,
     config: CLIConfigParameter,
 ) -> None:
@@ -32,13 +39,24 @@ async def retrieve(
         await _retrieve_deployment(id, config=config)
         return
 
-    await _retrieve_endpoint(id, config=config)
+    if id.startswith("ep_"):
+        await _retrieve_endpoint(id, config=config)
+        return
+
+    try:
+        endpoint = await resolve_endpoint(config, id)
+    except ValueError:
+        # Not an endpoint name — try as a deployment name before failing.
+        await _retrieve_deployment(id, config=config)
+        return
+
+    await _retrieve_endpoint(endpoint.id, config=config)
 
 
-async def _retrieve_deployment(deployment_id: str, *, config: CLIConfigParameter) -> None:
-    endpoint = await show_loading_status(
+async def _retrieve_deployment(deployment_id_or_name: str, *, config: CLIConfigParameter) -> None:
+    endpoint, deployment_id = await show_loading_status(
         "Resolving deployment...",
-        find_endpoint_by_deployment(config.client, deployment_id),
+        resolve_deployment_id(config.client, deployment_id_or_name),
     )
     deployment = await show_loading_status(
         "Loading deployment...",

--- a/src/together/lib/cli/api/beta/endpoints/retrieve.py
+++ b/src/together/lib/cli/api/beta/endpoints/retrieve.py
@@ -26,9 +26,7 @@ async def retrieve(
     id: Annotated[
         str,
         Parameter(
-            help=(
-                "Endpoint name, endpoint ID (ep_...), deployment name, or deployment ID (dep_...) to retrieve"
-            )
+            help=("Endpoint name, endpoint ID (ep_...), deployment name, or deployment ID (dep_...) to retrieve")
         ),
     ],
     *,

--- a/src/together/lib/cli/api/beta/endpoints/retrieve.py
+++ b/src/together/lib/cli/api/beta/endpoints/retrieve.py
@@ -18,7 +18,7 @@ from together.types.beta.endpoints import AbExperiment, ShadowExperiment
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.list import ListTable
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.api.beta.endpoints._utils._resolve_model import resolve_endpoint, resolve_model
+from together.lib.cli.api.beta.endpoints._utils._resolve_model import resolve_model, resolve_endpoint
 from together.lib.cli.api.beta.endpoints._utils._find_endpoint_by_deployment import resolve_deployment_id
 
 

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -282,7 +282,7 @@ BETA_ENDPOINTS_HELP_EXAMPLES = """[dim]Examples:[/dim]
   [primary]tg beta endpoints ls[/primary]
 
 [dim]-[/dim] Inspect an endpoint or deployment:
-  [primary]tg beta endpoints <endpoint-or-deployment-id>[/primary]
+  [primary]tg beta endpoints <endpoint-or-deployment-name-or-id>[/primary]
 
 [dim]-[/dim] Scale a deployment and adjust its traffic weight:
   [primary]tg beta endpoints update <deployment-id> --min-replicas 2 --max-replicas 8 --traffic-weight 1[/primary]
@@ -391,14 +391,16 @@ BETA_ENDPOINTS_LS_HELP_EXAMPLES = """[dim]Examples:[/dim]
 """
 
 BETA_ENDPOINTS_GET_HELP_EXAMPLES = """[dim]Examples:[/dim]
-[dim]-[/dim] Get endpoint details (includes deployments and traffic split):
+[dim]-[/dim] Get endpoint details by name or ID (includes deployments and traffic split):
+  [primary]tg beta endpoints my-endpoint[/primary]
   [primary]tg beta endpoints ep_xxxxxxxxxxxx[/primary]
 
-[dim]-[/dim] Get a single deployment:
+[dim]-[/dim] Get a single deployment by name or ID:
+  [primary]tg beta endpoints control[/primary]
   [primary]tg beta endpoints dep_xxxxxxxxxxxx[/primary]
 
 [dim]-[/dim] Machine-readable output:
-  [primary]tg beta endpoints ep_xxxxxxxxxxxx --json[/primary]
+  [primary]tg beta endpoints my-endpoint --json[/primary]
 """
 
 ## Beta models API commands

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -84,7 +84,7 @@ def _telemetry_command_for_default(
     if parsed_command.endswith(f" {default_name}") or parsed_command == default_name:
         return parsed_command
     if not parsed_command:
-        return default_name
+        return str(default_name)
     return f"{parsed_command} {default_name}"
 
 

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -14,7 +14,9 @@ _COMMAND_ID_IDENTIFIERS = {
     "evals": re.compile(r"^eval-"),
     "endpoints": re.compile(r"^endpoint-"),
     "beta models configs": re.compile(r"^ep_"),
-    "beta endpoints": re.compile(r"^(ep_|dep_)"),
+    # Any non-flag token: registered subcommands are already consumed by parse_commands,
+    # so leftover args are treated as an endpoint/deployment id or name for retrieve.
+    "beta endpoints": re.compile(r"^(?!--).+"),
     "beta models": re.compile(r"^ml_"),
     "beta endpoints deployments": re.compile(r"^dep_"),
     "beta clusters": _UUID_RE,

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -14,9 +14,7 @@ _COMMAND_ID_IDENTIFIERS = {
     "evals": re.compile(r"^eval-"),
     "endpoints": re.compile(r"^endpoint-"),
     "beta models configs": re.compile(r"^ep_"),
-    # Any non-flag token: registered subcommands are already consumed by parse_commands,
-    # so leftover args are treated as an endpoint/deployment id or name for retrieve.
-    "beta endpoints": re.compile(r"^(?!--).+"),
+    # `beta endpoints` uses App.default(retrieve) instead of token rewriting.
     "beta models": re.compile(r"^ml_"),
     "beta endpoints deployments": re.compile(r"^dep_"),
     "beta clusters": _UUID_RE,
@@ -25,12 +23,18 @@ _COMMAND_ID_IDENTIFIERS = {
     "beta jig volumes": _UUID_RE,
 }
 
+# Help/version flags registered on every App — not user subcommands.
+_BUILTIN_APP_COMMAND_NAMES = frozenset({"--help", "-h", "--version"})
+
 
 def _expand_implicit_retrieve_tokens(app: App, *tokens: str) -> list[str]:
     """
     Some commands (e.g. ft, eval, endpoint, cluster, volume) allow the user to provide an ID instead of a command.
     When this happens, we need to expand the tokens to include the retrieve command.
     For example, if the user runs "tg ft ft-12345678-90ab", we need to expand it to "tg ft retrieve ft-12345678-90ab".
+
+    ``beta endpoints`` is intentionally excluded: it registers retrieve via ``App.default``, so cyclopts
+    binds leftover tokens without rewriting argv.
     """
 
     (command_tokens, _app, args_tokens) = app.parse_commands(tokens)
@@ -45,6 +49,43 @@ def _expand_implicit_retrieve_tokens(app: App, *tokens: str) -> list[str]:
         return list(command_tokens) + ["retrieve"] + list(args_tokens)
 
     return list(tokens)
+
+
+def _leaf_app_has_user_commands(leaf: App) -> bool:
+    """True when ``leaf`` is a command group (has subcommands), not a single-command App."""
+    for name in leaf:
+        if name not in _BUILTIN_APP_COMMAND_NAMES:
+            return True
+    return False
+
+
+def _telemetry_command_for_default(
+    parsed_command: str,
+    apps: tuple[App, ...] | list[App],
+    rest_after_chain: list[str] | tuple[str, ...],
+) -> str:
+    """
+    When a command-group App has ``default_command`` and leftover non-flag args, cyclopts will run
+    that default (e.g. ``tg beta endpoints <name>`` → retrieve). Attribute telemetry to that default.
+    """
+    if not apps or not rest_after_chain:
+        return parsed_command
+    if str(rest_after_chain[0]).startswith("-"):
+        return parsed_command
+
+    leaf = apps[-1]
+    default_command = leaf.default_command
+    if default_command is None or not _leaf_app_has_user_commands(leaf):
+        return parsed_command
+
+    default_name = getattr(default_command, "__name__", None)
+    if not default_name:
+        return parsed_command
+    if parsed_command.endswith(f" {default_name}") or parsed_command == default_name:
+        return parsed_command
+    if not parsed_command:
+        return default_name
+    return f"{parsed_command} {default_name}"
 
 
 def _long_option_names_in_tokens(tokens: list[str]) -> list[str]:
@@ -106,7 +147,7 @@ def preparse_tokens(app: App, tokens: list[str]) -> tuple[str, list[str], bool, 
     """
     argv = list(tokens)
     argv = _expand_implicit_retrieve_tokens(app, *argv)
-    chain, _, rest_after_chain = app.parse_commands(argv, include_parent_meta=False)
+    chain, apps, rest_after_chain = app.parse_commands(argv, include_parent_meta=False)
     legacy_cmd, legacy_beta = _legacy_command_before_first_option(argv)
 
     if chain:
@@ -119,6 +160,9 @@ def preparse_tokens(app: App, tokens: list[str]) -> tuple[str, list[str], bool, 
     else:
         parsed_command = legacy_cmd
         is_beta_command = legacy_beta
+
+    # App.default handlers (e.g. beta endpoints retrieve) don't rewrite argv; still tag telemetry.
+    parsed_command = _telemetry_command_for_default(parsed_command, apps, rest_after_chain)
 
     explicit_args: list[str] = []
     try:

--- a/tests/cli/test_beta_endpoints_retrieve.py
+++ b/tests/cli/test_beta_endpoints_retrieve.py
@@ -59,6 +59,29 @@ def _deployment_body(**overrides: Any) -> dict[str, Any]:
     return body
 
 
+def _whoami_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "api_key_id": "key-1",
+        "organization_id": "org-1",
+        "organization_name": "Acme",
+        "project_id": "proj",
+        "project_name": "My Project",
+        "project_slug": "my-project",
+        "user_id": "user-1",
+    }
+    body.update(overrides)
+    return body
+
+
+def _mock_endpoint_get_side_resources(respx_mock: MockRouter) -> None:
+    respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+        return_value=httpx.Response(200, json={"object": "list", "data": [], "next_cursor": None})
+    )
+    respx_mock.get("/projects/proj/endpoints/ep_1/shadowExperiments").mock(
+        return_value=httpx.Response(200, json={"object": "list", "data": [], "next_cursor": None})
+    )
+
+
 class TestBetaEndpointsRetrieve:
     @pytest.mark.respx(base_url=base_url)
     def test_retrieve_deployment_id(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
@@ -92,6 +115,69 @@ class TestBetaEndpointsRetrieve:
         )
 
         result = cli_runner.invoke(["beta", "endpoints", "dep_control", "--project", "proj", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["id"] == "dep_control"
+        assert payload["endpointId"] == "ep_1"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_retrieve_endpoint_by_name(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/whoami").mock(return_value=httpx.Response(200, json=_whoami_body()))
+        respx_mock.get("/projects/proj/endpoints").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_endpoint_body()], "next_cursor": None},
+            )
+        )
+        respx_mock.get("/projects/proj/endpoints/ep_1").mock(
+            return_value=httpx.Response(200, json=_endpoint_body())
+        )
+        _mock_endpoint_get_side_resources(respx_mock)
+
+        result = cli_runner.invoke(["beta", "endpoints", "get", "my-endpoint", "--project", "proj", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["id"] == "ep_1"
+        assert payload["name"] == "my-project/my-endpoint"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_implicit_retrieve_endpoint_by_name(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/whoami").mock(return_value=httpx.Response(200, json=_whoami_body()))
+        respx_mock.get("/projects/proj/endpoints").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_endpoint_body()], "next_cursor": None},
+            )
+        )
+        respx_mock.get("/projects/proj/endpoints/ep_1").mock(
+            return_value=httpx.Response(200, json=_endpoint_body())
+        )
+        _mock_endpoint_get_side_resources(respx_mock)
+
+        result = cli_runner.invoke(["beta", "endpoints", "my-endpoint", "--project", "proj", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["id"] == "ep_1"
+        assert payload["name"] == "my-project/my-endpoint"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_implicit_retrieve_deployment_by_name(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/whoami").mock(return_value=httpx.Response(200, json=_whoami_body()))
+        # Name lookup as endpoint fails (no matching endpoint), then deployment name resolves.
+        respx_mock.get("/projects/proj/endpoints").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_endpoint_body()], "next_cursor": None},
+            )
+        )
+        respx_mock.get("/projects/proj/endpoints/ep_1/deployments/dep_control").mock(
+            return_value=httpx.Response(200, json=_deployment_body())
+        )
+
+        result = cli_runner.invoke(["beta", "endpoints", "control", "--project", "proj", "--json"])
 
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)

--- a/tests/cli/test_beta_endpoints_retrieve.py
+++ b/tests/cli/test_beta_endpoints_retrieve.py
@@ -179,3 +179,40 @@ class TestBetaEndpointsRetrieve:
         payload = json.loads(result.output)
         assert payload["id"] == "dep_control"
         assert payload["endpointId"] == "ep_1"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_retrieve_deployment_by_ambiguous_name_errors(
+        self, respx_mock: MockRouter, cli_runner: CliRunner
+    ) -> None:
+        respx_mock.get("/whoami").mock(return_value=httpx.Response(200, json=_whoami_body()))
+        other = _endpoint_body(
+            id="ep_2",
+            name="my-project/other-endpoint",
+            trafficSplit=[{"deploymentId": "dep_other", "weight": 1.0}],
+            deployments=[
+                {
+                    "id": "dep_other",
+                    "name": "my-project/other-endpoint/control",
+                    "model": "projects/proj/models/ml_control/revisions/latest",
+                    "modelId": "ml_control",
+                    "hardware": "1x-h100",
+                    "state": "DEPLOYMENT_STATE_READY",
+                    "readyReplicas": 1,
+                    "desiredReplicas": 1,
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "autoscaling": {"minReplicas": 1, "maxReplicas": 1},
+                }
+            ],
+        )
+        # Endpoint name lookup: neither endpoint is named "control".
+        respx_mock.get("/projects/proj/endpoints").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_endpoint_body(), other], "next_cursor": None},
+            )
+        )
+
+        result = cli_runner.invoke(["beta", "endpoints", "get", "control", "--project", "proj", "--json"])
+
+        assert result.exit_code != 0
+        assert 'Multiple deployments found for "control"' in result.output

--- a/tests/cli/test_beta_endpoints_retrieve.py
+++ b/tests/cli/test_beta_endpoints_retrieve.py
@@ -130,9 +130,7 @@ class TestBetaEndpointsRetrieve:
                 json={"object": "list", "data": [_endpoint_body()], "next_cursor": None},
             )
         )
-        respx_mock.get("/projects/proj/endpoints/ep_1").mock(
-            return_value=httpx.Response(200, json=_endpoint_body())
-        )
+        respx_mock.get("/projects/proj/endpoints/ep_1").mock(return_value=httpx.Response(200, json=_endpoint_body()))
         _mock_endpoint_get_side_resources(respx_mock)
 
         result = cli_runner.invoke(["beta", "endpoints", "get", "my-endpoint", "--project", "proj", "--json"])
@@ -151,9 +149,7 @@ class TestBetaEndpointsRetrieve:
                 json={"object": "list", "data": [_endpoint_body()], "next_cursor": None},
             )
         )
-        respx_mock.get("/projects/proj/endpoints/ep_1").mock(
-            return_value=httpx.Response(200, json=_endpoint_body())
-        )
+        respx_mock.get("/projects/proj/endpoints/ep_1").mock(return_value=httpx.Response(200, json=_endpoint_body()))
         _mock_endpoint_get_side_resources(respx_mock)
 
         result = cli_runner.invoke(["beta", "endpoints", "my-endpoint", "--project", "proj", "--json"])

--- a/tests/cli/test_beta_endpoints_retrieve.py
+++ b/tests/cli/test_beta_endpoints_retrieve.py
@@ -181,9 +181,7 @@ class TestBetaEndpointsRetrieve:
         assert payload["endpointId"] == "ep_1"
 
     @pytest.mark.respx(base_url=base_url)
-    def test_retrieve_deployment_by_ambiguous_name_errors(
-        self, respx_mock: MockRouter, cli_runner: CliRunner
-    ) -> None:
+    def test_retrieve_deployment_by_ambiguous_name_errors(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         respx_mock.get("/whoami").mock(return_value=httpx.Response(200, json=_whoami_body()))
         other = _endpoint_body(
             id="ep_2",

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -241,6 +241,27 @@ def test_parse_command_and_flags_inserts_implicit_retrieve_for_beta_endpoint_dep
     assert argv == ["beta", "endpoints", "retrieve", "dep_control", "--json"]
 
 
+def test_parse_command_and_flags_inserts_implicit_retrieve_for_beta_endpoint_name() -> None:
+    from together.lib.cli import app
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
+
+    cmd, flags, is_beta, argv = preparse_tokens(app, ["beta", "endpoints", "my-endpoint", "--json"])
+    assert cmd == "endpoints retrieve"
+    assert "id" in flags
+    assert is_beta is True
+    assert argv == ["beta", "endpoints", "retrieve", "my-endpoint", "--json"]
+
+
+def test_parse_command_and_flags_does_not_treat_beta_endpoints_subcommand_as_retrieve() -> None:
+    from together.lib.cli import app
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
+
+    cmd, _, is_beta, argv = preparse_tokens(app, ["beta", "endpoints", "deploy", "ml_1", "--endpoint", "e"])
+    assert cmd == "endpoints deploy"
+    assert is_beta is True
+    assert argv == ["beta", "endpoints", "deploy", "ml_1", "--endpoint", "e"]
+
+
 def test_parse_command_and_flags_implicit_retrieve_fine_tuning_spelling() -> None:
     from together.lib.cli import app
     from together.lib.cli.utils._preparse_tokens import preparse_tokens

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -230,18 +230,19 @@ def test_parse_command_and_flags_inserts_implicit_retrieve_for_ft_job_id() -> No
     assert is_beta is False
 
 
-def test_parse_command_and_flags_inserts_implicit_retrieve_for_beta_endpoint_deployment_id() -> None:
+def test_parse_command_and_flags_attributes_beta_endpoints_default_retrieve_for_deployment_id() -> None:
     from together.lib.cli import app
     from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
+    # App.default handles implicit get — argv is not rewritten to insert `retrieve`.
     cmd, flags, is_beta, argv = preparse_tokens(app, ["beta", "endpoints", "dep_control", "--json"])
     assert cmd == "endpoints retrieve"
     assert "id" in flags
     assert is_beta is True
-    assert argv == ["beta", "endpoints", "retrieve", "dep_control", "--json"]
+    assert argv == ["beta", "endpoints", "dep_control", "--json"]
 
 
-def test_parse_command_and_flags_inserts_implicit_retrieve_for_beta_endpoint_name() -> None:
+def test_parse_command_and_flags_attributes_beta_endpoints_default_retrieve_for_name() -> None:
     from together.lib.cli import app
     from together.lib.cli.utils._preparse_tokens import preparse_tokens
 
@@ -249,7 +250,7 @@ def test_parse_command_and_flags_inserts_implicit_retrieve_for_beta_endpoint_nam
     assert cmd == "endpoints retrieve"
     assert "id" in flags
     assert is_beta is True
-    assert argv == ["beta", "endpoints", "retrieve", "my-endpoint", "--json"]
+    assert argv == ["beta", "endpoints", "my-endpoint", "--json"]
 
 
 def test_parse_command_and_flags_does_not_treat_beta_endpoints_subcommand_as_retrieve() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "together"
-version = "2.27.1"
+version = "2.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- Expand implicit retrieve for `tg beta endpoints <token>` so any non-flag string that isn’t a registered subcommand routes to `retrieve` (not just `ep_` / `dep_` IDs).
- Resolve endpoint and deployment **names** in `get`/`retrieve` via existing `resolve_endpoint` and a name-aware deployment lookup.
- Update help copy/examples and add CLI + telemetry coverage for name-based get.

Fixes ENG-91342.

## Test plan
- [x] `tests/cli/test_beta_endpoints_retrieve.py` — explicit/implicit get by endpoint name and deployment name
- [x] `tests/unit/test_cli_telemetry.py` — implicit retrieve for names; subcommands still win
- [ ] Run targeted pytest for retrieve + telemetry