### PR TITLE
feat(cli): add --ab-percent to beta endpoints update (ENG-91343)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ async with client.beta.realtime.transcription(
 
     async for event in session:
         if isinstance(event, TranscriptDelta):
-            print("interim:", event.text)   # updates while a phrase is spoken
+            print("interim:", event.text)  # updates while a phrase is spoken
         elif isinstance(event, TranscriptCompleted):
-            print("final:", event.text)     # one per finished utterance
+            print("final:", event.text)  # one per finished utterance
 
     transcript = await session.flush()  # finalize whatever was said last
 ```

--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -671,7 +671,7 @@ beta_endpoints_app.command(
 )  # This is just here to allow the default command to work
 beta_endpoints_app.command(
     (f"{_CLI}.beta.endpoints.update:update"),
-    help="Update a deployment's name, autoscaling, or traffic weight",
+    help="Update a deployment's name, autoscaling, traffic weight, or A/B percent",
     help_epilogue=BETA_ENDPOINTS_UPDATE_HELP_EXAMPLES,
     sort_key=4,
 )

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -38,9 +38,7 @@ def update_ab_member_percent(
         raise ValueError(f"Deployment {deployment_id} is not a member of the A/B experiment.")
 
     if target.role == "AB_EXPERIMENT_MEMBER_ROLE_CONTROL":
-        raise ValueError(
-            "--ab-percent can only update variant deployments; control percent is derived from variants."
-        )
+        raise ValueError("--ab-percent can only update variant deployments; control percent is derived from variants.")
 
     control = next((m for m in members if m.role == "AB_EXPERIMENT_MEMBER_ROLE_CONTROL"), None)
     if control is None:

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
+
 from together import AsyncClient
 from together.types.beta import AbMember, AbMemberParam
+from together.lib.utils.tools import format_datetime
+from together.lib.cli.utils._console import console
 from together.types.beta.endpoints.ab_experiment import AbExperiment
 
 
@@ -72,3 +76,95 @@ def build_ab_members_with_percent(
             )
         )
     return result
+
+
+def calculate_ab_members(
+    *,
+    control_deployment_id: str,
+    new_deployment_id: str,
+    new_percent: int,
+    existing_members: list[AbMember] | None = None,
+) -> list[AbMemberParam]:
+    existing_variants: list[AbMember] = []
+
+    if existing_members:
+        control_member = next(
+            (member for member in existing_members if member.role == "AB_EXPERIMENT_MEMBER_ROLE_CONTROL"),
+            None,
+        )
+        if control_member is None:
+            raise ValueError("Existing A/B experiment has no control member.")
+        if control_member.deployment_id != control_deployment_id:
+            raise ValueError(
+                "Control deployment does not match the existing A/B experiment control member. "
+                f"Expected {control_member.deployment_id}, got {control_deployment_id}."
+            )
+        existing_variants = [
+            member for member in existing_members if member.role == "AB_EXPERIMENT_MEMBER_ROLE_VARIANT"
+        ]
+
+    existing_variant_total = sum(member.percent for member in existing_variants)
+    control_percent = 100 - existing_variant_total - new_percent
+    if control_percent < 1:
+        raise ValueError(
+            f"Cannot allocate {new_percent}% to the new variant: control would be {control_percent}% (minimum 1%)."
+        )
+
+    members: list[AbMemberParam] = [
+        AbMemberParam(
+            deployment_id=control_deployment_id,
+            role="AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+            percent=control_percent,
+        ),
+        *[
+            AbMemberParam(
+                deployment_id=member.deployment_id,
+                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                percent=member.percent,
+            )
+            for member in existing_variants
+        ],
+        AbMemberParam(
+            deployment_id=new_deployment_id,
+            role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+            percent=new_percent,
+        ),
+    ]
+    return members
+
+
+def print_ab_experiment_detail(experiment: Any) -> None:
+    if experiment is None:
+        console.print("A/B experiment not found.")
+        return
+
+    console.print(f"[dim][primary]Name:[/primary][/dim]\t\t[bold]{experiment.name}[/bold]")
+    if getattr(experiment, "id", None):
+        console.print(f"[dim][primary]ID:[/primary][/dim]\t\t{experiment.id}")
+    if getattr(experiment, "endpoint_id", None):
+        console.print(f"[dim][primary]Endpoint:[/primary][/dim]\t{experiment.endpoint_id}")
+    if getattr(experiment, "project_id", None):
+        console.print(f"[dim][primary]Project:[/primary][/dim]\t{experiment.project_id}")
+    if getattr(experiment, "description", None):
+        console.print(f"[dim][primary]Description:[/primary][/dim]\t{experiment.description}")
+    if getattr(experiment, "etag", None):
+        console.print(f"[dim][primary]ETag:[/primary][/dim]\t\t{experiment.etag}")
+    if getattr(experiment, "members", None):
+        console.print("[dim][primary]Members:[/primary][/dim]")
+        for member in experiment.members:
+            role = format_member_role(member.role)
+            console.print(f"\t\t{member.deployment_id} ({role}): {member.percent}%")
+    if getattr(experiment, "created_at", None):
+        console.print(f"[dim][primary]Created:[/primary][/dim]\t{format_datetime(experiment.created_at)}")
+    if getattr(experiment, "updated_at", None):
+        console.print(f"[dim][primary]Updated:[/primary][/dim]\t{format_datetime(experiment.updated_at)}")
+
+
+def format_member_role(role: str | None) -> str:
+    if not role:
+        return ""
+    if role.endswith("_CONTROL"):
+        return "CONTROL"
+    if role.endswith("_VARIANT"):
+        return "VARIANT"
+    return role

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from together import AsyncClient, omit
+from together import AsyncClient
 from together.types.beta import AbMember, AbMemberParam
 from together.types.beta.endpoints.ab_experiment import AbExperiment
 
@@ -10,18 +10,9 @@ async def find_ab_for_deployment(
     endpoint_id: str,
     deployment_id: str,
 ) -> AbExperiment | None:
-    cursor: str | None = None
-    while True:
-        page = await client.beta.endpoints.ab_experiments.list(
-            endpoint_id=endpoint_id,
-            after=cursor or omit,
-        )
-        for experiment in page.data:
-            if any(m.deployment_id == deployment_id for m in experiment.members):
-                return experiment
-        if not page.next_cursor:
-            break
-        cursor = page.next_cursor
+    async for experiment in client.beta.endpoints.ab_experiments.list(endpoint_id=endpoint_id):
+        if any(m.deployment_id == deployment_id for m in experiment.members):
+            return experiment
     return None
 
 

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -160,9 +160,7 @@ def print_ab_experiment_detail(experiment: Any) -> None:
         console.print(f"[dim][primary]Updated:[/primary][/dim]\t{format_datetime(experiment.updated_at)}")
 
 
-def format_member_role(role: str | None) -> str:
-    if not role:
-        return ""
+def format_member_role(role: str) -> str:
     if role.endswith("_CONTROL"):
         return "CONTROL"
     if role.endswith("_VARIANT"):

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -30,7 +30,23 @@ def update_ab_member_percent(
     deployment_id: str,
     new_percent: int,
 ) -> list[AbMemberParam]:
-    """Set a variant's AB percent by taking from or returning to control only."""
+    """Set a variant's AB percent by taking from or returning to control only.
+
+    Rules:
+    - ``deployment_id`` must identify a *variant* member (not control). Control
+      percent is derived: ``100 - sum(variants)``.
+    - Only the target variant and the control member change. All other variants
+      keep their current percent.
+    - Increasing a variant takes the delta from control.
+    - Decreasing a variant returns the delta to control.
+    - Control must remain >= 1% after the update.
+
+    Examples (control=85, variant_a=5, variant_b=10):
+    - Set variant_a to 20 → control=70, variant_a=20, variant_b=10
+    - Set variant_a to 2  → control=88, variant_a=2,  variant_b=10
+    - Set control to 80   → ValueError (control is not updatable)
+    - Set variant_a to 95 → ValueError (control would be 0%)
+    """
     target = next((m for m in members if m.deployment_id == deployment_id), None)
     if target is None:
         raise ValueError(f"Deployment {deployment_id} is not a member of the A/B experiment.")

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -9,13 +9,11 @@ async def find_ab_for_deployment(
     client: AsyncClient,
     endpoint_id: str,
     deployment_id: str,
-    project_id: str | None,
 ) -> AbExperiment | None:
     cursor: str | None = None
     while True:
         page = await client.beta.endpoints.ab_experiments.list(
             endpoint_id=endpoint_id,
-            project_id=project_id,
             after=cursor or omit,
         )
         for experiment in page.data:

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -25,12 +25,12 @@ async def find_ab_for_deployment(
     return None
 
 
-def update_ab_member_percent(
+def build_ab_members_with_percent(
     members: list[AbMember],
     deployment_id: str,
     new_percent: int,
 ) -> list[AbMemberParam]:
-    """Set a variant's AB percent by taking from or returning to control only.
+    """Build AB member params with a variant percent adjusted against control.
 
     Rules:
     - ``deployment_id`` must identify a *variant* member (not control). Control

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from together import AsyncClient
 from together.types.beta import AbMember, AbMemberParam
 from together.lib.utils.tools import format_datetime
@@ -16,6 +14,18 @@ async def find_ab_for_deployment(
 ) -> AbExperiment | None:
     async for experiment in client.beta.endpoints.ab_experiments.list(endpoint_id=endpoint_id):
         if any(m.deployment_id == deployment_id for m in experiment.members):
+            return experiment
+    return None
+
+
+async def find_ab_experiment_by_name(
+    client: AsyncClient,
+    *,
+    endpoint_id: str,
+    name: str,
+) -> AbExperiment | None:
+    async for experiment in client.beta.endpoints.ab_experiments.list(endpoint_id=endpoint_id):
+        if experiment.name == name:
             return experiment
     return None
 
@@ -42,9 +52,7 @@ def build_ab_members_with_percent(
     - Set control to 80   → ValueError (control is not updatable)
     - Set variant_a to 95 → ValueError (control would be 0%)
     """
-    target = next((m for m in members if m.deployment_id == deployment_id), None)
-    if target is None:
-        raise ValueError(f"Deployment {deployment_id} is not a member of the A/B experiment.")
+    target = next(m for m in members if m.deployment_id == deployment_id)
 
     if target.role == "AB_EXPERIMENT_MEMBER_ROLE_CONTROL":
         raise ValueError("--ab-percent can only update variant deployments; control percent is derived from variants.")
@@ -133,31 +141,24 @@ def calculate_ab_members(
     return members
 
 
-def print_ab_experiment_detail(experiment: Any) -> None:
+def print_ab_experiment_detail(experiment: AbExperiment | None) -> None:
     if experiment is None:
         console.print("A/B experiment not found.")
         return
 
     console.print(f"[dim][primary]Name:[/primary][/dim]\t\t[bold]{experiment.name}[/bold]")
-    if getattr(experiment, "id", None):
-        console.print(f"[dim][primary]ID:[/primary][/dim]\t\t{experiment.id}")
-    if getattr(experiment, "endpoint_id", None):
-        console.print(f"[dim][primary]Endpoint:[/primary][/dim]\t{experiment.endpoint_id}")
-    if getattr(experiment, "project_id", None):
-        console.print(f"[dim][primary]Project:[/primary][/dim]\t{experiment.project_id}")
-    if getattr(experiment, "description", None):
+    console.print(f"[dim][primary]ID:[/primary][/dim]\t\t{experiment.id}")
+    console.print(f"[dim][primary]Endpoint:[/primary][/dim]\t{experiment.endpoint_id}")
+    console.print(f"[dim][primary]Project:[/primary][/dim]\t{experiment.project_id}")
+    if experiment.description:
         console.print(f"[dim][primary]Description:[/primary][/dim]\t{experiment.description}")
-    if getattr(experiment, "etag", None):
-        console.print(f"[dim][primary]ETag:[/primary][/dim]\t\t{experiment.etag}")
-    if getattr(experiment, "members", None):
-        console.print("[dim][primary]Members:[/primary][/dim]")
-        for member in experiment.members:
-            role = format_member_role(member.role)
-            console.print(f"\t\t{member.deployment_id} ({role}): {member.percent}%")
-    if getattr(experiment, "created_at", None):
-        console.print(f"[dim][primary]Created:[/primary][/dim]\t{format_datetime(experiment.created_at)}")
-    if getattr(experiment, "updated_at", None):
-        console.print(f"[dim][primary]Updated:[/primary][/dim]\t{format_datetime(experiment.updated_at)}")
+    console.print(f"[dim][primary]ETag:[/primary][/dim]\t\t{experiment.etag}")
+    console.print("[dim][primary]Members:[/primary][/dim]")
+    for member in experiment.members:
+        role = format_member_role(member.role)
+        console.print(f"\t\t{member.deployment_id} ({role}): {member.percent}%")
+    console.print(f"[dim][primary]Created:[/primary][/dim]\t{format_datetime(experiment.created_at)}")
+    console.print(f"[dim][primary]Updated:[/primary][/dim]\t{format_datetime(experiment.updated_at)}")
 
 
 def format_member_role(role: str) -> str:

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_ab_experiments.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from together import AsyncClient, omit
+from together.types.beta import AbMember, AbMemberParam
+from together.types.beta.endpoints.ab_experiment import AbExperiment
+
+
+async def find_ab_for_deployment(
+    client: AsyncClient,
+    endpoint_id: str,
+    deployment_id: str,
+    project_id: str | None,
+) -> AbExperiment | None:
+    cursor: str | None = None
+    while True:
+        page = await client.beta.endpoints.ab_experiments.list(
+            endpoint_id=endpoint_id,
+            project_id=project_id,
+            after=cursor or omit,
+        )
+        for experiment in page.data:
+            if any(m.deployment_id == deployment_id for m in experiment.members):
+                return experiment
+        if not page.next_cursor:
+            break
+        cursor = page.next_cursor
+    return None
+
+
+def update_ab_member_percent(
+    members: list[AbMember],
+    deployment_id: str,
+    new_percent: int,
+) -> list[AbMemberParam]:
+    """Set a variant's AB percent by taking from or returning to control only."""
+    target = next((m for m in members if m.deployment_id == deployment_id), None)
+    if target is None:
+        raise ValueError(f"Deployment {deployment_id} is not a member of the A/B experiment.")
+
+    if target.role == "AB_EXPERIMENT_MEMBER_ROLE_CONTROL":
+        raise ValueError(
+            "--ab-percent can only update variant deployments; control percent is derived from variants."
+        )
+
+    control = next((m for m in members if m.role == "AB_EXPERIMENT_MEMBER_ROLE_CONTROL"), None)
+    if control is None:
+        raise ValueError("Existing A/B experiment has no control member.")
+
+    delta = new_percent - target.percent
+    control_percent = control.percent - delta
+    if control_percent < 1:
+        raise ValueError(
+            f"Cannot allocate {new_percent}% to deployment {deployment_id}: "
+            f"control would be {control_percent}% (minimum 1%)."
+        )
+
+    result: list[AbMemberParam] = []
+    for member in members:
+        percent = member.percent
+        if member.deployment_id == deployment_id:
+            percent = new_percent
+        elif member.deployment_id == control.deployment_id:
+            percent = control_percent
+        result.append(
+            AbMemberParam(
+                deployment_id=member.deployment_id,
+                role=member.role,
+                percent=percent,
+            )
+        )
+    return result

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_resolve_model.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_resolve_model.py
@@ -78,7 +78,7 @@ async def resolve_model_and_config(
     if "/" not in model_input:
         if config.project_id:
             try:
-                model = await config.client.beta.models.retrieve(model_input)
+                model = await config.client.beta.models.retrieve(id=model_input, project_id=config.project_id)
             except NotFoundError:
                 pass
             else:

--- a/src/together/lib/cli/api/beta/endpoints/_utils/_resolve_model.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_resolve_model.py
@@ -78,7 +78,7 @@ async def resolve_model_and_config(
     if "/" not in model_input:
         if config.project_id:
             try:
-                model = await config.client.beta.models.retrieve(id=model_input, project_id=config.project_id)
+                model = await config.client.beta.models.retrieve(model_input)
             except NotFoundError:
                 pass
             else:

--- a/src/together/lib/cli/api/beta/endpoints/ab.py
+++ b/src/together/lib/cli/api/beta/endpoints/ab.py
@@ -7,14 +7,13 @@ from typing_extensions import Annotated
 from cyclopts import Parameter
 from cyclopts.validators import Number
 
-from together import AsyncClient, omit
+from together import omit
 from together._utils._json import openapi_dumps
 from together.types.beta.endpoint import Endpoint
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._prompt import PromptParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
-from together.types.beta.endpoints.ab_experiment import AbExperiment
 from together.lib.cli.api.beta.endpoints.retrieve import retrieve
 from together.lib.cli.api.beta.endpoints._utils._parameters import ModelParameter
 from together.lib.cli.api.beta.endpoints._utils._resolve_model import (
@@ -23,6 +22,7 @@ from together.lib.cli.api.beta.endpoints._utils._resolve_model import (
 )
 from together.lib.cli.api.beta.endpoints._utils._ab_experiments import (
     calculate_ab_members,
+    find_ab_experiment_by_name,
     print_ab_experiment_detail,
 )
 from together.lib.cli.api.beta.endpoints._utils._resolve_config import (
@@ -180,24 +180,3 @@ def verify_control_receiving_traffic(endpoint: Endpoint, control_deployment_id: 
             f"Control deployment {control_deployment_id} is not in the endpoint traffic split. "
             "Route traffic to the control deployment before starting an A/B experiment."
         )
-
-
-async def find_ab_experiment_by_name(
-    client: AsyncClient,
-    *,
-    endpoint_id: str,
-    name: str,
-) -> AbExperiment | None:
-    cursor: str | None = None
-    while True:
-        page = await client.beta.endpoints.ab_experiments.list(
-            endpoint_id=endpoint_id,
-            after=cursor or omit,
-        )
-        for experiment in page.data:
-            if experiment.name == name:
-                return experiment
-        if not page.next_cursor:
-            break
-        cursor = page.next_cursor
-    return None

--- a/src/together/lib/cli/api/beta/endpoints/ab.py
+++ b/src/together/lib/cli/api/beta/endpoints/ab.py
@@ -127,7 +127,6 @@ async def ab(
                 endpoint_id=endpoint.id,
                 name=experiment_name,
                 members=members,
-                project_id=config.project_id,
             ),
         )
     else:
@@ -140,7 +139,6 @@ async def ab(
                 update_mask="members",
                 members=members,
                 etag=existing_experiment.etag or omit,
-                project_id=config.project_id,
             ),
         )
 

--- a/src/together/lib/cli/api/beta/endpoints/ab.py
+++ b/src/together/lib/cli/api/beta/endpoints/ab.py
@@ -8,9 +8,7 @@ from cyclopts import Parameter
 from cyclopts.validators import Number
 
 from together import AsyncClient, omit
-from together.types.beta import AbMember, AbMemberParam
 from together._utils._json import openapi_dumps
-from together.lib.utils.tools import format_datetime
 from together.types.beta.endpoint import Endpoint
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._prompt import PromptParameter
@@ -22,6 +20,10 @@ from together.lib.cli.api.beta.endpoints._utils._parameters import ModelParamete
 from together.lib.cli.api.beta.endpoints._utils._resolve_model import (
     construct_model_path,
     resolve_model_and_config,
+)
+from together.lib.cli.api.beta.endpoints._utils._ab_experiments import (
+    calculate_ab_members,
+    print_ab_experiment_detail,
 )
 from together.lib.cli.api.beta.endpoints._utils._resolve_config import (
     construct_config_path,
@@ -37,10 +39,10 @@ async def ab(
     percent: Annotated[
         int,
         Parameter(
-            help="Percentage of live traffic to allocate to the new variant (1–100)",
-            validator=Number(gte=1, lte=100),
+            help="Percentage of live traffic to allocate to the new variant (1–99)",
+            validator=Number(gte=1, lte=99),
         ),
-        PromptParameter(message="Traffic percent to allocate to the new variant (1–100)"),
+        PromptParameter(message="Traffic percent to allocate to the new variant (1–99)"),
     ],
     config_id: Annotated[
         Optional[str],
@@ -182,61 +184,6 @@ def verify_control_receiving_traffic(endpoint: Endpoint, control_deployment_id: 
         )
 
 
-def calculate_ab_members(
-    *,
-    control_deployment_id: str,
-    new_deployment_id: str,
-    new_percent: int,
-    existing_members: list[AbMember] | None = None,
-) -> list[AbMemberParam]:
-    existing_variants: list[AbMember] = []
-
-    if existing_members:
-        control_member = next(
-            (member for member in existing_members if member.role == "AB_EXPERIMENT_MEMBER_ROLE_CONTROL"),
-            None,
-        )
-        if control_member is None:
-            raise ValueError("Existing A/B experiment has no control member.")
-        if control_member.deployment_id != control_deployment_id:
-            raise ValueError(
-                "Control deployment does not match the existing A/B experiment control member. "
-                f"Expected {control_member.deployment_id}, got {control_deployment_id}."
-            )
-        existing_variants = [
-            member for member in existing_members if member.role == "AB_EXPERIMENT_MEMBER_ROLE_VARIANT"
-        ]
-
-    existing_variant_total = sum(member.percent for member in existing_variants)
-    control_percent = 100 - existing_variant_total - new_percent
-    if control_percent < 1:
-        raise ValueError(
-            f"Cannot allocate {new_percent}% to the new variant: control would be {control_percent}% (minimum 1%)."
-        )
-
-    members: list[AbMemberParam] = [
-        AbMemberParam(
-            deployment_id=control_deployment_id,
-            role="AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
-            percent=control_percent,
-        ),
-        *[
-            AbMemberParam(
-                deployment_id=member.deployment_id,
-                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
-                percent=member.percent,
-            )
-            for member in existing_variants
-        ],
-        AbMemberParam(
-            deployment_id=new_deployment_id,
-            role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
-            percent=new_percent,
-        ),
-    ]
-    return members
-
-
 async def find_ab_experiment_by_name(
     client: AsyncClient,
     *,
@@ -256,40 +203,3 @@ async def find_ab_experiment_by_name(
             break
         cursor = page.next_cursor
     return None
-
-
-def print_ab_experiment_detail(experiment: Any) -> None:
-    if experiment is None:
-        console.print("A/B experiment not found.")
-        return
-
-    console.print(f"[dim][primary]Name:[/primary][/dim]\t\t[bold]{experiment.name}[/bold]")
-    if getattr(experiment, "id", None):
-        console.print(f"[dim][primary]ID:[/primary][/dim]\t\t{experiment.id}")
-    if getattr(experiment, "endpoint_id", None):
-        console.print(f"[dim][primary]Endpoint:[/primary][/dim]\t{experiment.endpoint_id}")
-    if getattr(experiment, "project_id", None):
-        console.print(f"[dim][primary]Project:[/primary][/dim]\t{experiment.project_id}")
-    if getattr(experiment, "description", None):
-        console.print(f"[dim][primary]Description:[/primary][/dim]\t{experiment.description}")
-    if getattr(experiment, "etag", None):
-        console.print(f"[dim][primary]ETag:[/primary][/dim]\t\t{experiment.etag}")
-    if getattr(experiment, "members", None):
-        console.print("[dim][primary]Members:[/primary][/dim]")
-        for member in experiment.members:
-            role = format_member_role(member.role)
-            console.print(f"\t\t{member.deployment_id} ({role}): {member.percent}%")
-    if getattr(experiment, "created_at", None):
-        console.print(f"[dim][primary]Created:[/primary][/dim]\t{format_datetime(experiment.created_at)}")
-    if getattr(experiment, "updated_at", None):
-        console.print(f"[dim][primary]Updated:[/primary][/dim]\t{format_datetime(experiment.updated_at)}")
-
-
-def format_member_role(role: str | None) -> str:
-    if not role:
-        return ""
-    if role.endswith("_CONTROL"):
-        return "CONTROL"
-    if role.endswith("_VARIANT"):
-        return "VARIANT"
-    return role

--- a/src/together/lib/cli/api/beta/endpoints/rm.py
+++ b/src/together/lib/cli/api/beta/endpoints/rm.py
@@ -155,7 +155,7 @@ async def _delete_deployment(deployment_id: str, *, config: CLIConfigParameter) 
             )
             actions.append(f"deleted empty shadow experiment {shadow.id}")
 
-    ab = await find_ab_for_deployment(config.client, endpoint.id, deployment_id, config.project_id)
+    ab = await find_ab_for_deployment(config.client, endpoint.id, deployment_id)
     if ab is not None:
         removed = next(m for m in ab.members if m.deployment_id == deployment_id)
         remaining_members = [m for m in ab.members if m.deployment_id != deployment_id]

--- a/src/together/lib/cli/api/beta/endpoints/rm.py
+++ b/src/together/lib/cli/api/beta/endpoints/rm.py
@@ -16,6 +16,7 @@ from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
 from together.types.beta.endpoints.ab_experiment import AbExperiment
 from together.types.beta.endpoints.shadow_experiment import ShadowExperiment
+from together.lib.cli.api.beta.endpoints._utils._ab_experiments import find_ab_for_deployment
 from together.lib.cli.api.beta.endpoints._utils._find_endpoint_by_deployment import find_endpoint_by_deployment
 
 
@@ -154,7 +155,7 @@ async def _delete_deployment(deployment_id: str, *, config: CLIConfigParameter) 
             )
             actions.append(f"deleted empty shadow experiment {shadow.id}")
 
-    ab = await _find_ab_for_deployment(config.client, endpoint.id, deployment_id, config.project_id)
+    ab = await find_ab_for_deployment(config.client, endpoint.id, deployment_id, config.project_id)
     if ab is not None:
         removed = next(m for m in ab.members if m.deployment_id == deployment_id)
         remaining_members = [m for m in ab.members if m.deployment_id != deployment_id]
@@ -326,28 +327,6 @@ async def _find_shadow_for_deployment(
         for target in experiment.targets or []:
             if target.target_deployment_id == deployment_id:
                 return experiment
-    return None
-
-
-async def _find_ab_for_deployment(
-    client: AsyncClient,
-    endpoint_id: str,
-    deployment_id: str,
-    project_id: str | None,
-) -> AbExperiment | None:
-    cursor: str | None = None
-    while True:
-        page = await client.beta.endpoints.ab_experiments.list(
-            endpoint_id=endpoint_id,
-            project_id=project_id,
-            after=cursor or omit,
-        )
-        for experiment in page.data:
-            if any(m.deployment_id == deployment_id for m in experiment.members):
-                return experiment
-        if not page.next_cursor:
-            break
-        cursor = page.next_cursor
     return None
 
 

--- a/src/together/lib/cli/api/beta/endpoints/rm.py
+++ b/src/together/lib/cli/api/beta/endpoints/rm.py
@@ -167,7 +167,6 @@ async def _delete_deployment(deployment_id: str, *, config: CLIConfigParameter) 
                     id=ab.id,
                     endpoint_id=endpoint.id,
                     etag=ab.etag or omit,
-                    project_id=config.project_id,
                 ),
             )
             actions.append(f"deleted A/B experiment {ab.id}")
@@ -181,7 +180,6 @@ async def _delete_deployment(deployment_id: str, *, config: CLIConfigParameter) 
                     update_mask="members",
                     members=members,
                     etag=ab.etag or omit,
-                    project_id=config.project_id,
                 ),
             )
             actions.append(f"removed from A/B experiment {ab.id}")
@@ -258,7 +256,6 @@ async def _delete_ab_experiment(experiment_id: str, *, config: CLIConfigParamete
             id=experiment.id,
             endpoint_id=endpoint_id,
             etag=experiment.etag or omit,
-            project_id=config.project_id,
         ),
     )
     return {"message": f"Deleted A/B experiment {experiment_id}", "id": experiment_id, "type": "ab_experiment"}

--- a/src/together/lib/cli/api/beta/endpoints/update.py
+++ b/src/together/lib/cli/api/beta/endpoints/update.py
@@ -17,7 +17,6 @@ from together.lib.cli.api.beta.endpoints.retrieve import retrieve as retrieve_en
 from together.lib.cli.api.beta.endpoints._utils._traffic_split import upsert_traffic_weight
 from together.lib.cli.api.beta.endpoints._utils._ab_experiments import (
     find_ab_for_deployment,
-    print_ab_experiment_detail,
     build_ab_members_with_percent,
 )
 from together.lib.cli.api.beta.endpoints._utils._build_autoscaling import (
@@ -224,11 +223,8 @@ async def update(
     if traffic_weight is not None:
         console.print(f"[green]√[/green] Updated traffic weight for deployment {id}.\n\n")
     if ab_percent is not None:
-        assert updated_ab is not None
         if ab_already_at_percent:
             console.print(f"Deployment {id} is already at {ab_percent}%.\n\n")
         else:
             console.print(f"[green]√[/green] Updated A/B percent for deployment {id}.\n\n")
-        print_ab_experiment_detail(updated_ab)
-        console.print()
     await retrieve_endpoint(endpoint.id, config=config)

--- a/src/together/lib/cli/api/beta/endpoints/update.py
+++ b/src/together/lib/cli/api/beta/endpoints/update.py
@@ -12,11 +12,12 @@ from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.api.beta.endpoints.ab import print_ab_experiment_detail
+from together.types.beta.endpoints.ab_experiment import AbExperiment
 from together.lib.cli.api.beta.endpoints.retrieve import retrieve as retrieve_endpoint
 from together.lib.cli.api.beta.endpoints._utils._traffic_split import upsert_traffic_weight
 from together.lib.cli.api.beta.endpoints._utils._ab_experiments import (
     find_ab_for_deployment,
+    print_ab_experiment_detail,
     build_ab_members_with_percent,
 )
 from together.lib.cli.api.beta.endpoints._utils._build_autoscaling import (
@@ -100,12 +101,7 @@ async def update(
     ] = None,
     etag: Annotated[
         Optional[str],
-        Parameter(
-            help=(
-                "ETag for optimistic concurrency. Applies to the deployment update, "
-                "and to the A/B experiment update when --ab-percent is set."
-            )
-        ),
+        Parameter(help="ETag for optimistic concurrency on the deployment update."),
     ] = None,
     *,
     config: CLIConfigParameter,
@@ -144,6 +140,23 @@ async def update(
 
     endpoint = await find_endpoint_by_deployment(config.client, id)
 
+    # Validate / compute A/B members before any mutations so failures leave no partial state.
+    ab_members = None
+    ab_experiment: AbExperiment | None = None
+    ab_already_at_percent = False
+    if ab_percent is not None:
+        ab_experiment = await find_ab_for_deployment(
+            config.client,
+            endpoint.id,
+            id,
+        )
+        if ab_experiment is None:
+            raise ValueError(f"Deployment {id} is not part of an A/B experiment.")
+
+        ab_members = build_ab_members_with_percent(ab_experiment.members, id, ab_percent)
+        current = next(m for m in ab_experiment.members if m.deployment_id == id)
+        ab_already_at_percent = current.percent == ab_percent
+
     updated: Any = None
     if update_mask:
         updated = await show_loading_status(
@@ -172,48 +185,50 @@ async def update(
             ),
         )
 
-    updated_ab: Any = None
+    updated_ab: AbExperiment | None = None
     if ab_percent is not None:
-        ab_experiment = await find_ab_for_deployment(
-            config.client,
-            endpoint.id,
-            id,
-        )
-        if ab_experiment is None:
-            raise ValueError(f"Deployment {id} is not part of an A/B experiment.")
-
-        members = build_ab_members_with_percent(ab_experiment.members, id, ab_percent)
-        updated_ab = await show_loading_status(
-            "Updating A/B experiment...",
-            config.client.beta.endpoints.ab_experiments.update(
-                id=ab_experiment.id,
-                endpoint_id=endpoint.id,
-                update_mask="members",
-                members=members,
-                etag=etag if etag is not None else (ab_experiment.etag or omit),
-            ),
-        )
+        assert ab_experiment is not None
+        if ab_already_at_percent:
+            updated_ab = ab_experiment
+        else:
+            assert ab_members is not None
+            updated_ab = await show_loading_status(
+                "Updating A/B experiment...",
+                config.client.beta.endpoints.ab_experiments.update(
+                    id=ab_experiment.id,
+                    endpoint_id=endpoint.id,
+                    update_mask="members",
+                    members=ab_members,
+                    etag=ab_experiment.etag or omit,
+                ),
+            )
 
     if config.json:
-        payload: dict[str, Any] = {}
-        if updated is not None:
-            payload["deployment"] = updated
-        if updated_ab is not None:
-            payload["ab_experiment"] = updated_ab
-        if traffic_weight is not None:
-            payload["endpoint"] = endpoint
-        if len(payload) == 1:
-            console.print_json(openapi_dumps(next(iter(payload.values()))).decode("utf-8"))
-        else:
+        # Preserve pre--ab-percent unwrapped precedence for existing flag combos.
+        # Only wrap when --ab-percent is involved (may combine with other updates).
+        if ab_percent is not None:
+            payload: dict[str, Any] = {"ab_experiment": updated_ab}
+            if updated is not None:
+                payload["deployment"] = updated
+            if traffic_weight is not None:
+                payload["endpoint"] = endpoint
             console.print_json(openapi_dumps(payload).decode("utf-8"))
+        elif updated is not None:
+            console.print_json(openapi_dumps(updated).decode("utf-8"))
+        else:
+            console.print_json(openapi_dumps(endpoint).decode("utf-8"))
         return
 
     if updated is not None:
         console.print(f"[green]√[/green] Updated deployment {updated.name or id}.\n\n")
     if traffic_weight is not None:
         console.print(f"[green]√[/green] Updated traffic weight for deployment {id}.\n\n")
-    if updated_ab is not None:
-        console.print(f"[green]√[/green] Updated A/B percent for deployment {id}.\n\n")
+    if ab_percent is not None:
+        assert updated_ab is not None
+        if ab_already_at_percent:
+            console.print(f"Deployment {id} is already at {ab_percent}%.\n\n")
+        else:
+            console.print(f"[green]√[/green] Updated A/B percent for deployment {id}.\n\n")
         print_ab_experiment_detail(updated_ab)
         console.print()
     await retrieve_endpoint(endpoint.id, config=config)

--- a/src/together/lib/cli/api/beta/endpoints/update.py
+++ b/src/together/lib/cli/api/beta/endpoints/update.py
@@ -98,7 +98,15 @@ async def update(
             validator=Number(gte=1, lte=99),
         ),
     ] = None,
-    etag: Annotated[Optional[str], Parameter(help="ETag for optimistic concurrency")] = None,
+    etag: Annotated[
+        Optional[str],
+        Parameter(
+            help=(
+                "ETag for optimistic concurrency. Applies to the deployment update, "
+                "and to the A/B experiment update when --ab-percent is set."
+            )
+        ),
+    ] = None,
     *,
     config: CLIConfigParameter,
 ) -> None:
@@ -182,8 +190,7 @@ async def update(
                 endpoint_id=endpoint.id,
                 update_mask="members",
                 members=members,
-                etag=ab_experiment.etag or omit,
-                project_id=config.project_id,
+                etag=etag if etag is not None else (ab_experiment.etag or omit),
             ),
         )
 

--- a/src/together/lib/cli/api/beta/endpoints/update.py
+++ b/src/together/lib/cli/api/beta/endpoints/update.py
@@ -12,8 +12,13 @@ from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.api.beta.endpoints.ab import print_ab_experiment_detail
 from together.lib.cli.api.beta.endpoints.retrieve import retrieve as retrieve_endpoint
 from together.lib.cli.api.beta.endpoints._utils._traffic_split import upsert_traffic_weight
+from together.lib.cli.api.beta.endpoints._utils._ab_experiments import (
+    find_ab_for_deployment,
+    update_ab_member_percent,
+)
 from together.lib.cli.api.beta.endpoints._utils._build_autoscaling import (
     SCALING_METRIC_NAMES,
     ScalingMetricName,
@@ -83,6 +88,16 @@ async def update(
             validator=Number(gte=0),
         ),
     ] = None,
+    ab_percent: Annotated[
+        Optional[int],
+        Parameter(
+            help=(
+                "A/B experiment traffic percentage for this variant deployment. "
+                "Takes from or returns percentage to the control only; other variants are unchanged."
+            ),
+            validator=Number(gte=1, lte=99),
+        ),
+    ] = None,
     etag: Annotated[Optional[str], Parameter(help="ETag for optimistic concurrency")] = None,
     *,
     config: CLIConfigParameter,
@@ -115,7 +130,7 @@ async def update(
     if etag is not None:
         kwargs["etag"] = etag
 
-    if not update_mask and traffic_weight is None:
+    if not update_mask and traffic_weight is None and ab_percent is None:
         console.print("Error: At least one update option must be specified.")
         sys.exit(1)
 
@@ -149,15 +164,54 @@ async def update(
             ),
         )
 
+    updated_ab: Any = None
+    if ab_percent is not None:
+        ab_experiment = await find_ab_for_deployment(
+            config.client,
+            endpoint.id,
+            id,
+            config.project_id,
+        )
+        if ab_experiment is None:
+            raise ValueError(f"Deployment {id} is not part of an A/B experiment.")
+
+        members = update_ab_member_percent(ab_experiment.members, id, ab_percent)
+        updated_ab = await show_loading_status(
+            "Updating A/B experiment...",
+            config.client.beta.endpoints.ab_experiments.update(
+                id=ab_experiment.id,
+                endpoint_id=endpoint.id,
+                update_mask="members",
+                members=members,
+                etag=ab_experiment.etag or omit,
+                project_id=config.project_id,
+            ),
+        )
+
     if config.json:
+        payload: dict[str, Any] = {}
         if updated is not None:
-            console.print_json(openapi_dumps(updated).decode("utf-8"))
+            payload["deployment"] = updated
+        if updated_ab is not None:
+            payload["ab_experiment"] = updated_ab
+        if traffic_weight is not None:
+            payload["endpoint"] = endpoint
+        if not payload:
+            payload["endpoint"] = endpoint
+        if len(payload) == 1:
+            console.print_json(openapi_dumps(next(iter(payload.values()))).decode("utf-8"))
         else:
-            console.print_json(openapi_dumps(endpoint).decode("utf-8"))
+            console.print_json(openapi_dumps(payload).decode("utf-8"))
         return
 
     if updated is not None:
         console.print(f"[green]√[/green] Updated deployment {updated.name or id}.\n\n")
-    else:
+    if traffic_weight is not None:
         console.print(f"[green]√[/green] Updated traffic weight for deployment {id}.\n\n")
+    if updated_ab is not None:
+        console.print(f"[green]√[/green] Updated A/B percent for deployment {id}.\n\n")
+        print_ab_experiment_detail(updated_ab)
+        console.print()
+    if updated is None and traffic_weight is None and updated_ab is None:
+        console.print(f"[green]√[/green] Updated deployment {id}.\n\n")
     await retrieve_endpoint(endpoint.id, config=config)

--- a/src/together/lib/cli/api/beta/endpoints/update.py
+++ b/src/together/lib/cli/api/beta/endpoints/update.py
@@ -202,8 +202,6 @@ async def update(
             payload["ab_experiment"] = updated_ab
         if traffic_weight is not None:
             payload["endpoint"] = endpoint
-        if not payload:
-            payload["endpoint"] = endpoint
         if len(payload) == 1:
             console.print_json(openapi_dumps(next(iter(payload.values()))).decode("utf-8"))
         else:
@@ -218,6 +216,4 @@ async def update(
         console.print(f"[green]√[/green] Updated A/B percent for deployment {id}.\n\n")
         print_ab_experiment_detail(updated_ab)
         console.print()
-    if updated is None and traffic_weight is None and updated_ab is None:
-        console.print(f"[green]√[/green] Updated deployment {id}.\n\n")
     await retrieve_endpoint(endpoint.id, config=config)

--- a/src/together/lib/cli/api/beta/endpoints/update.py
+++ b/src/together/lib/cli/api/beta/endpoints/update.py
@@ -17,7 +17,7 @@ from together.lib.cli.api.beta.endpoints.retrieve import retrieve as retrieve_en
 from together.lib.cli.api.beta.endpoints._utils._traffic_split import upsert_traffic_weight
 from together.lib.cli.api.beta.endpoints._utils._ab_experiments import (
     find_ab_for_deployment,
-    update_ab_member_percent,
+    build_ab_members_with_percent,
 )
 from together.lib.cli.api.beta.endpoints._utils._build_autoscaling import (
     SCALING_METRIC_NAMES,
@@ -174,7 +174,7 @@ async def update(
         if ab_experiment is None:
             raise ValueError(f"Deployment {id} is not part of an A/B experiment.")
 
-        members = update_ab_member_percent(ab_experiment.members, id, ab_percent)
+        members = build_ab_members_with_percent(ab_experiment.members, id, ab_percent)
         updated_ab = await show_loading_status(
             "Updating A/B experiment...",
             config.client.beta.endpoints.ab_experiments.update(

--- a/src/together/lib/cli/api/beta/endpoints/update.py
+++ b/src/together/lib/cli/api/beta/endpoints/update.py
@@ -170,7 +170,6 @@ async def update(
             config.client,
             endpoint.id,
             id,
-            config.project_id,
         )
         if ab_experiment is None:
             raise ValueError(f"Deployment {id} is not part of an A/B experiment.")

--- a/src/together/lib/cli/api/beta/endpoints/update.py
+++ b/src/together/lib/cli/api/beta/endpoints/update.py
@@ -34,6 +34,7 @@ async def update(
         str,
         Parameter(help=("Deployment ID to update.")),
     ],
+    *,
     name: Annotated[Optional[str], Parameter(help="Updated deployment name")] = None,
     min_replicas: Annotated[
         Optional[int], Parameter(help="New minimum replicas; set both replica bounds to 0 to stop the deployment")
@@ -100,9 +101,10 @@ async def update(
     ] = None,
     etag: Annotated[
         Optional[str],
-        Parameter(help="ETag for optimistic concurrency on the deployment update."),
+        Parameter(
+            help="ETag for optimistic concurrency on the deployment update (does not apply to ab_percent or traffic_weight)."
+        ),
     ] = None,
-    *,
     config: CLIConfigParameter,
 ) -> None:
     """Update a deployment's parameters on an endpoint."""

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -332,6 +332,9 @@ BETA_ENDPOINTS_UPDATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
 [dim]-[/dim] Shift live traffic weight (relative to other deployments):
   [primary]tg beta endpoints update <deployment-id> --traffic-weight 2[/primary]
 
+[dim]-[/dim] Set an A/B variant percent (takes from or returns to control):
+  [primary]tg beta endpoints update <variant-deployment-id> --ab-percent 20[/primary]
+
 [dim]-[/dim] Rename a deployment:
   [primary]tg beta endpoints update <deployment-id> --name my-deployment-v2[/primary]
 """

--- a/tests/cli/test_beta_endpoints_ab.py
+++ b/tests/cli/test_beta_endpoints_ab.py
@@ -13,10 +13,10 @@ from tests.cli.utils import CliRunner
 from together.types.beta import AbMember
 from together.types.beta.endpoint import Endpoint
 from together.lib.cli.api.beta.endpoints.ab import (
-    calculate_ab_members,
     build_ab_experiment_name,
     verify_control_receiving_traffic,
 )
+from together.lib.cli.api.beta.endpoints._utils._ab_experiments import calculate_ab_members
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 

--- a/tests/cli/test_beta_endpoints_update.py
+++ b/tests/cli/test_beta_endpoints_update.py
@@ -475,6 +475,28 @@ class TestBetaEndpointsUpdateAbPercent:
         }
 
     @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_uses_user_supplied_etag(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_ab_experiment_body()], "next_cursor": None},
+            )
+        )
+        update_ab = respx_mock.patch("/projects/proj/endpoints/ep_1/abExperiments/abx_1").mock(
+            return_value=httpx.Response(200, json=_ab_experiment_body())
+        )
+
+        result = cli_runner.invoke(_update_args("dep_variant", "--ab-percent", "20", "--etag", "user-etag"))
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(cast(Call, update_ab.calls[0]).request.content.decode())["etag"] == "user-etag"
+
+    @pytest.mark.respx(base_url=base_url)
     def test_update_ab_percent_errors_when_not_in_ab_experiment(
         self,
         respx_mock: MockRouter,

--- a/tests/cli/test_beta_endpoints_update.py
+++ b/tests/cli/test_beta_endpoints_update.py
@@ -485,7 +485,7 @@ class TestBetaEndpointsUpdateAbPercent:
         }
 
     @pytest.mark.respx(base_url=base_url)
-    def test_update_ab_percent_uses_user_supplied_etag(
+    def test_update_ab_percent_ignores_user_etag_for_experiment(
         self,
         respx_mock: MockRouter,
         cli_runner: CliRunner,
@@ -497,14 +497,22 @@ class TestBetaEndpointsUpdateAbPercent:
                 json={"object": "list", "data": [_ab_experiment_body()], "next_cursor": None},
             )
         )
+        update_dep = respx_mock.patch("/projects/proj/endpoints/ep_1/deployments/dep_variant").mock(
+            return_value=httpx.Response(200, json=_deployment_body(id="dep_variant", name="renamed"))
+        )
         update_ab = respx_mock.patch("/projects/proj/endpoints/ep_1/abExperiments/abx_1").mock(
             return_value=httpx.Response(200, json=_ab_experiment_body())
         )
 
-        result = cli_runner.invoke(_update_args("dep_variant", "--ab-percent", "20", "--etag", "user-etag"))
+        result = cli_runner.invoke(
+            _update_args("dep_variant", "--name", "renamed", "--ab-percent", "20", "--etag", "user-etag")
+        )
 
         assert result.exit_code == 0, result.output
-        assert json.loads(cast(Call, update_ab.calls[0]).request.content.decode())["etag"] == "user-etag"
+        dep_body = json.loads(cast(Call, update_dep.calls[0]).request.content.decode())
+        ab_body = json.loads(cast(Call, update_ab.calls[0]).request.content.decode())
+        assert dep_body["etag"] == "user-etag"
+        assert ab_body["etag"] == "etag-ab"
 
     @pytest.mark.respx(base_url=base_url)
     def test_update_ab_percent_errors_when_not_in_ab_experiment(
@@ -521,6 +529,27 @@ class TestBetaEndpointsUpdateAbPercent:
         )
 
         result = cli_runner.invoke(_update_args("dep_variant", "--ab-percent", "20"))
+
+        assert result.exit_code != 0
+        assert "Deployment dep_variant is not part of an A/B experiment" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_validates_before_mutations(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [], "next_cursor": None},
+            )
+        )
+        # Intentionally not mocking the deployment PATCH: if validation ran after
+        # mutations, that call would be an unmocked request and fail the test.
+
+        result = cli_runner.invoke(_update_args("dep_variant", "--name", "renamed", "--ab-percent", "20"))
 
         assert result.exit_code != 0
         assert "Deployment dep_variant is not part of an A/B experiment" in result.output
@@ -543,3 +572,105 @@ class TestBetaEndpointsUpdateAbPercent:
 
         assert result.exit_code != 0
         assert "can only update variant deployments" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_noop_skips_patch(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_ab_experiment_body()], "next_cursor": None},
+            )
+        )
+        # Intentionally not mocking the AB PATCH: a no-op must not issue one.
+
+        result = cli_runner.invoke(_update_args("dep_variant", "--ab-percent", "5"))
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["ab_experiment"]["id"] == "abx_1"
+        assert "deployment" not in payload
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_json_wraps_payload(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_ab_experiment_body()], "next_cursor": None},
+            )
+        )
+        respx_mock.patch("/projects/proj/endpoints/ep_1/deployments/dep_variant").mock(
+            return_value=httpx.Response(200, json=_deployment_body(id="dep_variant", name="renamed"))
+        )
+        respx_mock.patch("/projects/proj/endpoints/ep_1/abExperiments/abx_1").mock(
+            return_value=httpx.Response(
+                200,
+                json=_ab_experiment_body(
+                    members=[
+                        {
+                            "deploymentId": "dep_control",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                            "percent": 70,
+                        },
+                        {
+                            "deploymentId": "dep_variant",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                            "percent": 20,
+                        },
+                        {
+                            "deploymentId": "dep_other",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                            "percent": 10,
+                        },
+                    ]
+                ),
+            )
+        )
+
+        result = cli_runner.invoke(_update_args("dep_variant", "--name", "renamed", "--ab-percent", "20"))
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert set(payload.keys()) == {"deployment", "ab_experiment"}
+        assert payload["deployment"]["id"] == "dep_variant"
+        assert payload["ab_experiment"]["id"] == "abx_1"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_name_and_traffic_weight_json_keeps_unwrapped_deployment(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.patch("/projects/proj/endpoints/ep_1/deployments/dep_variant").mock(
+            return_value=httpx.Response(200, json=_deployment_body(id="dep_variant", name="renamed"))
+        )
+        respx_mock.patch("/projects/proj/endpoints/ep_1").mock(
+            return_value=httpx.Response(
+                200,
+                json=_endpoint_body(
+                    trafficSplit=[
+                        {"deploymentId": "dep_control", "weight": 1.0},
+                        {"deploymentId": "dep_variant", "weight": 2.0},
+                    ]
+                ),
+            )
+        )
+
+        result = cli_runner.invoke(_update_args("dep_variant", "--name", "renamed", "--traffic-weight", "2"))
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        # Pre--ab-percent precedence: bare deployment object, not a wrapped multi-key payload.
+        assert payload["id"] == "dep_variant"
+        assert "deployment" not in payload
+        assert "endpoint" not in payload

--- a/tests/cli/test_beta_endpoints_update.py
+++ b/tests/cli/test_beta_endpoints_update.py
@@ -11,7 +11,7 @@ from respx.models import Call
 
 from tests.cli.utils import CliRunner
 from together.types.beta import AbMember
-from together.lib.cli.api.beta.endpoints._utils._ab_experiments import update_ab_member_percent
+from together.lib.cli.api.beta.endpoints._utils._ab_experiments import build_ab_members_with_percent
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -224,7 +224,7 @@ class TestUpdateAbMemberPercent:
             ),
         ]
 
-        updated = update_ab_member_percent(members, "dep_variant", 20)
+        updated = build_ab_members_with_percent(members, "dep_variant", 20)
 
         assert updated == [
             {
@@ -263,7 +263,7 @@ class TestUpdateAbMemberPercent:
             ),
         ]
 
-        updated = update_ab_member_percent(members, "dep_variant", 2)
+        updated = build_ab_members_with_percent(members, "dep_variant", 2)
 
         assert updated == [
             {
@@ -298,7 +298,7 @@ class TestUpdateAbMemberPercent:
         ]
 
         with pytest.raises(ValueError, match="can only update variant deployments"):
-            update_ab_member_percent(members, "dep_control", 80)
+            build_ab_members_with_percent(members, "dep_control", 80)
 
     def test_rejects_control_below_minimum(self) -> None:
         members = [
@@ -320,7 +320,7 @@ class TestUpdateAbMemberPercent:
         ]
 
         with pytest.raises(ValueError, match="control would be 0%"):
-            update_ab_member_percent(members, "dep_variant", 90)
+            build_ab_members_with_percent(members, "dep_variant", 90)
 
 
 class TestBetaEndpointsUpdateAbPercent:

--- a/tests/cli/test_beta_endpoints_update.py
+++ b/tests/cli/test_beta_endpoints_update.py
@@ -10,6 +10,8 @@ from respx import MockRouter
 from respx.models import Call
 
 from tests.cli.utils import CliRunner
+from together.types.beta import AbMember
+from together.lib.cli.api.beta.endpoints._utils._ab_experiments import update_ab_member_percent
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -50,7 +52,68 @@ def _endpoint_body(**overrides: Any) -> dict[str, Any]:
                 "createdAt": "2026-01-01T00:00:00Z",
                 "autoscaling": {"minReplicas": 0, "maxReplicas": 0},
             },
+            {
+                "id": "dep_variant",
+                "name": "variant",
+                "model": "projects/proj/models/ml_variant/revisions/latest",
+                "modelId": "ml_variant",
+                "hardware": "1x-h100",
+                "state": "DEPLOYMENT_STATE_READY",
+                "readyReplicas": 1,
+                "desiredReplicas": 1,
+                "createdAt": "2026-01-01T00:00:00Z",
+                "autoscaling": {"minReplicas": 1, "maxReplicas": 1},
+            },
+            {
+                "id": "dep_other",
+                "name": "other",
+                "model": "projects/proj/models/ml_other/revisions/latest",
+                "modelId": "ml_other",
+                "hardware": "1x-h100",
+                "state": "DEPLOYMENT_STATE_READY",
+                "readyReplicas": 1,
+                "desiredReplicas": 1,
+                "createdAt": "2026-01-01T00:00:00Z",
+                "autoscaling": {"minReplicas": 1, "maxReplicas": 1},
+            },
         ],
+    }
+    body.update(overrides)
+    return body
+
+
+def _ab_experiment_body(
+    experiment_id: str = "abx_1",
+    members: list[dict[str, Any]] | None = None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "id": experiment_id,
+        "projectId": "proj",
+        "endpointId": "ep_1",
+        "name": "control-ab",
+        "members": members
+        or [
+            {
+                "deploymentId": "dep_control",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                "percent": 85,
+            },
+            {
+                "deploymentId": "dep_variant",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                "percent": 5,
+            },
+            {
+                "deploymentId": "dep_other",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                "percent": 10,
+            },
+        ],
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "createdBy": "user_1",
+        "etag": "etag-ab",
     }
     body.update(overrides)
     return body
@@ -133,3 +196,318 @@ class TestBetaEndpointsUpdate:
         result = cli_runner.invoke(["beta", "endpoints", "update", "--project", "proj", "dep_control"])
         assert result.exit_code != 0
         assert "At least one update option must be specified" in result.output
+
+    def test_update_ab_percent_counts_as_update_option(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(
+            ["beta", "endpoints", "update", "--project", "proj", "dep_missing", "--ab-percent", "20"]
+        )
+        assert "At least one update option must be specified" not in result.output
+
+
+class TestUpdateAbMemberPercent:
+    def test_increase_takes_from_control_only(self) -> None:
+        members = [
+            AbMember.construct(
+                deploymentId="dep_control",
+                role="AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                percent=85,
+            ),
+            AbMember.construct(
+                deploymentId="dep_variant",
+                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                percent=5,
+            ),
+            AbMember.construct(
+                deploymentId="dep_other",
+                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                percent=10,
+            ),
+        ]
+
+        updated = update_ab_member_percent(members, "dep_variant", 20)
+
+        assert updated == [
+            {
+                "deployment_id": "dep_control",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                "percent": 70,
+            },
+            {
+                "deployment_id": "dep_variant",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                "percent": 20,
+            },
+            {
+                "deployment_id": "dep_other",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                "percent": 10,
+            },
+        ]
+
+    def test_decrease_returns_to_control_only(self) -> None:
+        members = [
+            AbMember.construct(
+                deploymentId="dep_control",
+                role="AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                percent=85,
+            ),
+            AbMember.construct(
+                deploymentId="dep_variant",
+                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                percent=10,
+            ),
+            AbMember.construct(
+                deploymentId="dep_other",
+                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                percent=5,
+            ),
+        ]
+
+        updated = update_ab_member_percent(members, "dep_variant", 2)
+
+        assert updated == [
+            {
+                "deployment_id": "dep_control",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                "percent": 93,
+            },
+            {
+                "deployment_id": "dep_variant",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                "percent": 2,
+            },
+            {
+                "deployment_id": "dep_other",
+                "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                "percent": 5,
+            },
+        ]
+
+    def test_rejects_control_member(self) -> None:
+        members = [
+            AbMember.construct(
+                deploymentId="dep_control",
+                role="AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                percent=90,
+            ),
+            AbMember.construct(
+                deploymentId="dep_variant",
+                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                percent=10,
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="can only update variant deployments"):
+            update_ab_member_percent(members, "dep_control", 80)
+
+    def test_rejects_control_below_minimum(self) -> None:
+        members = [
+            AbMember.construct(
+                deploymentId="dep_control",
+                role="AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                percent=10,
+            ),
+            AbMember.construct(
+                deploymentId="dep_variant",
+                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                percent=80,
+            ),
+            AbMember.construct(
+                deploymentId="dep_other",
+                role="AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                percent=10,
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="control would be 0%"):
+            update_ab_member_percent(members, "dep_variant", 90)
+
+
+class TestBetaEndpointsUpdateAbPercent:
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_increases_variant_takes_from_control(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_ab_experiment_body()], "next_cursor": None},
+            )
+        )
+        update_ab = respx_mock.patch("/projects/proj/endpoints/ep_1/abExperiments/abx_1").mock(
+            return_value=httpx.Response(
+                200,
+                json=_ab_experiment_body(
+                    members=[
+                        {
+                            "deploymentId": "dep_control",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                            "percent": 70,
+                        },
+                        {
+                            "deploymentId": "dep_variant",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                            "percent": 20,
+                        },
+                        {
+                            "deploymentId": "dep_other",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                            "percent": 10,
+                        },
+                    ]
+                ),
+            )
+        )
+
+        result = cli_runner.invoke(_update_args("dep_variant", "--ab-percent", "20"))
+
+        assert result.exit_code == 0, result.output
+        req = cast(Call, update_ab.calls[0]).request
+        assert "updateMask=members" in str(req.url)
+        assert json.loads(req.content.decode()) == {
+            "etag": "etag-ab",
+            "members": [
+                {
+                    "deploymentId": "dep_control",
+                    "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                    "percent": 70,
+                },
+                {
+                    "deploymentId": "dep_variant",
+                    "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                    "percent": 20,
+                },
+                {
+                    "deploymentId": "dep_other",
+                    "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                    "percent": 10,
+                },
+            ],
+        }
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_decreases_variant_returns_to_control(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        _ab_experiment_body(
+                            members=[
+                                {
+                                    "deploymentId": "dep_control",
+                                    "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                                    "percent": 85,
+                                },
+                                {
+                                    "deploymentId": "dep_variant",
+                                    "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                                    "percent": 10,
+                                },
+                                {
+                                    "deploymentId": "dep_other",
+                                    "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                                    "percent": 5,
+                                },
+                            ]
+                        )
+                    ],
+                    "next_cursor": None,
+                },
+            )
+        )
+        update_ab = respx_mock.patch("/projects/proj/endpoints/ep_1/abExperiments/abx_1").mock(
+            return_value=httpx.Response(
+                200,
+                json=_ab_experiment_body(
+                    members=[
+                        {
+                            "deploymentId": "dep_control",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                            "percent": 93,
+                        },
+                        {
+                            "deploymentId": "dep_variant",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                            "percent": 2,
+                        },
+                        {
+                            "deploymentId": "dep_other",
+                            "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                            "percent": 5,
+                        },
+                    ]
+                ),
+            )
+        )
+
+        result = cli_runner.invoke(_update_args("dep_variant", "--ab-percent", "2"))
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(cast(Call, update_ab.calls[0]).request.content.decode()) == {
+            "etag": "etag-ab",
+            "members": [
+                {
+                    "deploymentId": "dep_control",
+                    "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL",
+                    "percent": 93,
+                },
+                {
+                    "deploymentId": "dep_variant",
+                    "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                    "percent": 2,
+                },
+                {
+                    "deploymentId": "dep_other",
+                    "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT",
+                    "percent": 5,
+                },
+            ],
+        }
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_errors_when_not_in_ab_experiment(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [], "next_cursor": None},
+            )
+        )
+
+        result = cli_runner.invoke(_update_args("dep_variant", "--ab-percent", "20"))
+
+        assert result.exit_code != 0
+        assert "Deployment dep_variant is not part of an A/B experiment" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_rejects_control_member(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint_list(respx_mock)
+        respx_mock.get("/projects/proj/endpoints/ep_1/abExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "data": [_ab_experiment_body()], "next_cursor": None},
+            )
+        )
+
+        result = cli_runner.invoke(_update_args("dep_control", "--ab-percent", "80"))
+
+        assert result.exit_code != 0
+        assert "can only update variant deployments" in result.output

--- a/tests/cli/test_beta_endpoints_update.py
+++ b/tests/cli/test_beta_endpoints_update.py
@@ -197,11 +197,21 @@ class TestBetaEndpointsUpdate:
         assert result.exit_code != 0
         assert "At least one update option must be specified" in result.output
 
-    def test_update_ab_percent_counts_as_update_option(self, cli_runner: CliRunner) -> None:
-        result = cli_runner.invoke(
-            ["beta", "endpoints", "update", "--project", "proj", "dep_missing", "--ab-percent", "20"]
-        )
+    @pytest.mark.respx(base_url=base_url)
+    def test_update_ab_percent_counts_as_update_option(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        # Prove --ab-percent clears the "at least one option" guard by reaching
+        # deployment lookup (not by asserting the absence of an error string).
+        _mock_endpoint_list(respx_mock)
+
+        result = cli_runner.invoke(_update_args("dep_missing", "--ab-percent", "20"))
+
+        assert result.exit_code != 0
         assert "At least one update option must be specified" not in result.output
+        assert "Deployment dep_missing not found" in result.output
 
 
 class TestUpdateAbMemberPercent:

--- a/uv.lock
+++ b/uv.lock
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "together"
-version = "2.27.1"
+version = "2.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Implements ENG-91343: `tg beta endpoints update <dep_id> --ab-percent N`.

- Errors if the deployment is not part of an A/B experiment
- Adjusts only the control member when increasing/decreasing a variant's percent (other variants unchanged)
- Rejects `--ab-percent` on the control deployment itself

## Changes

- Add `--ab-percent` to `tg beta endpoints update`
- Shared AB helpers in `_utils/_ab_experiments.py` (`find_ab_for_deployment`, `update_ab_member_percent`)
- Refactor `rm` to use the shared AB lookup
- Help text / examples updated
- CLI unit + integration tests

## Test plan

- [x] `uv run pytest tests/cli/test_beta_endpoints_update.py tests/cli/test_beta_endpoints_rm.py tests/cli/test_beta_endpoints_ab.py`

```bash
tg beta endpoints update dep_variant123 --ab-percent 20
```

**Note:** This Linear issue was assigned against `together-cli`, but the `tg` CLI lives in `together-py`. PR is against the correct repo.

Fixes ENG-91343