### PR TITLE
ENG-9000 docs(realtime): carry decode context and session config across failover

### DIFF
--- a/examples/realtime_failover.py
+++ b/examples/realtime_failover.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Realtime transcription with failover across multiple endpoints.
 
-Stream live audio to a primary endpoint; when it fails beyond recovery,
-resume on the next endpoint in the ring, carrying over any speech that was
-never transcribed so nothing is lost across the switch.
+Stream live audio to an endpoint; when it fails beyond recovery, resume on the
+next endpoint in the ring, carrying over any speech that was never transcribed
+so nothing is lost across the switch.
 
 The SDK handles transient failures on a single endpoint internally (surfaced
 only as Reconnecting/Reconnected events — nothing to handle). When an endpoint
@@ -11,6 +11,21 @@ is unrecoverable, SDK calls raise RealtimeConnectionError — including when the
 server reports it cannot currently serve (exc.code == "no_healthy_workers",
 raised immediately with no same-endpoint retry). One except handles both.
 Moving to another endpoint is application code: the loop below handles failover.
+
+Two things the successor needs from its predecessor, both carried below:
+  * `pending_audio()` — speech the failed endpoint received but never
+    transcribed. Replayed into the new session.
+  * `context_prompt()` — tail of the delivered transcripts, passed as `prompt`
+    so the new server decodes with the context the old one had. Without it the
+    transcript degrades across the boundary.
+
+What does NOT carry, because the successor is a fresh server session:
+  * VAD *state* (position in the speech/silence hysteresis) — reconverges from
+    the replayed audio, so a turn boundary at the switch may land slightly
+    differently. VAD *config* carries fine: it is just SESSION_CFG.
+  * item_id / session_id restart — turn ids are not comparable across endpoints.
+  * Replayed audio is re-transcribed, so text can overlap what you already
+    received; TranscriptCompleted.replayed marks it.
 
 Usage:
     uv add "together[realtime]"
@@ -23,6 +38,7 @@ from __future__ import annotations
 import sys
 import wave
 import asyncio
+import itertools
 from pathlib import Path
 
 from together import AsyncTogether
@@ -35,18 +51,37 @@ from together.realtime import (
     RealtimeConnectionError,
 )
 
-# Independent deployments of the same model. Order = preference; on failure
-# the next entry takes over, wrapping around. Each entry is (base_url, model);
-# base_url is the API root and may point at region-specific hosts so the ring
-# entries share no failure domain.
+# Independent deployments of the same model. On failure the next entry takes
+# over, wrapping around. Each entry is (base_url, model); base_url is the API
+# root and may point at region-specific hosts so the ring entries share no
+# failure domain.
 ENDPOINTS = [
     ("https://api.together.ai/v1", "openai/whisper-large-v3-endpoint1"),
     ("https://api.together.ai/v1", "openai/whisper-large-v3-endpoint2"),
 ]
 
+# False: ENDPOINTS order is a strict preference — every session starts on the
+# first entry, later entries are pure standby.
+# True: start each session on the next endpoint in turn, so all of them take
+# live traffic and stay continuously exercised; the failover ring still works
+# from wherever a session starts. Size each endpoint to absorb the full load
+# alone, or an outage moves every session onto a saturated survivor.
+SPREAD_SESSIONS = False
+_ring = itertools.count()
+
 SAMPLE_RATE = 16_000
 CHUNK_BYTES = SAMPLE_RATE * 2 // 10  # 100 ms per append, like a live source
 MAX_ATTEMPTS = 3 * len(ENDPOINTS)  # give up after several full ring cycles
+
+# Every session in the ring is configured identically — defined once and spread
+# into each one, so a failover cannot silently change transcription behaviour.
+# Put language / turn_detection / energy_gate_rms / session_params here.
+SESSION_CFG = {
+    "sample_rate": SAMPLE_RATE,
+    # Switch endpoints immediately on failure. Raise max_attempts to let the
+    # SDK retry the same endpoint first.
+    "reconnect": {"max_attempts": 0},
+}
 
 
 def on_event(event: RealtimeSessionEvent) -> None:
