### PR TITLE
feat(cli): show GPU and estimated price before deploy project confirm

### DIFF
--- a/src/together/lib/cli/api/beta/endpoints/_utils/_hardware_pricing.py
+++ b/src/together/lib/cli/api/beta/endpoints/_utils/_hardware_pricing.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+from dataclasses import dataclass
+
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.types.beta.models.config import Config
+from together.types.beta.endpoints.inference_instance_type import InferenceInstanceType
+
+
+@dataclass(frozen=True)
+class HardwarePricing:
+    """Resolved GPU label and hourly cost for a deploy preview."""
+
+    gpu_label: str
+    estimated_price_label: str
+    hardware_id: str
+    price_cents_per_hour: int
+
+
+def selector_value(config: Config, key: str) -> Optional[str]:
+    for selector in config.selectors or []:
+        if selector.key == key:
+            return selector.value
+    return None
+
+
+def hardware_from_selectors(config: Config) -> Optional[str]:
+    """Build an instance-type name from accelerator selectors.
+
+    Matches the backend / web convention: ``accelerator_count`` + ``accelerator_type``
+    → ``{count}x{type}`` (e.g. ``1xnvidia-h100-80gb``).
+    """
+    accel_type = selector_value(config, "accelerator_type")
+    accel_count = selector_value(config, "accelerator_count")
+    if not accel_type or not accel_count:
+        return None
+    return f"{accel_count}x{accel_type}"
+
+
+def prettify_hardware(hardware: str) -> str:
+    """Human-readable GPU label, e.g. ``1xnvidia-h100-80gb`` → ``1x H100 80GB``."""
+    match = re.search(r"(\d+)x(.*)", hardware)
+    if not match:
+        return hardware.replace("_", " ").title()
+    count, hw_type = match.groups()
+    parts = [part for part in hw_type.split("-") if part]
+    if parts and parts[0].lower() in {"nvidia", "amd"}:
+        parts = parts[1:]
+    if not parts:
+        return f"{count}x {hw_type.upper()}"
+    return f"{count}x {' '.join(parts).upper()}"
+
+
+def format_gpu_label(instance: InferenceInstanceType) -> str:
+    # Prefer the deployable name (`1xnvidia-h100-80gb` → `1x H100 80GB`) so the
+    # preview matches `tg beta endpoints ls` hardware formatting.
+    if instance.name:
+        return prettify_hardware(instance.name)
+    gpu_type = instance.gpu_type or ""
+    gpu_type = re.sub(r"(?i)^nvidia-", "", gpu_type)
+    gpu_type = gpu_type.replace("-", " ").strip()
+    if instance.gpu_count and gpu_type:
+        return f"{instance.gpu_count}x {gpu_type.upper()}"
+    return instance.id
+
+
+def format_estimated_price(
+    price_cents_per_hour: int,
+    *,
+    min_replicas: int,
+    max_replicas: int,
+) -> str:
+    """Hourly cost at min/max replica bounds (collapses when they match)."""
+    min_replicas = max(0, min_replicas)
+    max_replicas = max(min_replicas, max_replicas)
+    min_dollars = (price_cents_per_hour * min_replicas) / 100
+    max_dollars = (price_cents_per_hour * max_replicas) / 100
+    if max_dollars > min_dollars:
+        return f"${min_dollars:.2f}/hr - ${max_dollars:.2f}/hr"
+    return f"${min_dollars:.2f}/hr"
+
+
+def find_instance_type(
+    instance_types: list[InferenceInstanceType],
+    *,
+    hardware_id: str,
+) -> Optional[InferenceInstanceType]:
+    """Match an instance type by deployable name (preferred) or id."""
+    for instance in instance_types:
+        if instance.name == hardware_id or instance.id == hardware_id:
+            return instance
+    # Tolerate missing vendor prefix: ``1xh100-80gb`` ↔ ``1xnvidia-h100-80gb``.
+    normalized = hardware_id.lower().replace("nvidia-", "")
+    for instance in instance_types:
+        candidate = (instance.name or "").lower().replace("nvidia-", "")
+        if candidate == normalized:
+            return instance
+    return None
+
+
+async def ensure_config_with_selectors(config: CLIConfigParameter, model_config: Config) -> Config:
+    """Fetch the full config body when the resolved stub lacks selectors."""
+    if model_config.selectors:
+        return model_config
+    if not model_config.id or not model_config.project_id:
+        return model_config
+    try:
+        return await config.client.beta.models.configs.retrieve(
+            model_config.id,
+            project_id=model_config.project_id,
+        )
+    except Exception:
+        return model_config
+
+
+async def resolve_hardware_pricing(
+    config: CLIConfigParameter,
+    model_config: Config,
+    *,
+    min_replicas: int,
+    max_replicas: int,
+) -> Optional[HardwarePricing]:
+    """Look up GPU info and estimated hourly price for a deployment config."""
+    model_config = await ensure_config_with_selectors(config, model_config)
+    hardware_id = hardware_from_selectors(model_config)
+    if not hardware_id:
+        return None
+
+    try:
+        catalog = await config.client.beta.endpoints.hardware.list()
+    except Exception:
+        # Preview should not block deploy when the catalog is unavailable.
+        return HardwarePricing(
+            gpu_label=prettify_hardware(hardware_id),
+            estimated_price_label="unavailable",
+            hardware_id=hardware_id,
+            price_cents_per_hour=0,
+        )
+
+    instance = find_instance_type(catalog.data or [], hardware_id=hardware_id)
+    if instance is None:
+        return HardwarePricing(
+            gpu_label=prettify_hardware(hardware_id),
+            estimated_price_label="unavailable",
+            hardware_id=hardware_id,
+            price_cents_per_hour=0,
+        )
+
+    return HardwarePricing(
+        gpu_label=format_gpu_label(instance),
+        estimated_price_label=format_estimated_price(
+            instance.price_cents_per_hour,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+        ),
+        hardware_id=instance.name or hardware_id,
+        price_cents_per_hour=instance.price_cents_per_hour,
+    )

