### PR TITLE
feat(cli): add NVIDIA catalog version selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 .envrc
 codegen.log
 Brewfile.lock.json
+.codemogger/

--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -397,7 +397,10 @@ async def launcher(
         elif not isinstance(e, APIError):
             # API Errors are handled better inside the run_command() function
             # We don't want to raise them here as that will print a stack trace which we do not want.
-            console.print(f"[red]Error:[/red] {escape_rich_markup(str(e))}")
+            if config.json:
+                console.print_json(openapi_dumps({"error": str(e)}).decode("utf-8"))
+            else:
+                console.print(f"[red]Error:[/red] {escape_rich_markup(str(e))}")
 
         sys.exit(1)
     finally:

--- a/src/together/lib/cli/api/beta/clusters/create.py
+++ b/src/together/lib/cli/api/beta/clusters/create.py
@@ -170,7 +170,7 @@ async def _set_nvidia_version_params(
             "Use --nvidia-version-id or provide --nvidia-driver-version and --cuda-version in non-interactive mode."
         )
 
-    if not interactive and os_name is None:
+    if has_driver and os_name is None:
         return
 
     region = params.get("region")

--- a/src/together/lib/cli/api/beta/clusters/create.py
+++ b/src/together/lib/cli/api/beta/clusters/create.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import getpass
-from typing import Any, List, Literal, Optional, Annotated, cast
+from typing import Any, Literal, Optional, Sequence, Annotated, cast
 
 from cyclopts import Parameter
 
+from together import TogetherError
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.types.beta.cluster_create_params import AddOn, SharedVolume, ClusterCreateParams
+from together.types.beta.cluster_list_regions_response import (
+    RegionDriverVersion,
+    ClusterListRegionsResponse,
+)
 
 NameParameter = Annotated[Optional[str], Parameter(help="Name of the cluster")]
 NumGpusParameter = Annotated[Optional[int], Parameter(help="Number of GPUs to allocate in the cluster")]
@@ -19,6 +24,10 @@ BillingTypeParameter = Annotated[
 ]
 NvidiaDriverVersionParameter = Annotated[Optional[str], Parameter(help="Nvidia driver version to use for the cluster")]
 CudaVersionParameter = Annotated[Optional[str], Parameter(help="CUDA version to use for the cluster")]
+OSParameter = Annotated[Optional[str], Parameter(help="Operating system for NVIDIA version selection")]
+NvidiaVersionIDParameter = Annotated[
+    Optional[str], Parameter(help="NVIDIA version catalog ID to use directly for the cluster")
+]
 DurationDaysParameter = Annotated[
     Optional[int], Parameter(help="Duration in days to keep the cluster running for reserved clusters")
 ]
@@ -48,6 +57,147 @@ ReservationStartTimeParameter = Annotated[
 SlurmImageParameter = Annotated[Optional[str], Parameter(help="Custom Slurm image for Slurm clusters")]
 SlurmShmSizeGibParameter = Annotated[Optional[int], Parameter(help="Shared memory size in GiB for Slurm clusters")]
 
+_DEFAULT_NVIDIA_VERSION_CHOICE = 1
+
+
+def _format_nvidia_version(version: RegionDriverVersion) -> str:
+    details = f"driver {version.nvidia_driver_version}, CUDA {version.cuda_version}"
+    if version.os:
+        details += f", OS {version.os}"
+    if version.id:
+        details += f" ({version.id})"
+
+    return details
+
+
+def _region_nvidia_versions(
+    catalog: ClusterListRegionsResponse,
+    region: str,
+) -> list[RegionDriverVersion]:
+    for catalog_region in catalog.regions:
+        if catalog_region.name == region:
+            return catalog_region.driver_versions
+
+    raise TogetherError(f"No NVIDIA versions are available in region '{region}'. Run `tg beta clusters list-regions`.")
+
+
+def _resolve_nvidia_version(
+    catalog: ClusterListRegionsResponse,
+    *,
+    region: str,
+    nvidia_driver_version: str | None,
+    cuda_version: str | None,
+    os_name: str | None,
+) -> RegionDriverVersion:
+    matches = [
+        version
+        for version in _region_nvidia_versions(catalog, region)
+        if (nvidia_driver_version is None or version.nvidia_driver_version == nvidia_driver_version)
+        and (cuda_version is None or version.cuda_version == cuda_version)
+        and (os_name is None or version.os == os_name)
+    ]
+    requested = ", ".join(
+        value
+        for value in (
+            f"driver {nvidia_driver_version}" if nvidia_driver_version else "",
+            f"CUDA {cuda_version}" if cuda_version else "",
+            f"OS {os_name}" if os_name else "",
+        )
+        if value
+    )
+
+    if not matches:
+        raise TogetherError(
+            f"No NVIDIA version matches {requested} in region '{region}'. Run `tg beta clusters list-regions`."
+        )
+    if len(matches) > 1:
+        choices = "; ".join(_format_nvidia_version(version) for version in matches)
+        guidance = "Use --nvidia-version-id." if os_name else "Add --os or use --nvidia-version-id."
+        raise TogetherError(
+            f"Multiple NVIDIA versions match {requested} in region '{region}'. {guidance} Matches: {choices}"
+        )
+
+    return matches[0]
+
+
+def _prompt_nvidia_version(versions: Sequence[RegionDriverVersion]) -> RegionDriverVersion:
+    if not versions:
+        raise TogetherError("No NVIDIA versions are available in the selected region.")
+
+    console.print("Clusters: Available NVIDIA versions:")
+    for choice, version in enumerate(versions, start=_DEFAULT_NVIDIA_VERSION_CHOICE):
+        console.print(f"  {choice}. {_format_nvidia_version(version)}")
+
+    raw_choice = input(f"Clusters: Select NVIDIA version [{_DEFAULT_NVIDIA_VERSION_CHOICE}]: ").strip()
+    try:
+        choice = int(raw_choice) if raw_choice else _DEFAULT_NVIDIA_VERSION_CHOICE
+    except ValueError as exc:
+        raise TogetherError("Select an NVIDIA version by its listed number.") from exc
+    if choice < _DEFAULT_NVIDIA_VERSION_CHOICE or choice > len(versions):
+        raise TogetherError(f"Select an NVIDIA version from 1 to {len(versions)}.")
+
+    return versions[choice - _DEFAULT_NVIDIA_VERSION_CHOICE]
+
+
+async def _set_nvidia_version_params(
+    *,
+    config: CLIConfigParameter,
+    params: dict[str, Any],
+    catalog: ClusterListRegionsResponse | None,
+    interactive: bool,
+    nvidia_version_id: str | None,
+    nvidia_driver_version: str | None,
+    cuda_version: str | None,
+    os_name: str | None,
+) -> None:
+    semantic_version_given = any(value is not None for value in (nvidia_driver_version, cuda_version, os_name))
+    if nvidia_version_id and semantic_version_given:
+        raise TogetherError("Use either --nvidia-version-id or --nvidia-driver-version/--cuda-version/--os, not both.")
+
+    has_driver = nvidia_driver_version is not None
+    has_cuda = cuda_version is not None
+    if not nvidia_version_id and (has_driver != has_cuda or (os_name is not None and not has_driver)):
+        raise TogetherError("--nvidia-driver-version and --cuda-version must be provided together; --os requires both.")
+
+    if nvidia_version_id:
+        params["nvidia_version_id"] = nvidia_version_id
+        params.pop("nvidia_driver_version", None)
+        params.pop("cuda_version", None)
+        return
+
+    if not interactive and not has_driver:
+        raise TogetherError(
+            "Use --nvidia-version-id or provide --nvidia-driver-version and --cuda-version in non-interactive mode."
+        )
+
+    if not interactive and os_name is None:
+        return
+
+    region = params.get("region")
+    if not region:
+        raise TogetherError("--region is required when selecting an NVIDIA version.")
+
+    if catalog is None:
+        catalog = await config.client.beta.clusters.list_regions()
+    if semantic_version_given:
+        selected = _resolve_nvidia_version(
+            catalog,
+            region=region,
+            nvidia_driver_version=nvidia_driver_version,
+            cuda_version=cuda_version,
+            os_name=os_name,
+        )
+    else:
+        selected = _prompt_nvidia_version(_region_nvidia_versions(catalog, region))
+
+    if selected.id:
+        params["nvidia_version_id"] = selected.id
+        params.pop("nvidia_driver_version", None)
+        params.pop("cuda_version", None)
+    else:
+        params["nvidia_driver_version"] = selected.nvidia_driver_version
+        params["cuda_version"] = selected.cuda_version
+
 
 async def create(
     name: NameParameter = None,
@@ -56,6 +206,8 @@ async def create(
     billing_type: BillingTypeParameter = None,
     nvidia_driver_version: NvidiaDriverVersionParameter = None,
     cuda_version: CudaVersionParameter = None,
+    os: OSParameter = None,
+    nvidia_version_id: NvidiaVersionIDParameter = None,
     duration_days: DurationDaysParameter = None,
     gpu_type: GpuTypeParameter = None,
     cluster_type: ClusterTypeParameter = None,
@@ -135,7 +287,9 @@ async def create(
         params["slurm_shm_size_gib"] = slurm_shm_size_gib
 
     # JSON Mode skips hand holding through the argument setup
-    if not config.json and not config.non_interactive:
+    interactive = not config.json and not config.non_interactive
+    catalog: ClusterListRegionsResponse | None = None
+    if interactive:
         if not name:
             params["cluster_name"] = (
                 input(f"Clusters: Cluster name: [{getpass.getuser()}] ").strip() or getpass.getuser()
@@ -145,9 +299,9 @@ async def create(
                 "Clusters: Cluster GPU type (H100_SXM, H200_SXM, RTX_6000_PCI, L40_PCIE, B200_SXM, H100_SXM_INF): "
             ).strip()
         if not region:
-            regions = await config.client.beta.clusters.list_regions()
+            catalog = await config.client.beta.clusters.list_regions()
             params["region"] = (
-                input(f"Clusters: Cluster region [{regions.regions[0].name}]: ").strip() or regions.regions[0].name
+                input(f"Clusters: Cluster region [{catalog.regions[0].name}]: ").strip() or catalog.regions[0].name
             )
         if num_gpus is None:
             n = input("Clusters: Cluster GPUs count (8-64): ").strip()
@@ -157,22 +311,19 @@ async def create(
             params["num_preemptible_gpus"] = int(n) if n else 0
         if not billing_type:
             params["billing_type"] = input("Clusters: Cluster billing type [ON_DEMAND]: ").strip() or "ON_DEMAND"
-        if not nvidia_driver_version:
-            regions = await config.client.beta.clusters.list_regions()
-            nvidia_driver_versions: List[str] = []
-            for r in regions.regions:
-                if r.name == params.get("region"):
-                    for driver_version in r.driver_versions:
-                        nvidia_driver_versions.append(driver_version.nvidia_driver_version)
-            params["nvidia_driver_version"] = input(f"Clusters: Cluster Nvidia driver version [550]: ").strip() or "550"
-        if not cuda_version:
-            regions = await config.client.beta.clusters.list_regions()
-            cuda_versions: List[str] = []
-            for r in regions.regions:
-                if r.name == params.get("region"):
-                    for driver_version in r.driver_versions:
-                        cuda_versions.append(driver_version.cuda_version)
-            params["cuda_version"] = input(f"Clusters: Cluster CUDA version [12.5]: ").strip() or "12.5"
+
+    await _set_nvidia_version_params(
+        config=config,
+        params=params,
+        catalog=catalog,
+        interactive=interactive,
+        nvidia_version_id=nvidia_version_id,
+        nvidia_driver_version=nvidia_driver_version,
+        cuda_version=cuda_version,
+        os_name=os,
+    )
+
+    if interactive:
         if duration_days is None and params.get("billing_type") == "RESERVED":
             d = input("Clusters: Cluster reserved duration (1-90 days) [3]: ").strip()
             params["duration_days"] = int(d) if d else 3

--- a/src/together/lib/cli/api/beta/clusters/list_regions.py
+++ b/src/together/lib/cli/api/beta/clusters/list_regions.py
@@ -24,9 +24,16 @@ async def list_regions(
     for region in response.regions:
         driver_versions: list[str] = []
         for driver_version in region.driver_versions or []:
-            driver_versions.append(
-                f"[dim]NVIDIA Driver:[/dim] [blue]{driver_version.nvidia_driver_version}[/blue] [dim]CUDA Version:[/dim] [blue]{driver_version.cuda_version}[/blue]"
-            )
+            details = [
+                f"[dim]NVIDIA Driver:[/dim] [blue]{driver_version.nvidia_driver_version}[/blue]",
+                f"[dim]CUDA Version:[/dim] [blue]{driver_version.cuda_version}[/blue]",
+            ]
+            if driver_version.os:
+                details.append(f"[dim]OS:[/dim] [blue]{driver_version.os}[/blue]")
+            if driver_version.id:
+                details.append(f"[dim]ID:[/dim] [blue]{driver_version.id}[/blue]")
+
+            driver_versions.append(" ".join(details))
 
         table.add_row(region.name, "\n".join(region.supported_instance_types or []), "\n".join(driver_versions))
 

--- a/src/together/resources/beta/clusters/clusters.py
+++ b/src/together/resources/beta/clusters/clusters.py
@@ -80,9 +80,6 @@ class ClustersResource(SyncAPIResource):
         gpu_type: Literal["H100_SXM", "H200_SXM", "RTX_6000_PCI", "L40_PCIE", "B200_SXM", "H100_SXM_INF", "B300_SXM"],
         num_gpus: int,
         region: str,
-        cuda_version: str | Omit = omit,
-        nvidia_driver_version: str | Omit = omit,
-        nvidia_version_id: str | Omit = omit,
         acceptance_tests_params: cluster_create_params.AcceptanceTestsParams | Omit = omit,
         add_ons: Iterable[cluster_create_params.AddOn] | Omit = omit,
         auto_scale: bool | Omit = omit,
@@ -91,11 +88,14 @@ class ClustersResource(SyncAPIResource):
         capacity_pool_id: str | Omit = omit,
         cluster_config: cluster_create_params.ClusterConfig | Omit = omit,
         cluster_type: Literal["KUBERNETES", "SLURM"] | Omit = omit,
+        cuda_version: str | Omit = omit,
         duration_days: int | Omit = omit,
         install_traefik: bool | Omit = omit,
         num_capacity_pool_gpus: int | Omit = omit,
         num_preemptible_gpus: int | Omit = omit,
         num_reserved_gpus: int | Omit = omit,
+        nvidia_driver_version: str | Omit = omit,
+        nvidia_version_id: str | Omit = omit,
         oidc_config: cluster_create_params.OidcConfig | Omit = omit,
         project_id: str | Omit = omit,
         reservation_end_time: Union[str, datetime] | Omit = omit,
@@ -128,17 +128,10 @@ class ClustersResource(SyncAPIResource):
 
           cluster_name: Name of the GPU cluster.
 
-          cuda_version: Legacy CUDA version for this cluster. For example, 12.5
-
           gpu_type: Type of GPU to use in the cluster
 
           num_gpus: Number of GPUs to allocate in the cluster. This must be multiple of 8. For
               example, 8, 16 or 24
-
-          nvidia_driver_version: Legacy Nvidia driver version for this cluster. For example, 550. Only some combination
-              of cuda_version and nvidia_driver_version are supported.
-
-          nvidia_version_id: NVIDIA version catalog ID for this cluster.
 
           region: Region to create the GPU cluster in. Usable regions can be found from
               `client.clusters.list_regions()`
@@ -163,6 +156,11 @@ class ClustersResource(SyncAPIResource):
 
           cluster_type: Type of cluster to create.
 
+          cuda_version: Legacy CUDA selector for this cluster. Bare semantic values such as 12.5 select
+              ubuntu-22.04; existing OS-suffixed values remain accepted for compatibility.
+              Must be paired with nvidia_driver_version. Prefer nvidia_version_id for new
+              integrations.
+
           duration_days: Duration in days to keep the cluster running.
 
           install_traefik: Whether to install Traefik ingress controller in the cluster. This field is only
@@ -178,6 +176,12 @@ class ClustersResource(SyncAPIResource):
 
           num_reserved_gpus: Number of prepaid (PLG) reserved GPUs for this cluster. When omitted for
               RESERVED billing on create, the server defaults this to num_gpus.
+
+          nvidia_driver_version: Legacy NVIDIA driver selector for this cluster. For example, 550. Must be paired
+              with cuda_version. Prefer nvidia_version_id for new integrations.
+
+          nvidia_version_id: Canonical region-specific NVIDIA version ID. If cuda_version and
+              nvidia_driver_version are also set, they must resolve to the same catalog entry.
 
           project_id: Project ID for the cluster. If not set, the project from the request context is
               used.
@@ -212,11 +216,8 @@ class ClustersResource(SyncAPIResource):
                 {
                     "billing_type": billing_type,
                     "cluster_name": cluster_name,
-                    "cuda_version": cuda_version,
                     "gpu_type": gpu_type,
                     "num_gpus": num_gpus,
-                    "nvidia_driver_version": nvidia_driver_version,
-                    "nvidia_version_id": nvidia_version_id,
                     "region": region,
                     "acceptance_tests_params": acceptance_tests_params,
                     "add_ons": add_ons,
@@ -226,11 +227,14 @@ class ClustersResource(SyncAPIResource):
                     "capacity_pool_id": capacity_pool_id,
                     "cluster_config": cluster_config,
                     "cluster_type": cluster_type,
+                    "cuda_version": cuda_version,
                     "duration_days": duration_days,
                     "install_traefik": install_traefik,
                     "num_capacity_pool_gpus": num_capacity_pool_gpus,
                     "num_preemptible_gpus": num_preemptible_gpus,
                     "num_reserved_gpus": num_reserved_gpus,
+                    "nvidia_driver_version": nvidia_driver_version,
+                    "nvidia_version_id": nvidia_version_id,
                     "oidc_config": oidc_config,
                     "project_id": project_id,
                     "reservation_end_time": reservation_end_time,
@@ -491,9 +495,6 @@ class AsyncClustersResource(AsyncAPIResource):
         gpu_type: Literal["H100_SXM", "H200_SXM", "RTX_6000_PCI", "L40_PCIE", "B200_SXM", "H100_SXM_INF", "B300_SXM"],
         num_gpus: int,
         region: str,
-        cuda_version: str | Omit = omit,
-        nvidia_driver_version: str | Omit = omit,
-        nvidia_version_id: str | Omit = omit,
         acceptance_tests_params: cluster_create_params.AcceptanceTestsParams | Omit = omit,
         add_ons: Iterable[cluster_create_params.AddOn] | Omit = omit,
         auto_scale: bool | Omit = omit,
@@ -502,11 +503,14 @@ class AsyncClustersResource(AsyncAPIResource):
         capacity_pool_id: str | Omit = omit,
         cluster_config: cluster_create_params.ClusterConfig | Omit = omit,
         cluster_type: Literal["KUBERNETES", "SLURM"] | Omit = omit,
+        cuda_version: str | Omit = omit,
         duration_days: int | Omit = omit,
         install_traefik: bool | Omit = omit,
         num_capacity_pool_gpus: int | Omit = omit,
         num_preemptible_gpus: int | Omit = omit,
         num_reserved_gpus: int | Omit = omit,
+        nvidia_driver_version: str | Omit = omit,
+        nvidia_version_id: str | Omit = omit,
         oidc_config: cluster_create_params.OidcConfig | Omit = omit,
         project_id: str | Omit = omit,
         reservation_end_time: Union[str, datetime] | Omit = omit,
@@ -539,17 +543,10 @@ class AsyncClustersResource(AsyncAPIResource):
 
           cluster_name: Name of the GPU cluster.
 
-          cuda_version: Legacy CUDA version for this cluster. For example, 12.5
-
           gpu_type: Type of GPU to use in the cluster
 
           num_gpus: Number of GPUs to allocate in the cluster. This must be multiple of 8. For
               example, 8, 16 or 24
-
-          nvidia_driver_version: Legacy Nvidia driver version for this cluster. For example, 550. Only some combination
-              of cuda_version and nvidia_driver_version are supported.
-
-          nvidia_version_id: NVIDIA version catalog ID for this cluster.
 
           region: Region to create the GPU cluster in. Usable regions can be found from
               `client.clusters.list_regions()`
@@ -574,6 +571,11 @@ class AsyncClustersResource(AsyncAPIResource):
 
           cluster_type: Type of cluster to create.
 
+          cuda_version: Legacy CUDA selector for this cluster. Bare semantic values such as 12.5 select
+              ubuntu-22.04; existing OS-suffixed values remain accepted for compatibility.
+              Must be paired with nvidia_driver_version. Prefer nvidia_version_id for new
+              integrations.
+
           duration_days: Duration in days to keep the cluster running.
 
           install_traefik: Whether to install Traefik ingress controller in the cluster. This field is only
@@ -589,6 +591,12 @@ class AsyncClustersResource(AsyncAPIResource):
 
           num_reserved_gpus: Number of prepaid (PLG) reserved GPUs for this cluster. When omitted for
               RESERVED billing on create, the server defaults this to num_gpus.
+
+          nvidia_driver_version: Legacy NVIDIA driver selector for this cluster. For example, 550. Must be paired
+              with cuda_version. Prefer nvidia_version_id for new integrations.
+
+          nvidia_version_id: Canonical region-specific NVIDIA version ID. If cuda_version and
+              nvidia_driver_version are also set, they must resolve to the same catalog entry.
 
           project_id: Project ID for the cluster. If not set, the project from the request context is
               used.
@@ -623,11 +631,8 @@ class AsyncClustersResource(AsyncAPIResource):
                 {
                     "billing_type": billing_type,
                     "cluster_name": cluster_name,
-                    "cuda_version": cuda_version,
                     "gpu_type": gpu_type,
                     "num_gpus": num_gpus,
-                    "nvidia_driver_version": nvidia_driver_version,
-                    "nvidia_version_id": nvidia_version_id,
                     "region": region,
                     "acceptance_tests_params": acceptance_tests_params,
                     "add_ons": add_ons,
@@ -637,11 +642,14 @@ class AsyncClustersResource(AsyncAPIResource):
                     "capacity_pool_id": capacity_pool_id,
                     "cluster_config": cluster_config,
                     "cluster_type": cluster_type,
+                    "cuda_version": cuda_version,
                     "duration_days": duration_days,
                     "install_traefik": install_traefik,
                     "num_capacity_pool_gpus": num_capacity_pool_gpus,
                     "num_preemptible_gpus": num_preemptible_gpus,
                     "num_reserved_gpus": num_reserved_gpus,
+                    "nvidia_driver_version": nvidia_driver_version,
+                    "nvidia_version_id": nvidia_version_id,
                     "oidc_config": oidc_config,
                     "project_id": project_id,
                     "reservation_end_time": reservation_end_time,

--- a/src/together/resources/beta/clusters/clusters.py
+++ b/src/together/resources/beta/clusters/clusters.py
@@ -77,11 +77,12 @@ class ClustersResource(SyncAPIResource):
         *,
         billing_type: Literal["RESERVED", "ON_DEMAND", "SCHEDULED_CAPACITY"],
         cluster_name: str,
-        cuda_version: str,
         gpu_type: Literal["H100_SXM", "H200_SXM", "RTX_6000_PCI", "L40_PCIE", "B200_SXM", "H100_SXM_INF", "B300_SXM"],
         num_gpus: int,
-        nvidia_driver_version: str,
         region: str,
+        cuda_version: str | Omit = omit,
+        nvidia_driver_version: str | Omit = omit,
+        nvidia_version_id: str | Omit = omit,
         acceptance_tests_params: cluster_create_params.AcceptanceTestsParams | Omit = omit,
         add_ons: Iterable[cluster_create_params.AddOn] | Omit = omit,
         auto_scale: bool | Omit = omit,
@@ -127,15 +128,17 @@ class ClustersResource(SyncAPIResource):
 
           cluster_name: Name of the GPU cluster.
 
-          cuda_version: CUDA version for this cluster. For example, 12.5
+          cuda_version: Legacy CUDA version for this cluster. For example, 12.5
 
           gpu_type: Type of GPU to use in the cluster
 
           num_gpus: Number of GPUs to allocate in the cluster. This must be multiple of 8. For
               example, 8, 16 or 24
 
-          nvidia_driver_version: Nvidia driver version for this cluster. For example, 550. Only some combination
+          nvidia_driver_version: Legacy Nvidia driver version for this cluster. For example, 550. Only some combination
               of cuda_version and nvidia_driver_version are supported.
+
+          nvidia_version_id: NVIDIA version catalog ID for this cluster.
 
           region: Region to create the GPU cluster in. Usable regions can be found from
               `client.clusters.list_regions()`
@@ -213,6 +216,7 @@ class ClustersResource(SyncAPIResource):
                     "gpu_type": gpu_type,
                     "num_gpus": num_gpus,
                     "nvidia_driver_version": nvidia_driver_version,
+                    "nvidia_version_id": nvidia_version_id,
                     "region": region,
                     "acceptance_tests_params": acceptance_tests_params,
                     "add_ons": add_ons,
@@ -484,11 +488,12 @@ class AsyncClustersResource(AsyncAPIResource):
         *,
         billing_type: Literal["RESERVED", "ON_DEMAND", "SCHEDULED_CAPACITY"],
         cluster_name: str,
-        cuda_version: str,
         gpu_type: Literal["H100_SXM", "H200_SXM", "RTX_6000_PCI", "L40_PCIE", "B200_SXM", "H100_SXM_INF", "B300_SXM"],
         num_gpus: int,
-        nvidia_driver_version: str,
         region: str,
+        cuda_version: str | Omit = omit,
+        nvidia_driver_version: str | Omit = omit,
+        nvidia_version_id: str | Omit = omit,
         acceptance_tests_params: cluster_create_params.AcceptanceTestsParams | Omit = omit,
         add_ons: Iterable[cluster_create_params.AddOn] | Omit = omit,
         auto_scale: bool | Omit = omit,
@@ -534,15 +539,17 @@ class AsyncClustersResource(AsyncAPIResource):
 
           cluster_name: Name of the GPU cluster.
 
-          cuda_version: CUDA version for this cluster. For example, 12.5
+          cuda_version: Legacy CUDA version for this cluster. For example, 12.5
 
           gpu_type: Type of GPU to use in the cluster
 
           num_gpus: Number of GPUs to allocate in the cluster. This must be multiple of 8. For
               example, 8, 16 or 24
 
-          nvidia_driver_version: Nvidia driver version for this cluster. For example, 550. Only some combination
+          nvidia_driver_version: Legacy Nvidia driver version for this cluster. For example, 550. Only some combination
               of cuda_version and nvidia_driver_version are supported.
+
+          nvidia_version_id: NVIDIA version catalog ID for this cluster.
 
           region: Region to create the GPU cluster in. Usable regions can be found from
               `client.clusters.list_regions()`
@@ -620,6 +627,7 @@ class AsyncClustersResource(AsyncAPIResource):
                     "gpu_type": gpu_type,
                     "num_gpus": num_gpus,
                     "nvidia_driver_version": nvidia_driver_version,
+                    "nvidia_version_id": nvidia_version_id,
                     "region": region,
                     "acceptance_tests_params": acceptance_tests_params,
                     "add_ons": add_ons,

--- a/src/together/types/beta/cluster_create_params.py
+++ b/src/together/types/beta/cluster_create_params.py
@@ -40,8 +40,8 @@ class ClusterCreateParams(TypedDict, total=False):
     cluster_name: Required[str]
     """Name of the GPU cluster."""
 
-    cuda_version: Required[str]
-    """CUDA version for this cluster. For example, 12.5"""
+    cuda_version: str
+    """Legacy CUDA version for this cluster. For example, 12.5"""
 
     gpu_type: Required[
         Literal["H100_SXM", "H200_SXM", "RTX_6000_PCI", "L40_PCIE", "B200_SXM", "H100_SXM_INF", "B300_SXM"]
@@ -54,12 +54,15 @@ class ClusterCreateParams(TypedDict, total=False):
     This must be multiple of 8. For example, 8, 16 or 24
     """
 
-    nvidia_driver_version: Required[str]
-    """Nvidia driver version for this cluster.
+    nvidia_driver_version: str
+    """Legacy Nvidia driver version for this cluster.
 
     For example, 550. Only some combination of cuda_version and
     nvidia_driver_version are supported.
     """
+
+    nvidia_version_id: str
+    """NVIDIA version catalog ID for this cluster."""
 
     region: Required[str]
     """Region to create the GPU cluster in.

--- a/src/together/types/beta/cluster_create_params.py
+++ b/src/together/types/beta/cluster_create_params.py
@@ -40,9 +40,6 @@ class ClusterCreateParams(TypedDict, total=False):
     cluster_name: Required[str]
     """Name of the GPU cluster."""
 
-    cuda_version: str
-    """Legacy CUDA version for this cluster. For example, 12.5"""
-
     gpu_type: Required[
         Literal["H100_SXM", "H200_SXM", "RTX_6000_PCI", "L40_PCIE", "B200_SXM", "H100_SXM_INF", "B300_SXM"]
     ]
@@ -53,16 +50,6 @@ class ClusterCreateParams(TypedDict, total=False):
 
     This must be multiple of 8. For example, 8, 16 or 24
     """
-
-    nvidia_driver_version: str
-    """Legacy Nvidia driver version for this cluster.
-
-    For example, 550. Only some combination of cuda_version and
-    nvidia_driver_version are supported.
-    """
-
-    nvidia_version_id: str
-    """NVIDIA version catalog ID for this cluster."""
 
     region: Required[str]
     """Region to create the GPU cluster in.
@@ -110,6 +97,14 @@ class ClusterCreateParams(TypedDict, total=False):
     cluster_type: Literal["KUBERNETES", "SLURM"]
     """Type of cluster to create."""
 
+    cuda_version: str
+    """Legacy CUDA selector for this cluster.
+
+    Bare semantic values such as 12.5 select ubuntu-22.04; existing OS-suffixed
+    values remain accepted for compatibility. Must be paired with
+    nvidia_driver_version. Prefer nvidia_version_id for new integrations.
+    """
+
     duration_days: int
     """Duration in days to keep the cluster running."""
 
@@ -138,6 +133,20 @@ class ClusterCreateParams(TypedDict, total=False):
 
     When omitted for RESERVED billing on create, the server defaults this to
     num_gpus.
+    """
+
+    nvidia_driver_version: str
+    """Legacy NVIDIA driver selector for this cluster.
+
+    For example, 550. Must be paired with cuda_version. Prefer nvidia_version_id for
+    new integrations.
+    """
+
+    nvidia_version_id: str
+    """Canonical region-specific NVIDIA version ID.
+
+    If cuda_version and nvidia_driver_version are also set, they must resolve to the
+    same catalog entry.
     """
 
     oidc_config: OidcConfig

--- a/src/together/types/beta/cluster_list_regions_response.py
+++ b/src/together/types/beta/cluster_list_regions_response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List
+from typing import List, Optional
 
 from ..._models import BaseModel
 
@@ -12,11 +12,17 @@ class RegionDriverVersion(BaseModel):
     CUDA/NVIDIA driver versions pair available in the region to use in the create cluster request.
     """
 
+    id: Optional[str] = None
+    """Identifier to send as nvidia_version_id in a create request."""
+
     cuda_version: str
     """CUDA driver version."""
 
     nvidia_driver_version: str
     """NVIDIA driver version."""
+
+    os: Optional[str] = None
+    """Operating system used by this NVIDIA version."""
 
 
 class Region(BaseModel):

--- a/src/together/types/beta/cluster_list_regions_response.py
+++ b/src/together/types/beta/cluster_list_regions_response.py
@@ -8,21 +8,22 @@ __all__ = ["ClusterListRegionsResponse", "Region", "RegionDriverVersion"]
 
 
 class RegionDriverVersion(BaseModel):
-    """
-    CUDA/NVIDIA driver versions pair available in the region to use in the create cluster request.
-    """
-
-    id: Optional[str] = None
-    """Identifier to send as nvidia_version_id in a create request."""
+    """NVIDIA software configuration available in the region."""
 
     cuda_version: str
-    """CUDA driver version."""
+    """Semantic CUDA version without operating system text."""
 
     nvidia_driver_version: str
     """NVIDIA driver version."""
 
+    id: Optional[str] = None
+    """
+    Region-specific NVIDIA catalog ID to send as nvidia_version_id when creating a
+    cluster.
+    """
+
     os: Optional[str] = None
-    """Operating system used by this NVIDIA version."""
+    """Operating system image family for this catalog entry."""
 
 
 class Region(BaseModel):

--- a/tests/cli/test_beta_clusters.py
+++ b/tests/cli/test_beta_clusters.py
@@ -861,6 +861,39 @@ class TestBetaClustersRetrieve:
 
 
 class TestBetaClustersCreate:
+    def test_invalid_nvidia_selector_is_json_in_json_mode(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(
+            [
+                "beta",
+                "clusters",
+                "create",
+                "--json",
+                "--cluster-type",
+                "KUBERNETES",
+                "--gpu-type",
+                "H100_SXM",
+                "--nvidia-version-id",
+                "nvidia-595-24",
+                "--nvidia-driver-version",
+                "595",
+                "--cuda-version",
+                "13.2",
+                "--region",
+                "us-central-8",
+                "--num-gpus",
+                "8",
+                "--billing-type",
+                "ON_DEMAND",
+                "--name",
+                "invalid-selector",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert json.loads(result.output) == {
+            "error": "Use either --nvidia-version-id or --nvidia-driver-version/--cuda-version/--os, not both."
+        }
+
     @pytest.mark.respx(base_url=base_url)
     def test_create_non_interactive_posts_expected_body(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         created = _cluster_body("new-id", "together-py-testing-suite")

--- a/tests/cli/test_beta_clusters.py
+++ b/tests/cli/test_beta_clusters.py
@@ -688,6 +688,29 @@ class TestBetaClustersNvidiaVersionSelection:
                 os_name=os_name,
             )
 
+    @pytest.mark.asyncio
+    async def test_interactive_explicit_legacy_pair_passes_through(self) -> None:
+        params: dict[str, Any] = {
+            "region": "us-central-8",
+            "nvidia_driver_version": "595",
+            "cuda_version": "13.2",
+        }
+
+        await create_cli._set_nvidia_version_params(
+            config=cast(Any, None),
+            params=params,
+            catalog=ClusterListRegionsResponse(**_REGIONS_BODY),
+            interactive=True,
+            nvidia_version_id=None,
+            nvidia_driver_version="595",
+            cuda_version="13.2",
+            os_name=None,
+        )
+
+        assert params["nvidia_driver_version"] == "595"
+        assert params["cuda_version"] == "13.2"
+        assert "nvidia_version_id" not in params
+
     def test_prompt_selects_one_coherent_duplicate_cuda_row(self, monkeypatch: pytest.MonkeyPatch) -> None:
         catalog = ClusterListRegionsResponse(**_REGIONS_BODY)
 

--- a/tests/cli/test_beta_clusters.py
+++ b/tests/cli/test_beta_clusters.py
@@ -20,7 +20,8 @@ from respx.models import Call
 
 from together import TogetherError
 from tests.cli.utils import CliRunner
-from together.lib.cli.api.beta.clusters import ssh as ssh_cli
+from together.types.beta import ClusterListRegionsResponse
+from together.lib.cli.api.beta.clusters import ssh as ssh_cli, create as create_cli
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -47,11 +48,30 @@ def _cluster_body(cluster_id: str = "cluster-1", name: str = "my-cluster", **ove
     return body
 
 
-_REGIONS_BODY = {
+_REGIONS_BODY: dict[str, Any] = {
     "regions": [
         {
             "name": "us-central-8",
-            "driver_versions": [{"cuda_version": "12.6", "nvidia_driver_version": "565"}],
+            "driver_versions": [
+                {
+                    "id": "nvidia-595-22",
+                    "cuda_version": "13.2",
+                    "nvidia_driver_version": "595",
+                    "os": "ubuntu-22.04",
+                },
+                {
+                    "id": "nvidia-595-24",
+                    "cuda_version": "13.2",
+                    "nvidia_driver_version": "595",
+                    "os": "ubuntu-24.04",
+                },
+                {
+                    "id": "nvidia-565-22",
+                    "cuda_version": "12.6",
+                    "nvidia_driver_version": "565",
+                    "os": "ubuntu-22.04",
+                },
+            ],
             "supported_instance_types": ["H100_SXM"],
         }
     ]
@@ -612,6 +632,200 @@ class TestBetaClustersListRegions:
         assert json.loads(result.output) == _REGIONS_BODY
         assert result.exit_code == 0
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_list_regions_omits_missing_id_and_os(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        legacy_body = {
+            "regions": [
+                {
+                    "name": "us-central-8",
+                    "driver_versions": [
+                        {
+                            "cuda_version": "12.6 Ubuntu 22.04",
+                            "nvidia_driver_version": "565",
+                        }
+                    ],
+                    "supported_instance_types": ["H100_SXM"],
+                }
+            ]
+        }
+        respx_mock.get("/compute/regions").mock(return_value=httpx.Response(200, json=legacy_body))
+
+        result = cli_runner.invoke(["beta", "clusters", "list-regions"])
+
+        assert result.exit_code == 0
+        assert "NVIDIA Driver:" in result.output
+        assert "ID:" not in result.output
+        assert "OS:" not in result.output
+        assert "None" not in result.output
+
+
+class TestBetaClustersNvidiaVersionSelection:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("nvidia_driver_version", "cuda_version", "os_name", "message"),
+        [
+            ("595", None, None, "must be provided together"),
+            (None, None, "ubuntu-24.04", "--os requires both"),
+            (None, None, None, "Use --nvidia-version-id"),
+        ],
+    )
+    async def test_non_interactive_selection_requires_complete_selector(
+        self,
+        nvidia_driver_version: str | None,
+        cuda_version: str | None,
+        os_name: str | None,
+        message: str,
+    ) -> None:
+        with pytest.raises(TogetherError, match=message):
+            await create_cli._set_nvidia_version_params(
+                config=cast(Any, None),
+                params={},
+                catalog=None,
+                interactive=False,
+                nvidia_version_id=None,
+                nvidia_driver_version=nvidia_driver_version,
+                cuda_version=cuda_version,
+                os_name=os_name,
+            )
+
+    def test_prompt_selects_one_coherent_duplicate_cuda_row(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        catalog = ClusterListRegionsResponse(**_REGIONS_BODY)
+
+        def select_second_version(_prompt: str) -> str:
+            return "2"
+
+        monkeypatch.setattr("builtins.input", select_second_version)
+
+        selected = create_cli._prompt_nvidia_version(catalog.regions[0].driver_versions)
+
+        assert selected.id == "nvidia-595-24"
+        assert selected.nvidia_driver_version == "595"
+        assert selected.cuda_version == "13.2"
+        assert selected.os == "ubuntu-24.04"
+
+    @pytest.mark.asyncio
+    async def test_prompt_falls_back_to_legacy_pair_when_catalog_has_no_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog = ClusterListRegionsResponse(
+            **cast(
+                Any,
+                {
+                    "regions": [
+                        {
+                            "name": "us-central-8",
+                            "driver_versions": [
+                                {
+                                    "cuda_version": "12.6 Ubuntu 22.04",
+                                    "nvidia_driver_version": "565",
+                                }
+                            ],
+                            "supported_instance_types": ["H100_SXM"],
+                        }
+                    ]
+                },
+            )
+        )
+
+        def select_first_version(_prompt: str) -> str:
+            return "1"
+
+        monkeypatch.setattr("builtins.input", select_first_version)
+        params: dict[str, Any] = {"region": "us-central-8"}
+
+        await create_cli._set_nvidia_version_params(
+            config=cast(Any, None),
+            params=params,
+            catalog=catalog,
+            interactive=True,
+            nvidia_version_id=None,
+            nvidia_driver_version=None,
+            cuda_version=None,
+            os_name=None,
+        )
+
+        assert params["nvidia_driver_version"] == "565"
+        assert params["cuda_version"] == "12.6 Ubuntu 22.04"
+        assert "nvidia_version_id" not in params
+
+    def test_semantic_selection_uses_os_to_disambiguate_duplicate_cuda_rows(self) -> None:
+        selected = create_cli._resolve_nvidia_version(
+            ClusterListRegionsResponse(**_REGIONS_BODY),
+            region="us-central-8",
+            nvidia_driver_version="595",
+            cuda_version="13.2",
+            os_name="ubuntu-22.04",
+        )
+
+        assert selected.id == "nvidia-595-22"
+
+    def test_semantic_selection_requires_disambiguation_for_duplicate_cuda_rows(self) -> None:
+        with pytest.raises(TogetherError, match="Add --os or use --nvidia-version-id"):
+            create_cli._resolve_nvidia_version(
+                ClusterListRegionsResponse(**_REGIONS_BODY),
+                region="us-central-8",
+                nvidia_driver_version="595",
+                cuda_version="13.2",
+                os_name=None,
+            )
+
+    def test_semantic_selection_with_duplicate_os_recommends_id_only(self) -> None:
+        catalog = ClusterListRegionsResponse(
+            **cast(
+                Any,
+                {
+                    "regions": [
+                        {
+                            "name": "us-central-8",
+                            "driver_versions": [
+                                {
+                                    "id": "first",
+                                    "cuda_version": "13.2",
+                                    "nvidia_driver_version": "595",
+                                    "os": "ubuntu-24.04",
+                                },
+                                {
+                                    "id": "second",
+                                    "cuda_version": "13.2",
+                                    "nvidia_driver_version": "595",
+                                    "os": "ubuntu-24.04",
+                                },
+                            ],
+                            "supported_instance_types": ["H100_SXM"],
+                        }
+                    ]
+                },
+            )
+        )
+
+        with pytest.raises(TogetherError, match=r"Use --nvidia-version-id\. Matches"):
+            create_cli._resolve_nvidia_version(
+                catalog,
+                region="us-central-8",
+                nvidia_driver_version="595",
+                cuda_version="13.2",
+                os_name="ubuntu-24.04",
+            )
+
+    @pytest.mark.parametrize(
+        ("region", "cuda_version", "message"),
+        [
+            ("us-east-1", "13.2", "No NVIDIA versions are available in region 'us-east-1'"),
+            ("us-central-8", "13.3", "No NVIDIA version matches"),
+        ],
+    )
+    def test_semantic_selection_rejects_region_mismatch_and_no_match(
+        self, region: str, cuda_version: str, message: str
+    ) -> None:
+        with pytest.raises(TogetherError, match=message):
+            create_cli._resolve_nvidia_version(
+                ClusterListRegionsResponse(**_REGIONS_BODY),
+                region=region,
+                nvidia_driver_version="595",
+                cuda_version=cuda_version,
+                os_name="ubuntu-24.04",
+            )
+
 
 class TestBetaClustersRetrieve:
     @pytest.mark.respx(base_url=base_url)
@@ -661,7 +875,84 @@ class TestBetaClustersCreate:
         assert body["volume_id"] == "vol-attach"
         assert body["num_gpus"] == 8
         assert body["billing_type"] == "ON_DEMAND"
+        assert body["nvidia_driver_version"] == "565"
+        assert body["cuda_version"] == "12.6"
+        assert "nvidia_version_id" not in body
         assert result.exit_code == 0
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_create_direct_nvidia_version_id_posts_id(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        created = _cluster_body("new-id", "direct-id")
+        route = respx_mock.post("/compute/clusters").mock(return_value=httpx.Response(200, json=created))
+        result = cli_runner.invoke(
+            [
+                "beta",
+                "clusters",
+                "create",
+                "--non-interactive",
+                "--cluster-type",
+                "KUBERNETES",
+                "--gpu-type",
+                "H100_SXM",
+                "--nvidia-version-id",
+                "nvidia-595-24",
+                "--region",
+                "us-central-8",
+                "--num-gpus",
+                "8",
+                "--billing-type",
+                "ON_DEMAND",
+                "--name",
+                "direct-id",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        body = json.loads(cast(Call, route.calls[0]).request.content.decode())
+        assert body["nvidia_version_id"] == "nvidia-595-24"
+        assert "nvidia_driver_version" not in body
+        assert "cuda_version" not in body
+        assert result.exit_code == 0
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_create_semantic_nvidia_selection_posts_resolved_id(
+        self, respx_mock: MockRouter, cli_runner: CliRunner
+    ) -> None:
+        respx_mock.get("/compute/regions").mock(return_value=httpx.Response(200, json=_REGIONS_BODY))
+        created = _cluster_body("new-id", "semantic-selection")
+        route = respx_mock.post("/compute/clusters").mock(return_value=httpx.Response(200, json=created))
+        result = cli_runner.invoke(
+            [
+                "beta",
+                "clusters",
+                "create",
+                "--non-interactive",
+                "--cluster-type",
+                "KUBERNETES",
+                "--gpu-type",
+                "H100_SXM",
+                "--nvidia-driver-version",
+                "595",
+                "--cuda-version",
+                "13.2",
+                "--os",
+                "ubuntu-24.04",
+                "--region",
+                "us-central-8",
+                "--num-gpus",
+                "8",
+                "--billing-type",
+                "ON_DEMAND",
+                "--name",
+                "semantic-selection",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        body = json.loads(cast(Call, route.calls[0]).request.content.decode())
+        assert body["nvidia_version_id"] == "nvidia-595-24"
+        assert "nvidia_driver_version" not in body
+        assert "cuda_version" not in body
 
     @pytest.mark.respx(base_url=base_url)
     def test_create_accepts_new_cluster_params(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:

--- a/tests/cli/test_beta_endpoints_retrieve.py
+++ b/tests/cli/test_beta_endpoints_retrieve.py
@@ -213,4 +213,4 @@ class TestBetaEndpointsRetrieve:
         result = cli_runner.invoke(["beta", "endpoints", "get", "control", "--project", "proj", "--json"])
 
         assert result.exit_code != 0
-        assert 'Multiple deployments found for "control"' in result.output
+        assert 'Multiple deployments found for "control"' in json.loads(result.output)["error"]


### PR DESCRIPTION
## Summary
- add canonical `--nvidia-version-id` creation and exact driver/CUDA/OS catalog resolution
- preserve explicit legacy pairs while rejecting incomplete or ambiguous selectors
- keep `--json` failures machine-readable and omit unavailable legacy catalog fields instead of printing `None`

## Dependencies
- Schema: https://github.com/togethercomputer/openapi/pull/492
- Backend: https://github.com/togethercomputer/tcloud/pull/2780

## Test plan
- [x] `./scripts/format`
- [x] `./scripts/lint`
- [x] `TOGETHER_API_KEY=test ./scripts/test --ignore=tests/integration`
  - Python 3.10 + Pydantic v2: 4,122 passed
  - Python 3.10 + Pydantic v1: 4,109 passed
  - Python 3.14 + Pydantic v2: 4,122 passed
- [x] final CI: build, lint, integration, unit, and Broly checks

Linear: https://linear.app/together-ai/issue/TCL-8199