### PR TITLE
fix(cli): inform about CLI upgrades at most once per day (DX-844)

### DIFF
--- a/src/together/lib/cli/utils/_version_check.py
+++ b/src/together/lib/cli/utils/_version_check.py
@@ -50,42 +50,80 @@ def _cache_path() -> Path:
     return Path.home() / ".cache" / "together" / "version-check.json"
 
 
-def _read_cached_version(now: float) -> str | None:
+def _load_cache() -> dict[str, object] | None:
     try:
         data: object = json.loads(_cache_path().read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             return None
-        cache = cast(dict[str, object], data)
-
-        checked_at = cache.get("checked_at")
-        latest_version = cache.get("latest_version")
-        if not isinstance(checked_at, (int, float)) or not isinstance(latest_version, str):
-            return None
-        if not 0 <= now - checked_at < _CACHE_TTL_SECONDS:
-            return None
-
-        _parse_version(latest_version)
-        return latest_version
-    except (OSError, json.JSONDecodeError, ValueError):
+        return cast(dict[str, object], data)
+    except (OSError, json.JSONDecodeError):
         return None
 
 
-def _write_cached_version(latest_version: str, now: float) -> None:
+def _write_cache(cache: dict[str, object]) -> None:
     path = _cache_path()
     tmp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path.write_text(
-            json.dumps({"checked_at": now, "latest_version": latest_version}, sort_keys=True) + "\n",
+            json.dumps(cache, sort_keys=True) + "\n",
             encoding="utf-8",
         )
         tmp_path.replace(path)
     except OSError as exc:
-        log_debug("Unable to cache the latest Together CLI version", error=exc)
+        log_debug("Unable to cache Together CLI version-check state", error=exc)
         try:
             tmp_path.unlink(missing_ok=True)
         except OSError:
             pass
+
+
+def _is_fresh_timestamp(timestamp: object, now: float) -> bool:
+    if not isinstance(timestamp, (int, float)):
+        return False
+    return 0 <= now - timestamp < _CACHE_TTL_SECONDS
+
+
+def _read_cached_version(now: float) -> str | None:
+    cache = _load_cache()
+    if cache is None:
+        return None
+
+    checked_at = cache.get("checked_at")
+    latest_version = cache.get("latest_version")
+    if not isinstance(latest_version, str) or not _is_fresh_timestamp(checked_at, now):
+        return None
+
+    try:
+        _parse_version(latest_version)
+    except ValueError:
+        return None
+    return latest_version
+
+
+def _write_cached_version(latest_version: str, now: float) -> None:
+    cache = _load_cache() or {}
+    payload: dict[str, object] = {
+        "checked_at": now,
+        "latest_version": latest_version,
+    }
+    informed_at = cache.get("informed_at")
+    if isinstance(informed_at, (int, float)):
+        payload["informed_at"] = informed_at
+    _write_cache(payload)
+
+
+def _was_informed_recently(now: float) -> bool:
+    cache = _load_cache()
+    if cache is None:
+        return False
+    return _is_fresh_timestamp(cache.get("informed_at"), now)
+
+
+def _mark_informed(now: float) -> None:
+    cache = _load_cache() or {}
+    cache["informed_at"] = now
+    _write_cache(cache)
 
 
 def _fetch_latest_version() -> str:
@@ -169,6 +207,13 @@ class VersionCheck:
             )
             if not _is_newer_version(latest_version, __version__):
                 return
+
+            # PyPI lookups are cached separately; this gate ensures we only prompt/inform
+            # the user once per day even when every command reuses a cached "outdated" result.
+            now = time.time()
+            if _was_informed_recently(now):
+                return
+            _mark_informed(now)
 
             command = _upgrade_command()
             command_text = escape_rich_markup(_format_command(command))

--- a/src/together/lib/cli/utils/_version_check.py
+++ b/src/together/lib/cli/utils/_version_check.py
@@ -56,7 +56,7 @@ def _load_cache() -> dict[str, object] | None:
         if not isinstance(data, dict):
             return None
         return cast(dict[str, object], data)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):  # JSONDecodeError and UnicodeDecodeError are both ValueError
         return None
 
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import json
+from pathlib import Path
 
 import pytest
 
