### PR TITLE
chore: bump detect-agent to 0.5.0 (ENG-91347)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "filelock>=3.13.1",
   "types-pyyaml>=6.0.12.20250915",
   "tomli>=2.0.0; python_version < '3.11'",
-  "detect-agent>=0.2.0",
+  "detect-agent>=0.5.0",
 ]
 
 requires-python = ">= 3.10"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -30,7 +30,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   tqdm
 cyclopts==4.10.2
     # via together
-detect-agent==0.2.0
+detect-agent==0.5.0
     # via together
 dirty-equals==0.11
 distro==1.9.0

--- a/uv.lock
+++ b/uv.lock
@@ -250,11 +250,11 @@ wheels = [
 
 [[package]]
 name = "detect-agent"
-version = "0.2.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/76/5a4f8fb1ce9d4d9af1299b66b487089d6e68c398ceb40dbb733905ce518c/detect_agent-0.2.0.tar.gz", hash = "sha256:da0287ca55c96c6ceb36004dd77cd05b7e6aa4c227f29760efdb163c24803ca6", size = 15004, upload-time = "2026-04-15T14:36:48.249Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ea/92fea3787c033488e4aeb56d07abfecb10428b4b2ebd5c7f0376c343741b/detect_agent-0.5.0.tar.gz", hash = "sha256:2344df2b332acaf2f220d119bba26f6f2aeb4f3f3e317ad5718d4dd57df9c5de", size = 45402, upload-time = "2026-07-24T17:16:15.626Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/22/91e9fd72f3724b63a39054f793e601ce5e73de4ab6740aea89e4123d1413/detect_agent-0.2.0-py3-none-any.whl", hash = "sha256:769f1885003605d2fca806fddcd7d3c5189c3460c4771f95ff856d464ea56a18", size = 3504, upload-time = "2026-04-15T14:36:49.151Z" },
+    { url = "https://files.pythonhosted.org/packages/21/41/1b201289f128a2c1d247e6777eb6804bff852643ada516e092a63020dc71/detect_agent-0.5.0-py3-none-any.whl", hash = "sha256:58dd50744a4e87ea7e658442675f72b7a998cdc3d8b1e0f7130e253d0f892d65", size = 11198, upload-time = "2026-07-24T17:16:14.837Z" },
 ]
 
 [[package]]
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "together"
-version = "2.27.1"
+version = "2.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -1633,7 +1633,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'aiohttp'" },
     { name = "anyio", specifier = ">=3.5.0,<5" },
     { name = "cyclopts", specifier = ">=4.6.0" },
-    { name = "detect-agent", specifier = ">=0.2.0" },
+    { name = "detect-agent", specifier = ">=0.5.0" },
     { name = "distro", specifier = ">=1.7.0,<2" },
     { name = "filelock", specifier = ">=3.13.1" },
     { name = "httpx", specifier = ">=0.23.0,<1" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bumps `detect-agent` from `>=0.2.0` to `>=0.5.0` and refreshes lockfiles.

## Why
ENG-91347 — update together-py to detect_agent 0.5.0 for broader/more accurate agent detection (upstream `agents.json` engine, improved Cursor detection, v0, additional agents).

## Changes
- `pyproject.toml`: `detect-agent>=0.5.0`
- `uv.lock` / `requirements-dev.lock`: pin `detect-agent==0.5.0`

No call-site changes needed — `determine_agent()` return shape (`is_agent` / `agent.name`) is unchanged.

## Test plan
- [x] `uv sync --all-extras` installs `detect-agent==0.5.0`
- [x] Smoke: `agent_headers()`, `_is_agent_or_ci()`, help formatter import
- [x] `pytest tests/test_client.py -k "header or agent or user_agent"` (52 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-91347](https://linear.app/together-ai/issue/ENG-91347/update-together-py-to-detect-agent-050)

<div><a href="https://cursor.com/agents/bc-d2a142f7-aece-42c6-a21f-4bc62694d400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2a142f7-aece-42c6-a21f-4bc62694d400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