@@ -74,19 +109,21 @@ async def transcribe_with_failover(audio: bytes) -> str:
 
     transcripts: list[str] = []
     carry_over = b""  # audio the failed endpoint received but never transcribed
+    carry_prompt = ""  # decode context the failed endpoint had built up
     position = 0  # progress through the source; survives endpoint switches
 
+    start = next(_ring) % len(clients) if SPREAD_SESSIONS else 0
+
     for attempt in range(MAX_ATTEMPTS):
-        client, model = clients[attempt % len(clients)]
+        client, model = clients[(start + attempt) % len(clients)]
         print(f"--- streaming to {model}")
 
         session = client.beta.realtime.transcription(
             model=model,
-            sample_rate=SAMPLE_RATE,
+            # Prime the successor with what its predecessor already decoded.
+            prompt=carry_prompt or None,
             event_callback=on_event,
-            # Switch endpoints immediately on failure. Raise max_attempts to
-            # let the SDK retry the same endpoint first.
-            reconnect={"max_attempts": 0},
+            **SESSION_CFG,
         )
         try:
             async with session:
@@ -103,10 +140,11 @@ async def transcribe_with_failover(audio: bytes) -> str:
                 return " ".join(t for t in transcripts if t)
         except RealtimeConnectionError as exc:
             # Endpoint unrecoverable (incl. exc.code == "no_healthy_workers"):
-            # keep its transcripts, take back the audio it never transcribed,
-            # and move to the next endpoint.
+            # keep its transcripts, take back the audio it never transcribed
+            # and the context it had built, and move to the next endpoint.
             transcripts.extend(session.transcripts)
             carry_over = session.pending_audio()
+            carry_prompt = session.context_prompt()
             print(f"--- {model} failed ({exc}); carrying over {len(carry_over) / (SAMPLE_RATE * 2):.1f}s of audio")
 
     raise SystemExit("all endpoints failed repeatedly; giving up")


### PR DESCRIPTION
## What
Three fixes to `examples/realtime_failover.py`. The SDK already has every piece needed for a clean cross-endpoint switch — the example just didn't wire them together.

**1. Pass `context_prompt()` to the successor.** `pending_audio()`'s own docstring says to feed the carried-over audio *"together with a prompt built from `self.transcripts`"* — the example passed only the audio. So the new endpoint decoded with no lexical context and the transcript degraded across the boundary. The same-endpoint reconnect path already handles this (`reprime_prompt` → `_effective_prompt()` appends the transcript tail to "restore the decode context the server lost"); the cross-endpoint path just never applied the equivalent.

**2. Hoist session config into `SESSION_CFG`.** The example passed only `model`/`sample_rate`, which reads as "config isn't a concern." Anyone with `turn_detection` / `language` / `energy_gate_rms` / `session_params` tuning would have it silently dropped on failover — transcription behaviour quietly changing after a switch. Now defined once and spread into every session, so the ring is identically configured by construction.

**3. `SPREAD_SESSIONS` flag (default `False`).** As written, `clients[attempt % len(clients)]` with `attempt` starting at 0 means *every* session starts on `ENDPOINTS[0]` — later entries are pure cold standby and take zero traffic until something breaks. The flag rotates the starting endpoint per session so a secondary can carry live traffic and stay continuously exercised; the ring still fails over from wherever a session starts. Default is off, preserving the documented preference-order behaviour.

## Also
Docstring now states what does **not** carry, so nobody assumes seamless turn continuity:
- VAD *runtime state* reconverges from the replayed audio (a turn boundary at the switch may land slightly differently). VAD *config* carries fine — it's just `SESSION_CFG`.
- `item_id` / `session_id` restart; turn ids aren't comparable across endpoints.
- Replayed audio is re-transcribed, so text can overlap what was already delivered (`TranscriptCompleted.replayed` marks it).

## Testing
Smoke-tested end to end against a live realtime endpoint — session opens, streams, and returns a coherent transcript. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)