--- a/src/together/lib/cli/api/beta/endpoints/deploy.py
+++ b/src/together/lib/cli/api/beta/endpoints/deploy.py
@@ -370,10 +370,6 @@ def _print_deployment_preview(
     add_row("--model", f"{model.name} ({model_path})")
     add_row("--config", config_value.id)  # type: ignore
 
-    if hardware_pricing is not None:
-        add_row("GPU", hardware_pricing.gpu_label)
-        add_row("Estimated price", hardware_pricing.estimated_price_label)
-
     table.add_row("\n".join(args))
 
     console.print(
@@ -383,6 +379,12 @@ def _print_deployment_preview(
             title_align="left",
         )
     )
+
+    if hardware_pricing is not None:
+        console.print(
+            f"[dim][/dim][yellow]This deployment will utilize {hardware_pricing.gpu_label}, "
+            f"which is estimated to cost approximately {hardware_pricing.estimated_price_label}.[/yellow]\n"
+        )
 
 
 # Helper method to enable the users to use this command to either create a new endpoint+deployment

--- a/src/together/lib/cli/api/beta/endpoints/deploy.py
+++ b/src/together/lib/cli/api/beta/endpoints/deploy.py
@@ -39,6 +39,10 @@ from together.lib.cli.api.beta.endpoints._utils._traffic_split import upsert_tra
 from together.lib.cli.api.beta.endpoints._utils._resolve_config import (
     construct_config_path,
 )
+from together.lib.cli.api.beta.endpoints._utils._hardware_pricing import (
+    HardwarePricing,
+    resolve_hardware_pricing,
+)
 from together.lib.cli.api.beta.endpoints._utils._build_autoscaling import (
     ScalingMetricName,
     ScalingPercentile,
@@ -229,6 +233,17 @@ async def deploy(
     model_path = construct_model_path(resolved_model, resolved_revision)
 
     if not config.json:
+        min_replicas_value = int(autoscaling.get("min_replicas") or 1)
+        max_replicas_value = int(autoscaling.get("max_replicas") or min_replicas_value)
+        hardware_pricing = await show_loading_status(
+            "Looking up GPU pricing...",
+            resolve_hardware_pricing(
+                config,
+                config_value,
+                min_replicas=min_replicas_value,
+                max_replicas=max_replicas_value,
+            ),
+        )
         _print_deployment_preview(
             endpoint=endpoint_name_or_id,
             deployment_name=deployment_name,
@@ -239,6 +254,7 @@ async def deploy(
             placement=placement_value,
             enable_lora=enable_lora,
             traffic_weight=traffic_weight,
+            hardware_pricing=hardware_pricing,
         )
     await assert_explicit_project_id(config)
 
@@ -302,6 +318,7 @@ def _print_deployment_preview(
     placement: Placement | None,
     enable_lora: bool | None,
     traffic_weight: float | None,
+    hardware_pricing: HardwarePricing | None = None,
 ) -> None:
     table = Table(expand=True, show_header=False, show_edge=False, show_lines=False, box=None, pad_edge=False)
     table.add_column("Arg", justify="left", no_wrap=True, ratio=1)
@@ -352,6 +369,10 @@ def _print_deployment_preview(
         add_row("--traffic-weight", str(traffic_weight))
     add_row("--model", f"{model.name} ({model_path})")
     add_row("--config", config_value.id)  # type: ignore
+
+    if hardware_pricing is not None:
+        add_row("GPU", hardware_pricing.gpu_label)
+        add_row("Estimated price", hardware_pricing.estimated_price_label)
 
     table.add_row("\n".join(args))
 

--- a/tests/cli/test_beta_endpoints.py
+++ b/tests/cli/test_beta_endpoints.py
@@ -266,15 +266,16 @@ class TestBetaEndpointsDeploy:
 
         # Non-interactive mode without an explicit project aborts at confirm —
         # after the deploy preview has already shown GPU + estimated price.
+        # Collapse Rich line-wrap whitespace so phrase checks stay stable.
+        output = " ".join(result.output.split())
         assert result.exit_code != 0
-        assert "Deploy" in result.output
-        assert "preview" in result.output
-        assert "GPU" in result.output
-        assert "1x H100" in result.output
-        assert "Estimated price" in result.output
-        assert "$24.00/hr - $48.00/hr" in result.output
-        assert "Project argument is required" in result.output
-        assert not any(call.request.method == "POST" for call in respx_mock.calls)
+        assert "Deploy" in output
+        assert "preview" in output
+        assert "This deployment will utilize 1x H100" in output
+        assert "estimated to cost approximately" in output
+        assert "$24.00/hr - $48.00/hr" in output
+        assert "Project argument is required" in output
+        assert not any(call.request.method == "POST" for call in cast(list[Call], respx_mock.calls))
 
     @pytest.mark.respx(base_url=base_url)
     def test_deploy_onto_existing_endpoint(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:

--- a/tests/cli/test_beta_endpoints.py
+++ b/tests/cli/test_beta_endpoints.py
@@ -75,11 +75,39 @@ def _config_body(**overrides: Any) -> dict[str, Any]:
         "projectId": "proj",
         "referenceModel": "projects/proj/models/ml_1",
         "referenceModelId": "ml_1",
-        "selectors": [{"key": "gpu", "value": "H100"}],
+        "selectors": [
+            {"key": "accelerator_count", "value": "1"},
+            {"key": "accelerator_type", "value": "nvidia-h100-80gb"},
+        ],
         "certifications": [],
     }
     body.update(overrides)
     return body
+
+
+def _hardware_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "id": "it_h100",
+        "name": "1xnvidia-h100-80gb",
+        "description": "1x NVIDIA H100 80GB",
+        "gpuCount": 1,
+        "gpuMemoryGib": 80,
+        "gpuType": "NVIDIA-H100-80GB-HBM3",
+        "priceCentsPerHour": 2400,
+        "regions": [],
+    }
+    body.update(overrides)
+    return body
+
+
+def _mock_hardware_catalog(respx_mock: MockRouter) -> None:
+    # Tests override TOGETHER_BASE_URL, so the SDK hits the relative public path.
+    respx_mock.get("/public/inference-instance-types").mock(
+        return_value=httpx.Response(
+            200,
+            json={"object": "list", "data": [_hardware_body()], "next_cursor": None},
+        )
+    )
 
 
 def _whoami_body(**overrides: Any) -> dict[str, Any]:
@@ -202,6 +230,51 @@ class TestBetaEndpointsDeploy:
         assert deployment_body["autoscaling"] == {"minReplicas": 1, "maxReplicas": 1}
         update_body = json.loads(cast(Call, update_endpoint_route.calls[0]).request.content.decode())
         assert update_body["trafficSplit"] == [{"deploymentId": "dep_1", "weight": 1.0}]
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_deploy_preview_shows_gpu_and_estimated_price_before_project_confirm(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        # Interactive project confirm only runs when --project / env are omitted.
+        cli_runner.env.pop("TOGETHER_PROJECT_ID", None)
+        _mock_model_and_config(respx_mock)
+        _mock_hardware_catalog(respx_mock)
+        respx_mock.get("/whoami").mock(return_value=httpx.Response(200, json=_whoami_body()))
+
+        result = cli_runner.invoke(
+            [
+                "beta",
+                "endpoints",
+                "deploy",
+                "--endpoint",
+                "fresh-endpoint",
+                "--model",
+                "ml_1",
+                "--config",
+                "cr_1",
+                "--deployment-name",
+                "my-dep",
+                "--min-replicas",
+                "1",
+                "--max-replicas",
+                "2",
+                "--non-interactive",
+            ]
+        )
+
+        # Non-interactive mode without an explicit project aborts at confirm —
+        # after the deploy preview has already shown GPU + estimated price.
+        assert result.exit_code != 0
+        assert "Deploy" in result.output
+        assert "preview" in result.output
+        assert "GPU" in result.output
+        assert "1x H100" in result.output
+        assert "Estimated price" in result.output
+        assert "$24.00/hr - $48.00/hr" in result.output
+        assert "Project argument is required" in result.output
+        assert not any(call.request.method == "POST" for call in respx_mock.calls)
 
     @pytest.mark.respx(base_url=base_url)
     def test_deploy_onto_existing_endpoint(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:

--- a/tests/cli/test_hardware_pricing.py
+++ b/tests/cli/test_hardware_pricing.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from together.lib.cli.utils.config import CLIConfig
+from together.types.beta.models.config import Config
+from together.types.beta.endpoints.inference_instance_type import InferenceInstanceType
+from together.lib.cli.api.beta.endpoints._utils._hardware_pricing import (
+    format_gpu_label,
+    prettify_hardware,
+    find_instance_type,
+    format_estimated_price,
+    hardware_from_selectors,
+    resolve_hardware_pricing,
+)
+
+
+def _config(**overrides: Any) -> Config:
+    body: dict[str, Any] = {
+        "id": "cr_1",
+        "projectId": "proj",
+        "referenceModel": "projects/proj/models/ml_1",
+        "referenceModelId": "ml_1",
+        "selectors": [
+            {"key": "accelerator_count", "value": "1"},
+            {"key": "accelerator_type", "value": "nvidia-h100-80gb"},
+        ],
+        "certifications": [],
+    }
+    body.update(overrides)
+    return Config.construct(**body)
+
+
+def _instance(**overrides: Any) -> InferenceInstanceType:
+    body: dict[str, Any] = {
+        "id": "it_h100",
+        "name": "1xnvidia-h100-80gb",
+        "description": "1x H100",
+        "gpuCount": 1,
+        "gpuMemoryGib": 80,
+        "gpuType": "NVIDIA-H100-80GB-HBM3",
+        "priceCentsPerHour": 2400,
+        "regions": [],
+    }
+    body.update(overrides)
+    return InferenceInstanceType.construct(**body)
+
+
+def test_hardware_from_selectors() -> None:
+    assert hardware_from_selectors(_config()) == "1xnvidia-h100-80gb"
+    assert hardware_from_selectors(_config(selectors=[])) is None
+
+
+def test_prettify_hardware() -> None:
+    assert prettify_hardware("1xnvidia-h100-80gb") == "1x H100 80GB"
+    assert prettify_hardware("8xnvidia-b200-180gb") == "8x B200 180GB"
+
+
+def test_format_gpu_label() -> None:
+    assert format_gpu_label(_instance()) == "1x H100 80GB"
+    assert (
+        format_gpu_label(_instance(name="", gpuType="NVIDIA-H100-80GB-HBM3", gpuCount=2))
+        == "2x H100 80GB HBM3"
+    )
+
+
+def test_format_estimated_price_single_and_range() -> None:
+    assert format_estimated_price(2400, min_replicas=1, max_replicas=1) == "$24.00/hr"
+    assert format_estimated_price(2400, min_replicas=1, max_replicas=2) == "$24.00/hr - $48.00/hr"
+    assert format_estimated_price(2400, min_replicas=0, max_replicas=1) == "$0.00/hr - $24.00/hr"
+
+
+def test_find_instance_type_exact_and_normalized() -> None:
+    catalog = [_instance()]
+    assert find_instance_type(catalog, hardware_id="1xnvidia-h100-80gb") is catalog[0]
+    assert find_instance_type(catalog, hardware_id="1xh100-80gb") is catalog[0]
+    assert find_instance_type(catalog, hardware_id="missing") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_hardware_pricing_happy_path() -> None:
+    client = MagicMock()
+    client.beta.endpoints.hardware.list = AsyncMock(
+        return_value=MagicMock(data=[_instance()]),
+    )
+    cli = CLIConfig(client=client, non_interactive=True, json=False, project_id="proj")
+
+    pricing = await resolve_hardware_pricing(cli, _config(), min_replicas=1, max_replicas=2)
+
+    assert pricing is not None
+    assert pricing.hardware_id == "1xnvidia-h100-80gb"
+    assert pricing.gpu_label == "1x H100 80GB"
+    assert pricing.estimated_price_label == "$24.00/hr - $48.00/hr"
+    client.beta.endpoints.hardware.list.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_hardware_pricing_fetches_config_when_selectors_missing() -> None:
+    client = MagicMock()
+    client.beta.models.configs.retrieve = AsyncMock(return_value=_config())
+    client.beta.endpoints.hardware.list = AsyncMock(
+        return_value=MagicMock(data=[_instance()]),
+    )
+    cli = CLIConfig(client=client, non_interactive=True, json=False, project_id="proj")
+    stub = _config(selectors=[])
+
+    pricing = await resolve_hardware_pricing(cli, stub, min_replicas=1, max_replicas=1)
+
+    assert pricing is not None
+    assert pricing.estimated_price_label == "$24.00/hr"
+    client.beta.models.configs.retrieve.assert_awaited_once_with("cr_1", project_id="proj")
+
+
+@pytest.mark.asyncio
+async def test_resolve_hardware_pricing_returns_none_without_hardware_selectors() -> None:
+    client = MagicMock()
+    client.beta.models.configs.retrieve = AsyncMock(
+        return_value=_config(selectors=[{"key": "optimization", "value": "balanced"}]),
+    )
+    cli = CLIConfig(client=client, non_interactive=True, json=False, project_id="proj")
+
+    pricing = await resolve_hardware_pricing(cli, _config(selectors=[]), min_replicas=1, max_replicas=1)
+
+    assert pricing is None
+    client.beta.endpoints.hardware.list.assert_not_called()

--- a/tests/cli/test_hardware_pricing.py
+++ b/tests/cli/test_hardware_pricing.py
@@ -61,10 +61,7 @@ def test_prettify_hardware() -> None:
 
 def test_format_gpu_label() -> None:
     assert format_gpu_label(_instance()) == "1x H100 80GB"
-    assert (
-        format_gpu_label(_instance(name="", gpuType="NVIDIA-H100-80GB-HBM3", gpuCount=2))
-        == "2x H100 80GB HBM3"
-    )
+    assert format_gpu_label(_instance(name="", gpuType="NVIDIA-H100-80GB-HBM3", gpuCount=2)) == "2x H100 80GB HBM3"
 
 
 def test_format_estimated_price_single_and_range() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Resolves **ENG-91847**: `tg beta endpoints deploy` now shows GPU info and estimated hourly price in the deploy preview **before** the project confirmation prompt.

## Changes
- Resolve hardware from config selectors (`accelerator_count` + `accelerator_type` → e.g. `1xnvidia-h100-80gb`)
- Look up pricing via `GET /public/inference-instance-types`
- Display in the existing deploy preview panel:
  - `GPU` — e.g. `1x H100 80GB`
  - `Estimated price` — e.g. `$24.00/hr` or `$24.00/hr - $48.00/hr` for min–max replica range
- Fetch full config when the resolved stub lacks selectors (public-profile path)
- Gracefully omit/mark price unavailable if the catalog lookup fails (does not block deploy)

## Test plan
- [x] Unit tests for selector → hardware, price formatting, catalog matching
- [x] CLI test: preview shows GPU + estimated price, then aborts at project confirm without creating resources
- [x] Existing `TestBetaEndpointsDeploy` cases still pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<img width="900" height="173" alt="image" src="https://github.com/user-attachments/assets/ac13d9f3-c160-4ecb-a9c1-9886049ecf32" />


Linear Issue: [ENG-91847](https://linear.app/together-ai/issue/ENG-91847/display-gpu-information-and-estimated-price-for-an-beta-endpoints)

<div><a href="https://cursor.com/agents/bc-6bb32093-8ade-41ba-b401-a05e972e1ca1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bb32093-8ade-41ba-b401-a05e972e1ca1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

