### PR TITLE
DX-881: pass language at session start via the connection URL

### DIFF
--- a/src/together/lib/realtime/_connection.py
+++ b/src/together/lib/realtime/_connection.py
@@ -60,12 +60,17 @@ def build_realtime_url(
     model: str,
     input_audio_format: str = DEFAULT_AUDIO_FORMAT,
     turn_detection: Optional[TurnDetectionParam] = None,
+    language: Optional[str] = None,
     extra_query: Optional[Mapping[str, Any]] = None,
 ) -> str:
     """Derive the wss:// realtime URL from the client's HTTP base_url.
 
     The model MUST be in the query string before any audio is appended —
     without it the server queues appends and never starts the session.
+
+    `language` is passed at the beginning of the session as a query param.
+    It is passed through verbatim (including "auto"); an explicit
+    `extra_query["language"]` takes precedence.
     """
     scheme = {"https": "wss", "http": "ws"}.get(base_url.scheme, base_url.scheme)
     path = base_url.path.rstrip("/") + "/realtime"
@@ -76,6 +81,8 @@ def build_realtime_url(
         if detection_type is not None:
             params["turn_detection"] = detection_type
         params.update(detection)
+    if language is not None:
+        params["language"] = language
     if extra_query:
         params.update(dict(extra_query))
     url = base_url.copy_with(scheme=scheme, path=path, params=params)
@@ -95,16 +102,17 @@ def build_realtime_headers(
 
 def _session_config(
     *,
-    language: Optional[str],
     prompt: Optional[str],
     rolling_prompt: Optional[bool],
     energy_gate_rms: Optional[float],
     session_params: Optional[Mapping[str, Any]],
 ) -> Dict[str, Any]:
-    """Session-level params delivered via `transcription_session.updated`."""
+    """Session-level params delivered via `transcription_session.updated`.
+
+    `language` is not here: it is set at the beginning of the session via
+    the connection URL query param — see `build_realtime_url`.
+    """
     config: Dict[str, Any] = {}
-    if language is not None:
-        config["language"] = language
     if prompt is not None:
         config["prompt"] = prompt
     if rolling_prompt is not None:
@@ -255,8 +263,10 @@ class RealtimeConnectionManager:
         self._model = model
         self._input_audio_format = input_audio_format
         self._turn_detection = turn_detection
+        # language is set at the beginning of the session via the
+        # connection URL query param (see build_realtime_url)
+        self._language = language
         self._session_config = _session_config(
-            language=language,
             prompt=prompt,
             rolling_prompt=rolling_prompt,
             energy_gate_rms=energy_gate_rms,
@@ -276,6 +286,7 @@ class RealtimeConnectionManager:
             model=self._model,
             input_audio_format=self._input_audio_format,
             turn_detection=self._turn_detection,
+            language=self._language,
             extra_query=self._extra_query,
         )
         headers = build_realtime_headers(self._client.auth_headers, extra_headers=self._extra_headers)
@@ -317,8 +328,10 @@ class AsyncRealtimeConnectionManager:
         self._model = model
         self._input_audio_format = input_audio_format
         self._turn_detection = turn_detection
+        # language is set at the beginning of the session via the
+        # connection URL query param (see build_realtime_url)
+        self._language = language
         self._session_config = _session_config(
-            language=language,
             prompt=prompt,
             rolling_prompt=rolling_prompt,
             energy_gate_rms=energy_gate_rms,
@@ -338,6 +351,7 @@ class AsyncRealtimeConnectionManager:
             model=self._model,
             input_audio_format=self._input_audio_format,
             turn_detection=self._turn_detection,
+            language=self._language,
             extra_query=self._extra_query,
         )
         headers = build_realtime_headers(self._client.auth_headers, extra_headers=self._extra_headers)

--- a/src/together/lib/realtime/_session.py
+++ b/src/together/lib/realtime/_session.py
@@ -402,11 +402,15 @@ class AsyncRealtimeTranscriptionSession:
         return self._model
 
     def _manager(self) -> AsyncRealtimeConnectionManager:
+        # language goes to the manager (it lands on the connection URL, the
+        # only place the server honors it — together-py#505); the manager is
+        # rebuilt per _open_connection() call, so reconnects keep it too
         return AsyncRealtimeConnectionManager(
             client=self._client,
             model=self.model,
             input_audio_format=self._format,
             turn_detection=self._turn_detection,
+            language=self._language,
             extra_query=self._extra_query,
             extra_headers=self._extra_headers,
         )
@@ -440,9 +444,10 @@ class AsyncRealtimeTranscriptionSession:
 
     async def _configure_session(self, connection: AsyncRealtimeConnection) -> None:
         # single source of truth for the session-param field mapping lives in
-        # _connection._session_config; only the reprime tail is layered on here
+        # _connection._session_config; only the reprime tail is layered on here.
+        # language is set at the beginning of the session on the connection
+        # URL (see _manager / build_realtime_url)
         session = _session_config(
-            language=self._language,
             prompt=self._effective_prompt(),
             rolling_prompt=self._rolling_prompt,
             energy_gate_rms=self._energy_gate_rms,

--- a/tests/unit/test_realtime_session.py
+++ b/tests/unit/test_realtime_session.py
@@ -15,6 +15,7 @@ import asyncio
 import logging
 import contextlib
 from typing import Any, Dict, List, Callable, Optional
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
@@ -258,8 +259,16 @@ class TestHappyPath:
             assert len(server.connections[0].audio) == len(seconds(0.5))
 
 
+def query_of(conn: ConnectionLog) -> Dict[str, List[str]]:
+    """Query params the server saw on this connection's handshake URL."""
+    return parse_qs(urlsplit(conn.path).query)
+
+
 class TestSessionParams:
     async def test_session_level_params_sent_on_connect(self) -> None:
+        # language rides on the connection URL — the server ignores it in
+        # transcription_session.updated and only honors the query param
+        # (together-py#505); the other params still go via session update
         async with FakeRealtimeServer() as server:
             session = make_session(
                 server,
@@ -272,14 +281,45 @@ class TestSessionParams:
             async with session:
                 await session.append(seconds(0.1))
                 await asyncio.sleep(0.1)
+            assert query_of(server.connections[0])["language"] == ["en"]
             updates = [e for e in server.connections[0].events if e["type"] == "transcription_session.updated"]
             assert updates, "expected a transcription_session.updated event"
             sent = updates[0]["session"]
-            assert sent["language"] == "en"
+            assert "language" not in sent
             assert sent["prompt"] == "medical terms"
             assert sent["rolling_prompt"] is True
             assert sent["energy_gate_rms"] == 0.02
             assert sent["custom_engine_knob"] == "x"
+
+    async def test_language_auto_verbatim_and_no_session_update_when_only_language(self) -> None:
+        # "auto" passes through verbatim; with no session-level params left
+        # there is nothing to send in a session update at all
+        async with FakeRealtimeServer() as server:
+            session = make_session(server, language="auto")
+            async with session:
+                await session.append(seconds(0.1))
+                await asyncio.sleep(0.1)
+            assert query_of(server.connections[0])["language"] == ["auto"]
+            updates = [e for e in server.connections[0].events if e["type"] == "transcription_session.updated"]
+            assert not updates
+
+    async def test_extra_query_language_wins_without_duplicate(self) -> None:
+        async with FakeRealtimeServer() as server:
+            session = make_session(server, language="en", extra_query={"language": "fr"})
+            async with session:
+                await session.append(seconds(0.1))
+                await asyncio.sleep(0.1)
+            assert query_of(server.connections[0])["language"] == ["fr"]
+
+    async def test_reconnect_preserves_language_in_url(self) -> None:
+        async with FakeRealtimeServer(drop_after_bytes=BPS) as server:
+            session = make_session(server, language="es")
+            async with session:
+                await session.append(seconds(1.0))  # server drops at 1s
+                await collect_until(session, lambda evs: any(isinstance(e, Reconnected) for e in evs), timeout=10.0)
+                assert len(server.connections) == 2
+                for conn in server.connections:
+                    assert query_of(conn)["language"] == ["es"]
 
 
 class TestReconnect:

--- a/tests/unit/test_realtime_wiring.py
+++ b/tests/unit/test_realtime_wiring.py
@@ -60,6 +60,39 @@ def test_url_and_header_derivation() -> None:
     assert headers["OpenAI-Beta"] == "realtime=v1"
 
 
+def test_url_language_query_param() -> None:
+    """language is a connection-time query param: the server ignores it in
+    transcription_session.updated and only honors it on the URL (#505)."""
+    from urllib.parse import parse_qs, urlsplit
+
+    import httpx
+
+    from together.lib.realtime._connection import build_realtime_url
+
+    base = httpx.URL("https://api.together.ai/v1/")
+
+    url = build_realtime_url(base, model="openai/whisper-large-v3", language="es")
+    assert parse_qs(urlsplit(url).query)["language"] == ["es"]
+
+    # "auto" passes through verbatim, not translated or dropped
+    url = build_realtime_url(base, model="openai/whisper-large-v3", language="auto")
+    assert parse_qs(urlsplit(url).query)["language"] == ["auto"]
+
+    # omitted -> no language param at all
+    url = build_realtime_url(base, model="openai/whisper-large-v3")
+    assert "language" not in parse_qs(urlsplit(url).query)
+
+    # an explicit extra_query overrides the language argument — one value, no
+    # duplicate query param
+    url = build_realtime_url(
+        base,
+        model="openai/whisper-large-v3",
+        language="en",
+        extra_query={"language": "fr"},
+    )
+    assert parse_qs(urlsplit(url).query)["language"] == ["fr"]
+
+
 def test_sync_async_resource_signatures_stay_in_sync() -> None:
     """The sync/async resource surfaces are intentionally duplicated for IDE
     ergonomics; this guard catches parameter drift between them."""


### PR DESCRIPTION
The realtime endpoint applies language at the beginning of the session, so the SDK now sends it as a connection URL query param instead of in the transcription_session.updated payload. 
Refs #505.