### PR TITLE
fix(cli): Avoid printing configs in endpoint ls command

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ async with client.beta.realtime.transcription(
 
     async for event in session:
         if isinstance(event, TranscriptDelta):
-            print("interim:", event.text)   # updates while a phrase is spoken
+            print("interim:", event.text)  # updates while a phrase is spoken
         elif isinstance(event, TranscriptCompleted):
-            print("final:", event.text)     # one per finished utterance
+            print("final:", event.text)  # one per finished utterance
 
     transcript = await session.flush()  # finalize whatever was said last
 ```

--- a/src/together/lib/cli/api/beta/endpoints/list.py
+++ b/src/together/lib/cli/api/beta/endpoints/list.py
@@ -15,7 +15,7 @@ from together.lib.cli.utils._console import console
 from together.lib.cli.components.list import ListTable
 from together.lib.cli.components.loader import show_loading_status
 from together.lib.cli.utils._mock_pagination import AfterParameter
-from together.lib.cli.api.beta.endpoints._utils._resolve_model import MODEL_PATH_RE, resolve_model
+from together.lib.cli.api.beta.endpoints._utils._resolve_model import MODEL_PATH_RE
 
 
 async def _resolve_model_names(endpoints: List[Endpoint], config: CLIConfigParameter) -> dict[str, str]:
@@ -37,7 +37,11 @@ async def _resolve_model_names(endpoints: List[Endpoint], config: CLIConfigParam
         except Exception:
             return model_id, model_id
 
-    return dict(await asyncio.gather(*(fetch_model_name(model_resource_path, model_id) for model_resource_path, model_id in model_resource_paths)))
+    return dict(
+        await asyncio.gather(
+            *(fetch_model_name(model_resource_path, model_id) for model_resource_path, model_id in model_resource_paths)
+        )
+    )
 
 
 def _print_next_page(next_cursor: str | None, *, public: bool = False, org: bool = False) -> None:

--- a/src/together/lib/cli/api/beta/endpoints/list.py
+++ b/src/together/lib/cli/api/beta/endpoints/list.py
@@ -15,25 +15,29 @@ from together.lib.cli.utils._console import console
 from together.lib.cli.components.list import ListTable
 from together.lib.cli.components.loader import show_loading_status
 from together.lib.cli.utils._mock_pagination import AfterParameter
-from together.lib.cli.api.beta.endpoints._utils._resolve_model import resolve_model
+from together.lib.cli.api.beta.endpoints._utils._resolve_model import MODEL_PATH_RE, resolve_model
 
 
 async def _resolve_model_names(endpoints: List[Endpoint], config: CLIConfigParameter) -> dict[str, str]:
-    model_ids = {
-        deployment.api_model_id
+    model_resource_paths = {
+        (deployment.model, deployment.api_model_id)
         for endpoint in endpoints
         for deployment in endpoint.deployments or []
-        if deployment.api_model_id
+        if deployment.model and deployment.api_model_id
     }
 
-    async def fetch_model_name(model_id: str) -> tuple[str, str]:
+    async def fetch_model_name(model_resource_path: str, model_id: str) -> tuple[str, str]:
         try:
-            # TODO: We should be able to just do a GET on the deployment.api_model instead of trying to resolve from the id.
-            return model_id, (await resolve_model(config, model_id)).name
+            match = MODEL_PATH_RE.match(model_resource_path)
+            if match is None:
+                return model_id, model_id
+            project_id, model_id = match.group(1), match.group(2)
+            model = await config.client.beta.models.retrieve(model_id, project_id=project_id)
+            return model_id, model.name
         except Exception:
             return model_id, model_id
 
-    return dict(await asyncio.gather(*(fetch_model_name(model_id) for model_id in model_ids)))
+    return dict(await asyncio.gather(*(fetch_model_name(model_resource_path, model_id) for model_resource_path, model_id in model_resource_paths)))
 
 
 def _print_next_page(next_cursor: str | None, *, public: bool = False, org: bool = False) -> None:

--- a/tests/cli/test_beta_endpoints.py
+++ b/tests/cli/test_beta_endpoints.py
@@ -332,7 +332,8 @@ class TestBetaEndpointsList:
 
     @pytest.mark.respx(base_url=base_url)
     def test_list_handles_deployment_without_hardware(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
-        _mock_model_and_config(respx_mock)
+        # List only resolves model display names; it does not fetch configs.
+        respx_mock.get("/projects/proj/models/ml_1").mock(return_value=httpx.Response(200, json=_model_body()))
         respx_mock.get("/projects/proj/endpoints").mock(
             return_value=httpx.Response(
                 200,

--- a/uv.lock
+++ b/uv.lock
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "together"
-version = "2.27.1"
+version = "2.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Because it's reusing the resolve_model api, it may print a configs table when a model has more than one config. This has zero benefit to the user and confusing. Address the TODO that's been there.


before | after
---|---
<img width="1118" height="409" alt="image" src="https://github.com/user-attachments/assets/fca2ff64-7c7f-4b0f-b12f-694fd85ae7ee" /> | 
<img width="1114" height="81" alt="image" src="https://github.com/user-attachments/assets/e69d53fa-ba4a-4dd6-8b35-031319dc371a" />