@@ -81,7 +82,7 @@ class TestMainGlobalOptions:
         assert calls == [(True, False)]
 
     def test_update_notice_does_not_corrupt_json_output(
-        self, monkeypatch: pytest.MonkeyPatch, cli_runner: CliRunner
+        self, monkeypatch: pytest.MonkeyPatch, cli_runner: CliRunner, tmp_path: Path
     ) -> None:
         cli_runner.env.pop("TOGETHER_DISABLE_VERSION_CHECK")
         monkeypatch.setattr("together.lib.cli.utils._version_check.__version__", "1.0.0")
@@ -89,6 +90,10 @@ class TestMainGlobalOptions:
         monkeypatch.setattr(
             "together.lib.cli.utils._version_check._upgrade_command",
             lambda: ["python", "-m", "pip", "install", "--upgrade", "together"],
+        )
+        monkeypatch.setattr(
+            "together.lib.cli.utils._version_check._cache_path",
+            lambda: tmp_path / "version-check.json",
         )
 
         result = cli_runner.invoke(["--json", "telemetry", "status"])

--- a/tests/cli/test_version_check.py
+++ b/tests/cli/test_version_check.py
@@ -73,6 +73,28 @@ def test_latest_version_fetches_pypi_and_caches(monkeypatch: pytest.MonkeyPatch,
     assert urlopen.call_args.kwargs == {"timeout": 1.0}
 
 
+def test_load_cache_returns_none_for_non_utf8(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cache_path = tmp_path / "version-check.json"
+    cache_path.write_bytes(b"\xff\xfe{not-utf8")
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: cache_path)
+
+    assert _version_check._load_cache() is None
+
+
+def test_latest_version_rewrites_non_utf8_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cache_path = tmp_path / "version-check.json"
+    cache_path.write_bytes(b"\xff\xfe{not-utf8")
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: cache_path)
+    monkeypatch.setattr(_version_check.time, "time", lambda: 1000)
+    monkeypatch.setattr(_version_check, "_fetch_latest_version", lambda: "3.2.1")
+
+    assert _version_check._latest_version() == "3.2.1"
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "checked_at": 1000,
+        "latest_version": "3.2.1",
+    }
+
+
 async def test_version_check_starts_resolution_when_created(monkeypatch: pytest.MonkeyPatch) -> None:
     started = threading.Event()
     release = threading.Event()

--- a/tests/cli/test_version_check.py
+++ b/tests/cli/test_version_check.py
@@ -132,9 +132,12 @@ async def test_version_check_stops_waiting_after_timeout(monkeypatch: pytest.Mon
     output.print.assert_not_called()
 
 
-async def test_version_check_prints_upgrade_command_when_non_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_version_check_prints_upgrade_command_when_non_interactive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     output = MagicMock()
     monkeypatch.delenv("TOGETHER_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: tmp_path / "version-check.json")
     monkeypatch.setattr(_version_check, "__version__", "1.0.0")
     monkeypatch.setattr(_version_check, "_latest_version", lambda: "1.1.0")
     monkeypatch.setattr(
@@ -150,10 +153,13 @@ async def test_version_check_prints_upgrade_command_when_non_interactive(monkeyp
     assert "python -m pip install -U together" in rendered
 
 
-async def test_version_check_does_not_prompt_after_failed_command(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_version_check_does_not_prompt_after_failed_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     output = MagicMock()
     confirm = AsyncMock()
     monkeypatch.delenv("TOGETHER_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: tmp_path / "version-check.json")
     monkeypatch.setattr(_version_check, "__version__", "1.0.0")
     monkeypatch.setattr(_version_check, "_latest_version", lambda: "1.1.0")
     monkeypatch.setattr(_version_check, "_upgrade_command", lambda: ["upgrade"])
@@ -167,11 +173,12 @@ async def test_version_check_does_not_prompt_after_failed_command(monkeypatch: p
     assert "Upgrade with:" in output.print.call_args.args[0]
 
 
-async def test_version_check_prompts_and_upgrades_on_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_version_check_prompts_and_upgrades_on_tty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     output = MagicMock()
     confirm = AsyncMock(return_value=True)
     run = MagicMock(return_value=subprocess.CompletedProcess(["upgrade"], returncode=0))
     monkeypatch.delenv("TOGETHER_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: tmp_path / "version-check.json")
     monkeypatch.setattr(_version_check, "__version__", "1.0.0")
     monkeypatch.setattr(_version_check, "_latest_version", lambda: "1.1.0")
     monkeypatch.setattr(_version_check, "_upgrade_command", lambda: ["upgrade"])
@@ -187,9 +194,10 @@ async def test_version_check_prompts_and_upgrades_on_tty(monkeypatch: pytest.Mon
     assert "upgraded" in output.print.call_args.args[0]
 
 
-async def test_version_check_prompt_interrupt_does_not_escape(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_version_check_prompt_interrupt_does_not_escape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     confirm = AsyncMock(side_effect=KeyboardInterrupt)
     monkeypatch.delenv("TOGETHER_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: tmp_path / "version-check.json")
     monkeypatch.setattr(_version_check, "__version__", "1.0.0")
     monkeypatch.setattr(_version_check, "_latest_version", lambda: "1.1.0")
     monkeypatch.setattr(_version_check, "confirm", confirm)
@@ -209,3 +217,72 @@ async def test_version_check_fails_open(monkeypatch: pytest.MonkeyPatch) -> None
 
     version_check = _version_check.VersionCheck()
     await version_check.inform(non_interactive=False, allow_prompt=True)
+
+
+async def test_version_check_informs_at_most_once_per_day(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = MagicMock()
+    cache_path = tmp_path / "version-check.json"
+    monkeypatch.delenv("TOGETHER_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: cache_path)
+    monkeypatch.setattr(_version_check, "__version__", "1.0.0")
+    monkeypatch.setattr(_version_check, "_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(_version_check, "_upgrade_command", lambda: ["upgrade"])
+    monkeypatch.setattr(_version_check, "error_console", output)
+    monkeypatch.setattr(_version_check.time, "time", lambda: 1_000.0)
+
+    first = _version_check.VersionCheck()
+    await first.inform(non_interactive=True, allow_prompt=True)
+    assert output.print.call_count == 2
+    assert json.loads(cache_path.read_text(encoding="utf-8"))["informed_at"] == 1_000.0
+
+    output.reset_mock()
+    second = _version_check.VersionCheck()
+    await second.inform(non_interactive=True, allow_prompt=True)
+    output.print.assert_not_called()
+
+
+async def test_version_check_informs_again_after_ttl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = MagicMock()
+    cache_path = tmp_path / "version-check.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "checked_at": 1_000.0,
+                "informed_at": 1_000.0,
+                "latest_version": "1.1.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("TOGETHER_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: cache_path)
+    monkeypatch.setattr(_version_check, "__version__", "1.0.0")
+    monkeypatch.setattr(_version_check, "_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(_version_check, "_upgrade_command", lambda: ["upgrade"])
+    monkeypatch.setattr(_version_check, "error_console", output)
+    monkeypatch.setattr(_version_check.time, "time", lambda: 1_000.0 + _version_check._CACHE_TTL_SECONDS)
+
+    version_check = _version_check.VersionCheck()
+    await version_check.inform(non_interactive=True, allow_prompt=True)
+
+    assert output.print.call_count == 2
+    assert (
+        json.loads(cache_path.read_text(encoding="utf-8"))["informed_at"] == 1_000.0 + _version_check._CACHE_TTL_SECONDS
+    )
+
+
+def test_write_cached_version_preserves_informed_at(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cache_path = tmp_path / "version-check.json"
+    cache_path.write_text(
+        json.dumps({"checked_at": 500, "informed_at": 750, "latest_version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_version_check, "_cache_path", lambda: cache_path)
+
+    _version_check._write_cached_version("1.2.0", now=1_000.0)
+
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "checked_at": 1_000.0,
+        "informed_at": 750,
+        "latest_version": "1.2.0",
+    }


### PR DESCRIPTION
## Summary

Fixes [DX-844](https://linear.app/together-ai/issue/DX-844/possible-bug-repeated-prompting).

The CLI version-check cache only skipped PyPI lookups (`checked_at` / `latest_version`). When the installed CLI was outdated, `VersionCheck.inform()` still printed/prompted on **every** command.

- Persist `informed_at` in the same cache file
- Skip user-facing upgrade notices for 24h after informing
- Preserve `informed_at` when refreshing the cached PyPI version
- Add regression tests for once-per-day gating + TTL expiry

## Test plan

- [x] `uv run pytest tests/cli/test_version_check.py tests/cli/test_main.py -q` (24 passed)
- [x] `./scripts/format` + `./scripts/lint`
- [ ] Manually: run CLI twice with an outdated install and confirm the upgrade notice appears only once within 24h