### PR TITLE
feat(cli): implement `tg login` OIDC authentication (ENG-91941)

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -106,16 +106,38 @@ _GLOBAL_PARAM_HELP = {
     "--version": "Display application version",
 }
 
-# Commands that authenticate out-of-band (OIDC / step-ca) and make no Together
-# API calls, so the launcher must not require an API key or run the up-front
-# whoami() for them. Values match preparse_tokens() command paths (beta prefix
-# stripped; reported separately via is_beta_command).
-_NO_AUTH_COMMANDS = frozenset({"clusters ssh"})
+# Commands that authenticate out-of-band and make no Together API calls, so the
+# launcher must not require an API key or run the up-front whoami() for them.
+# Values match preparse_tokens() command paths (beta prefix stripped; reported
+# separately via is_beta_command).
+_NO_AUTH_COMMANDS = frozenset({"login", "logout"})
+# Beta-only keyless commands (path after stripping the `beta` prefix).
+_NO_AUTH_BETA_COMMANDS = frozenset({"clusters ssh"})
 
 
 async def _resolve_project_id(client: AsyncTogether) -> str:
     me = await client.whoami()
     return me.project_id
+
+
+def _resolve_cli_api_key(api_key: Optional[str]) -> Optional[str]:
+    """Resolve API credentials for the CLI.
+
+    Precedence: explicit ``--api-key`` / caller value, then ``TOGETHER_API_KEY``,
+    then a short-lived OIDC access token from ``tg login`` (refreshed invisibly).
+    """
+    if api_key:
+        return api_key
+    env_key = os.environ.get("TOGETHER_API_KEY")
+    if env_key:
+        return env_key
+    try:
+        from together.lib.cli.auth.oidc import resolve_access_token
+
+        return resolve_access_token()
+    except Exception as e:
+        log_debug("OIDC credential resolution failed", error=e)
+        return None
 
 
 def _propagate_global_param_group(target_app: App) -> None:
@@ -133,6 +155,15 @@ def _propagate_global_param_group(target_app: App) -> None:
         _propagate_global_param_group(sub)
 
 
+def _missing_auth_message() -> str:
+    return (
+        "[red]Error:[/red] Together authentication missing.\n\n"
+        "Sign in with [bold]tg login[/bold], pass [bold]--api-key[/bold], or set the "
+        "[bold]TOGETHER_API_KEY[/bold] environment variable.\n"
+        "API keys: https://api.together.ai/settings/api-keys"
+    )
+
+
 def _create_client(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -141,9 +172,10 @@ def _create_client(
     project_id: Optional[str],
     require_api_key: bool = True,
 ) -> AsyncTogether:
+    resolved_api_key = _resolve_cli_api_key(api_key)
     try:
         client = AsyncTogether(
-            api_key=api_key,
+            api_key=resolved_api_key,
             base_url=base_url,
             timeout=timeout,
             max_retries=max_retries if max_retries is not None else 0,
@@ -160,10 +192,7 @@ def _create_client(
             )
 
             def block_requests_for_api_key(_: httpx.Request) -> None:
-                console.print(
-                    "[red]x[/red] api key missing.\n\nThe api key must be set either by passing --api-key to the command or by setting the TOGETHER_API_KEY environment variable",
-                )
-                console.print("You can find your api key at https://api.together.ai/settings/api-keys")
+                console.print(_missing_auth_message())
                 sys.exit(1)
 
             client._client.event_hooks["request"].append(block_requests_for_api_key)
@@ -182,14 +211,11 @@ def _create_client(
 
     client._client.event_hooks["request"].append(track_request)
 
-    # Out-of-band-auth commands (e.g. `beta clusters ssh`) make no Together API
-    # calls, so a missing key is not fatal for them. The block hook installed
+    # Out-of-band-auth commands (e.g. `login`, `beta clusters ssh`) make no Together
+    # API calls, so a missing key is not fatal for them. The block hook installed
     # above still errors clearly if such a command ever does hit the API.
     if require_api_key and client.api_key == "":
-        console.print(
-            "[red]Error:[/red] Together API Key missing.\n\nThe api key must be set either by passing --api-key to the command or by setting the TOGETHER_API_KEY environment variable",
-        )
-        console.print("You can find your api key at https://api.together.ai/settings/api-keys")
+        console.print(_missing_auth_message())
         sys.exit(1)
 
     return client
@@ -235,14 +261,13 @@ async def launcher(
 
     (parsed_command, explicit_args, is_beta_command, remaining) = preparse_tokens(app, [*tokens])
 
-    # Some commands authenticate out-of-band (OIDC / step-ca signed certificates)
-    # and never call the Together API. They must not be gated on an API key or the
-    # up-front whoami() used for project resolution. `tg beta clusters ssh` is one:
-    # its auth is entirely the cluster's Dex OIDC flow (see
-    # together.lib.cli.api.beta.clusters.ssh). Before the whoami() was added for
-    # project resolution these commands worked with no key; skip client setup so
-    # they stay keyless.
-    no_auth_command = is_beta_command and parsed_command in _NO_AUTH_COMMANDS
+    # Some commands authenticate out-of-band and never call the Together API
+    # (`tg login` / `tg logout`, or `tg beta clusters ssh` via Dex/step-ca). They
+    # must not be gated on an API key or the up-front whoami() used for project
+    # resolution.
+    no_auth_command = parsed_command in _NO_AUTH_COMMANDS or (
+        is_beta_command and parsed_command in _NO_AUTH_BETA_COMMANDS
+    )
 
     client = _create_client(api_key, base_url, timeout, max_retries, project_id, require_api_key=not no_auth_command)
 
@@ -908,6 +933,11 @@ storage_app.command(
     (f"{_CLI}.beta.jig.jig:jig_volumes_list"), name="list", alias="ls", help="List volumes for a Jig deployment"
 )
 
+app.command(
+    (f"{_CLI}.login:login"),
+    help="Log in with Together OIDC (browser) and store short-lived credentials",
+)
+app.command((f"{_CLI}.logout:logout"), help="Log out and remove stored OIDC credentials")
 app.command((f"{_CLI}.whoami:whoami"), help="Show the current user")
 
 app.help_epilogue = TOP_LEVEL_HELP_EXAMPLES

--- a/src/together/lib/cli/api/login.py
+++ b/src/together/lib/cli/api/login.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from typing import Optional, Annotated
+
+from cyclopts import Parameter
+
+from together import TogetherError
+from together.lib.cli.auth.oidc import (
+    DEFAULT_OAUTH_SCOPES,
+    format_expiry,
+    login_with_oidc,
+    discovery_url_from_base_url,
+)
+from together.lib.cli.utils._console import console
+
+
+async def login(
+    *,
+    client_id: Annotated[
+        Optional[str],
+        Parameter(
+            name="--client-id",
+            help="OIDC client id for the Together CLI OAuth app (or TOGETHER_OAUTH_CLIENT_ID)",
+            env_var="TOGETHER_OAUTH_CLIENT_ID",
+        ),
+    ] = None,
+    client_secret: Annotated[
+        Optional[str],
+        Parameter(
+            name="--client-secret",
+            help="OIDC client secret when the CLI app is confidential (or TOGETHER_OAUTH_CLIENT_SECRET)",
+            env_var="TOGETHER_OAUTH_CLIENT_SECRET",
+        ),
+    ] = None,
+    scope: Annotated[
+        str,
+        Parameter(help="OIDC scopes to request"),
+    ] = DEFAULT_OAUTH_SCOPES,
+    no_browser: Annotated[
+        bool,
+        Parameter(name="--no-browser", negative=(), help="Print the login URL instead of opening a browser"),
+    ] = False,
+) -> None:
+    """Authenticate with Together via OIDC (browser + PKCE) and store short-lived credentials.
+
+    Access tokens live ~5 minutes and are refreshed invisibly using the stored refresh token.
+    """
+    discovery = discovery_url_from_base_url(os.environ.get("TOGETHER_BASE_URL"))
+    try:
+        credentials = login_with_oidc(
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=scope,
+            discovery_url=discovery,
+            open_browser=not no_browser,
+        )
+    except TogetherError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print("[green]✓[/green] Logged in to Together")
+    console.print(f"[dim]Access token expires {format_expiry(credentials)} (auto-refreshed)[/dim]")

--- a/src/together/lib/cli/api/logout.py
+++ b/src/together/lib/cli/api/logout.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from together.lib.cli.utils._console import console
+from together.lib.cli.auth.credentials import credentials_path, clear_credentials
+
+
+async def logout() -> None:
+    """Remove locally stored OIDC credentials from `tg login`."""
+    path = credentials_path()
+    if clear_credentials(path):
+        console.print(f"[green]✓[/green] Logged out (removed {path})")
+    else:
+        console.print("[dim]Already logged out[/dim]")

--- a/src/together/lib/cli/auth/__init__.py
+++ b/src/together/lib/cli/auth/__init__.py
@@ -1,0 +1,25 @@
+"""CLI OIDC authentication helpers for `tg login` / credential refresh."""
+
+from together.lib.cli.auth.oidc import (
+    DEFAULT_OAUTH_SCOPES,
+    login_with_oidc,
+    resolve_access_token,
+)
+from together.lib.cli.auth.credentials import (
+    StoredCredentials,
+    credentials_path,
+    load_credentials,
+    save_credentials,
+    clear_credentials,
+)
+
+__all__ = [
+    "DEFAULT_OAUTH_SCOPES",
+    "StoredCredentials",
+    "clear_credentials",
+    "credentials_path",
+    "load_credentials",
+    "login_with_oidc",
+    "resolve_access_token",
+    "save_credentials",
+]

--- a/src/together/lib/cli/auth/credentials.py
+++ b/src/together/lib/cli/auth/credentials.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+import sys
+import json
+from typing import Any, Optional, cast
+from pathlib import Path
+from dataclasses import asdict, dataclass
+
+from filelock import FileLock
+
+_CONFIG_DIR_NAME = "together"
+_CREDENTIALS_FILE_NAME = "credentials.json"
+_LOCK_SUFFIX = ".lock"
+
+
+@dataclass
+class StoredCredentials:
+    """Persisted OIDC tokens from `tg login`.
+
+    Access tokens are short-lived (~5 minutes) and non-revocable; the CLI stores
+    the refresh token and silently refreshes the access token before API calls.
+    """
+
+    access_token: str
+    refresh_token: str
+    expires_at: float  # unix timestamp (UTC)
+    token_type: str = "Bearer"
+    id_token: Optional[str] = None
+    scope: Optional[str] = None
+    client_id: Optional[str] = None
+    token_endpoint: Optional[str] = None
+    issuer: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StoredCredentials:
+        return cls(
+            access_token=str(data["access_token"]),
+            refresh_token=str(data["refresh_token"]),
+            expires_at=float(data["expires_at"]),
+            token_type=str(data.get("token_type") or "Bearer"),
+            id_token=_optional_str(data.get("id_token")),
+            scope=_optional_str(data.get("scope")),
+            client_id=_optional_str(data.get("client_id")),
+            token_endpoint=_optional_str(data.get("token_endpoint")),
+            issuer=_optional_str(data.get("issuer")),
+        )
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return str(value)
+
+
+def credentials_path() -> Path:
+    """Return the path to the OIDC credentials file (XDG / APPDATA aware)."""
+    override = os.environ.get("TOGETHER_CREDENTIALS_PATH")
+    if override:
+        return Path(override).expanduser()
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Together" / _CREDENTIALS_FILE_NAME
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / _CONFIG_DIR_NAME / _CREDENTIALS_FILE_NAME
+    return Path.home() / ".config" / _CONFIG_DIR_NAME / _CREDENTIALS_FILE_NAME
+
+
+def credentials_lock_path(path: Optional[Path] = None) -> Path:
+    target = path or credentials_path()
+    return target.with_name(target.name + _LOCK_SUFFIX)
+
+
+def credentials_lock(path: Optional[Path] = None) -> FileLock:
+    lock_path = credentials_lock_path(path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    return FileLock(str(lock_path), timeout=60)  # type: ignore[return-value]
+
+
+def load_credentials(path: Optional[Path] = None) -> Optional[StoredCredentials]:
+    target = path or credentials_path()
+    if not target.is_file():
+        return None
+    try:
+        raw = target.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return None
+        payload = cast(dict[str, Any], data)
+        if "access_token" not in payload or "refresh_token" not in payload or "expires_at" not in payload:
+            return None
+        return StoredCredentials.from_dict(payload)
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def save_credentials(credentials: StoredCredentials, path: Optional[Path] = None) -> Path:
+    target = path or credentials_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(target.name + ".tmp")
+    tmp.write_text(json.dumps(credentials.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(target)
+    if sys.platform != "win32":
+        try:
+            target.chmod(0o600)
+        except OSError:
+            pass
+    return target
+
+
+def clear_credentials(path: Optional[Path] = None) -> bool:
+    """Remove stored credentials. Returns True if a file was removed."""
+    target = path or credentials_path()
+    try:
+        target.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False

--- a/src/together/lib/cli/auth/oidc.py
+++ b/src/together/lib/cli/auth/oidc.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import os
+import ssl
+import json as json_lib
+import time
+import base64
+import socket
+import hashlib
+import secrets
+import webbrowser
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Optional, cast
+from datetime import datetime, timezone
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing_extensions import override
+
+import httpx
+
+from together import TogetherError
+from together.lib.cli.utils._console import console
+from together.lib.cli.auth.credentials import (
+    StoredCredentials,
+    credentials_lock,
+    load_credentials,
+    save_credentials,
+)
+
+# Discovery document advertised at https://api.together.ai/.well-known/openid-configuration
+_DEFAULT_API_ORIGIN = "https://api.together.ai"
+_DEFAULT_REDIRECT_HOST = "localhost"
+_DEFAULT_REDIRECT_PATH = "/login-callback"
+_DEFAULT_REDIRECT_PORTS = (3000, 10001, 11110)
+_TRUSTED_HOST_SUFFIXES = (".together.ai", ".together.xyz")
+_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 30
+DEFAULT_OAUTH_SCOPES = "openid email profile"
+
+
+def discovery_url_from_base_url(base_url: Optional[str] = None) -> str:
+    """Derive the OIDC discovery URL from an API base URL (…/v1 → origin/.well-known/…)."""
+    origin = api_origin_from_base_url(base_url)
+    return f"{origin}/.well-known/openid-configuration"
+
+
+def api_origin_from_base_url(base_url: Optional[str] = None) -> str:
+    raw = base_url or os.environ.get("TOGETHER_BASE_URL") or _DEFAULT_API_ORIGIN
+    parsed = urllib.parse.urlparse(raw)
+    if not parsed.scheme or not parsed.hostname:
+        # bare host or path-only → treat as https origin
+        if "://" not in raw:
+            return f"https://{raw.rstrip('/')}"
+        raise TogetherError(f"Invalid TOGETHER_BASE_URL for OIDC discovery: {raw}")
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def default_oauth_client_id() -> Optional[str]:
+    return os.environ.get("TOGETHER_OAUTH_CLIENT_ID") or None
+
+
+def default_oauth_client_secret() -> Optional[str]:
+    return os.environ.get("TOGETHER_OAUTH_CLIENT_SECRET") or None
+
+
+def _certifi_ssl_context() -> ssl.SSLContext:
+    return httpx.create_ssl_context(trust_env=False)
+
+
+def _http_json(
+    url: str,
+    data: Optional[dict[str, Any]] = None,
+    ctx: Optional[ssl.SSLContext] = None,
+    purpose: str = "request",
+) -> dict[str, Any]:
+    if data is None:
+        req = urllib.request.Request(url, method="GET")
+    else:
+        body = urllib.parse.urlencode(data).encode()
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+        req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, context=ctx) as resp:
+            return cast("dict[str, Any]", json_lib.loads(resp.read().decode()))
+    except urllib.error.HTTPError as exc:
+        with exc:
+            error_body = exc.read().decode(errors="replace")[:500]
+            raise TogetherError(f"{purpose} failed: {url} returned HTTP {exc.code}: {error_body}") from exc
+    except urllib.error.URLError as exc:
+        reason = str(exc.reason)
+        if "CERTIFICATE_VERIFY_FAILED" in reason or "certificate verify failed" in reason.lower():
+            raise TogetherError(
+                f"{purpose} failed TLS verification for {url}. "
+                "The CLI uses its bundled CA store; upgrade the Together CLI if this persists."
+            ) from exc
+        raise TogetherError(f"{purpose} failed for {url}: {reason}") from exc
+
+
+def _is_loopback(host: Optional[str]) -> bool:
+    return (host or "").lower() in ("localhost", "127.0.0.1", "::1")
+
+
+def _is_trusted_together_url(url: str, *, allow_loopback: bool = False) -> bool:
+    parsed = urllib.parse.urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if not host or parsed.username is not None or parsed.password is not None:
+        return False
+    if parsed.query or parsed.fragment:
+        return False
+    if allow_loopback and _is_loopback(host) and parsed.scheme in ("http", "https"):
+        return True
+    if parsed.scheme != "https":
+        return False
+    if host in ("together.ai", "together.xyz"):
+        return True
+    return any(host.endswith(suffix) for suffix in _TRUSTED_HOST_SUFFIXES)
+
+
+def _validate_discovery_endpoint(endpoint: Any, name: str, *, allow_loopback: bool = False) -> str:
+    if not isinstance(endpoint, str) or not endpoint:
+        raise TogetherError(f"OIDC discovery returned no valid {name}")
+    if not _is_trusted_together_url(endpoint, allow_loopback=allow_loopback):
+        raise TogetherError(f"OIDC discovery {name} must be an https Together URL")
+    return endpoint
+
+
+def fetch_openid_configuration(discovery_url: Optional[str] = None) -> dict[str, Any]:
+    url = discovery_url or discovery_url_from_base_url()
+    allow_loopback = _is_loopback(urllib.parse.urlparse(url).hostname)
+    if not _is_trusted_together_url(url, allow_loopback=allow_loopback):
+        raise TogetherError(f"OIDC discovery URL is not a trusted Together URL: {url}")
+    disc = _http_json(url, ctx=_certifi_ssl_context(), purpose="OIDC discovery")
+    _validate_discovery_endpoint(
+        disc.get("authorization_endpoint"), "authorization endpoint", allow_loopback=allow_loopback
+    )
+    _validate_discovery_endpoint(disc.get("token_endpoint"), "token endpoint", allow_loopback=allow_loopback)
+    return disc
+
+
+def _redirect_uri_for_port(port: int) -> str:
+    return f"http://{_DEFAULT_REDIRECT_HOST}:{port}{_DEFAULT_REDIRECT_PATH}"
+
+
+def _localhost_port_in_use(port: int) -> bool:
+    try:
+        with socket.create_connection((_DEFAULT_REDIRECT_HOST, port), timeout=0.2):
+            return True
+    except OSError:
+        return False
+
+
+def _callback_server(handler: type[BaseHTTPRequestHandler]) -> tuple[HTTPServer, str]:
+    for port in _DEFAULT_REDIRECT_PORTS:
+        if _localhost_port_in_use(port):
+            continue
+        try:
+            return HTTPServer((_DEFAULT_REDIRECT_HOST, port), handler), _redirect_uri_for_port(port)
+        except OSError:
+            continue
+
+    ports = "/".join(str(port) for port in _DEFAULT_REDIRECT_PORTS)
+    raise TogetherError(
+        f"OIDC login needs a local callback port, but {ports} are all in use. "
+        "Stop the process using one of these ports and rerun `tg login`."
+    )
+
+
+def _callback_code(request_path: str, expected_state: str) -> Optional[str]:
+    parsed_request = urllib.parse.urlparse(request_path)
+    if parsed_request.path != _DEFAULT_REDIRECT_PATH:
+        return None
+    query = urllib.parse.parse_qs(parsed_request.query)
+    if "error" in query:
+        desc = query.get("error_description", query.get("error", ["unknown"]))[0]
+        raise TogetherError(f"OIDC authorization failed: {desc}")
+    callback_state = query.get("state", [""])[0]
+    if "code" not in query or not secrets.compare_digest(callback_state.encode(), expected_state.encode()):
+        return None
+    return query["code"][0]
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)
+    # RFC 7636: code_verifier is 43-128 unreserved chars; token_urlsafe(64) is fine.
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _credentials_from_token_response(
+    tok: dict[str, Any],
+    *,
+    client_id: str,
+    token_endpoint: str,
+    issuer: Optional[str],
+    previous: Optional[StoredCredentials] = None,
+) -> StoredCredentials:
+    access_token = tok.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise TogetherError(f"token endpoint returned no access_token: {tok}")
+
+    refresh_token = tok.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        if previous and previous.refresh_token:
+            refresh_token = previous.refresh_token
+        else:
+            raise TogetherError(
+                "token endpoint returned no refresh_token. "
+                "The CLI needs a refresh token to renew short-lived access tokens invisibly."
+            )
+
+    expires_in = tok.get("expires_in", 300)
+    try:
+        expires_in_s = int(expires_in)
+    except (TypeError, ValueError) as exc:
+        raise TogetherError(f"token endpoint returned invalid expires_in: {expires_in}") from exc
+
+    return StoredCredentials(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=time.time() + max(expires_in_s, 1),
+        token_type=str(tok.get("token_type") or "Bearer"),
+        id_token=tok.get("id_token") if isinstance(tok.get("id_token"), str) else (previous.id_token if previous else None),
+        scope=tok.get("scope") if isinstance(tok.get("scope"), str) else (previous.scope if previous else None),
+        client_id=client_id,
+        token_endpoint=token_endpoint,
+        issuer=issuer if isinstance(issuer, str) else (previous.issuer if previous else None),
+    )
+
+
+def login_with_oidc(
+    *,
+    client_id: Optional[str] = None,
+    client_secret: Optional[str] = None,
+    scope: str = DEFAULT_OAUTH_SCOPES,
+    discovery_url: Optional[str] = None,
+    open_browser: bool = True,
+) -> StoredCredentials:
+    """Run authorization-code + PKCE against Together OIDC and persist credentials."""
+    resolved_client_id = client_id or default_oauth_client_id()
+    if not resolved_client_id:
+        raise TogetherError(
+            "OIDC client_id is not configured. Set TOGETHER_OAUTH_CLIENT_ID or pass --client-id. "
+            "This is the Together CLI OAuth application id (app_…) registered in UMS."
+        )
+    resolved_secret = client_secret if client_secret is not None else default_oauth_client_secret()
+
+    ctx = _certifi_ssl_context()
+    disc = fetch_openid_configuration(discovery_url)
+    authorization_endpoint = _validate_discovery_endpoint(
+        disc.get("authorization_endpoint"), "authorization endpoint"
+    )
+    token_endpoint = _validate_discovery_endpoint(disc.get("token_endpoint"), "token endpoint")
+    issuer = disc.get("issuer") if isinstance(disc.get("issuer"), str) else None
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(16)
+    nonce = secrets.token_urlsafe(16)
+    captured: dict[str, str] = {}
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            try:
+                code = _callback_code(self.path, state)
+            except TogetherError as exc:
+                captured["error"] = str(exc)
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"Login failed. You can close this tab.")
+                return
+            if code is not None:
+                captured["code"] = code
+                captured["state"] = state
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"Login complete. You can close this tab and return to the terminal.")
+            else:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"Invalid login callback.")
+
+        @override
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: ARG002
+            pass
+
+    server, redirect_uri = _callback_server(_Handler)
+    params = {
+        "response_type": "code",
+        "client_id": resolved_client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+        "state": state,
+        "nonce": nonce,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    auth_url = authorization_endpoint + "?" + urllib.parse.urlencode(params)
+    console.print("[dim]Opening browser for Together login…[/dim]")
+    console.print(f"[dim]{auth_url}[/dim]")
+    if open_browser and not webbrowser.open(auth_url):
+        console.print(f"Open this URL to log in:\n{auth_url}")
+    elif not open_browser:
+        console.print(f"Open this URL to log in:\n{auth_url}")
+
+    try:
+        server.handle_request()
+    finally:
+        server.server_close()
+
+    if captured.get("error"):
+        raise TogetherError(captured["error"])
+    if not captured.get("code") or captured.get("state") != state:
+        raise TogetherError(
+            "Browser login did not complete. Keep this terminal running until the browser "
+            "redirects back to localhost, then try `tg login` again."
+        )
+
+    token_data: dict[str, Any] = {
+        "grant_type": "authorization_code",
+        "code": captured["code"],
+        "redirect_uri": redirect_uri,
+        "client_id": resolved_client_id,
+        "code_verifier": verifier,
+    }
+    if resolved_secret:
+        token_data["client_secret"] = resolved_secret
+
+    tok = _http_json(token_endpoint, data=token_data, ctx=ctx, purpose="OIDC token exchange")
+    credentials = _credentials_from_token_response(
+        tok,
+        client_id=resolved_client_id,
+        token_endpoint=token_endpoint,
+        issuer=issuer,
+    )
+    with credentials_lock():
+        save_credentials(credentials)
+    return credentials
+
+
+def _access_token_needs_refresh(credentials: StoredCredentials, *, skew_seconds: int = _ACCESS_TOKEN_REFRESH_SKEW_SECONDS) -> bool:
+    return time.time() >= (credentials.expires_at - skew_seconds)
+
+
+def refresh_access_token(
+    credentials: StoredCredentials,
+    *,
+    client_secret: Optional[str] = None,
+) -> StoredCredentials:
+    """Exchange a refresh token for a new short-lived access token."""
+    if not credentials.token_endpoint:
+        # Fall back to discovery when older credential files omit the endpoint.
+        disc = fetch_openid_configuration()
+        token_endpoint = _validate_discovery_endpoint(disc.get("token_endpoint"), "token endpoint")
+    else:
+        token_endpoint = credentials.token_endpoint
+
+    client_id = credentials.client_id or default_oauth_client_id()
+    if not client_id:
+        raise TogetherError(
+            "Stored credentials are missing client_id and TOGETHER_OAUTH_CLIENT_ID is unset. "
+            "Run `tg login` again."
+        )
+
+    resolved_secret = client_secret if client_secret is not None else default_oauth_client_secret()
+    token_data: dict[str, Any] = {
+        "grant_type": "refresh_token",
+        "refresh_token": credentials.refresh_token,
+        "client_id": client_id,
+    }
+    if resolved_secret:
+        token_data["client_secret"] = resolved_secret
+
+    tok = _http_json(
+        token_endpoint,
+        data=token_data,
+        ctx=_certifi_ssl_context(),
+        purpose="OIDC token refresh",
+    )
+    refreshed = _credentials_from_token_response(
+        tok,
+        client_id=client_id,
+        token_endpoint=token_endpoint,
+        issuer=credentials.issuer,
+        previous=credentials,
+    )
+    save_credentials(refreshed)
+    return refreshed
+
+
+def resolve_access_token(*, client_secret: Optional[str] = None) -> Optional[str]:
+    """Return a valid access token from disk, refreshing invisibly when near expiry."""
+    with credentials_lock():
+        credentials = load_credentials()
+        if credentials is None:
+            return None
+        if not _access_token_needs_refresh(credentials):
+            return credentials.access_token
+        try:
+            refreshed = refresh_access_token(credentials, client_secret=client_secret)
+        except TogetherError:
+            # Stale/invalid refresh token — treat as logged out for auth resolution.
+            return None
+        return refreshed.access_token
+
+
+def format_expiry(credentials: StoredCredentials) -> str:
+    dt = datetime.fromtimestamp(credentials.expires_at, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")

--- a/tests/unit/test_cli_no_auth_ssh.py
+++ b/tests/unit/test_cli_no_auth_ssh.py
@@ -63,6 +63,7 @@ def test_ssh_command_does_not_require_api_key_or_whoami(monkeypatch: pytest.Monk
     # missing key) and the project-resolution whoami() is skipped entirely.
     assert require_flags == [False], "ssh must build the client with require_api_key=False"
     assert resolve_calls == 0, "ssh must not run the project-resolution whoami()"
+    assert "clusters ssh" in cli._NO_AUTH_BETA_COMMANDS
 
 
 def test_non_ssh_command_still_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_cli_oidc_auth.py
+++ b/tests/unit/test_cli_oidc_auth.py
@@ -1,0 +1,245 @@
+"""Unit tests for `tg login` OIDC credential storage and invisible refresh."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from together import TogetherError
+from together.lib.cli.auth import oidc as oidc_mod, credentials as creds_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "credentials.json"
+    monkeypatch.setenv("TOGETHER_CREDENTIALS_PATH", str(path))
+    monkeypatch.delenv("TOGETHER_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("TOGETHER_OAUTH_CLIENT_SECRET", raising=False)
+    return path
+
+
+def _stored(**overrides: Any) -> creds_mod.StoredCredentials:
+    base: dict[str, Any] = {
+        "access_token": "access-1",
+        "refresh_token": "refresh-1",
+        "expires_at": time.time() + 300,
+        "client_id": "app_cli",
+        "token_endpoint": "https://api.together.ai/oauth/token",
+        "issuer": "https://ums.together.ai",
+        "scope": "openid email profile",
+    }
+    base.update(overrides)
+    return creds_mod.StoredCredentials(**base)
+
+
+class TestCredentialsStore:
+    def test_save_load_roundtrip(self) -> None:
+        original = _stored()
+        path = creds_mod.save_credentials(original)
+        assert path.is_file()
+        loaded = creds_mod.load_credentials()
+        assert loaded is not None
+        assert loaded.access_token == "access-1"
+        assert loaded.refresh_token == "refresh-1"
+        assert loaded.client_id == "app_cli"
+        raw = json.loads(path.read_text())
+        assert "access_token" in raw
+
+    def test_clear_credentials(self) -> None:
+        creds_mod.save_credentials(_stored())
+        assert creds_mod.clear_credentials() is True
+        assert creds_mod.load_credentials() is None
+        assert creds_mod.clear_credentials() is False
+
+
+class TestDiscoveryHelpers:
+    def test_discovery_url_from_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TOGETHER_BASE_URL", raising=False)
+        assert oidc_mod.discovery_url_from_base_url() == ("https://api.together.ai/.well-known/openid-configuration")
+
+    def test_discovery_url_strips_v1(self) -> None:
+        assert oidc_mod.discovery_url_from_base_url("https://api.qa.together.ai/v1") == (
+            "https://api.qa.together.ai/.well-known/openid-configuration"
+        )
+
+
+class TestTokenRefresh:
+    def test_resolve_returns_valid_token_without_refresh(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        creds_mod.save_credentials(_stored(expires_at=time.time() + 120))
+
+        def boom(*_a: object, **_k: object) -> Any:
+            raise AssertionError("should not refresh")
+
+        monkeypatch.setattr(oidc_mod, "refresh_access_token", boom)
+        assert oidc_mod.resolve_access_token() == "access-1"
+
+    def test_resolve_refreshes_near_expiry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        creds_mod.save_credentials(_stored(expires_at=time.time() + 5))
+
+        def fake_refresh(_credentials: creds_mod.StoredCredentials, **_k: object) -> creds_mod.StoredCredentials:
+            refreshed = _stored(access_token="access-2", expires_at=time.time() + 300)
+            creds_mod.save_credentials(refreshed)
+            return refreshed
+
+        monkeypatch.setattr(oidc_mod, "refresh_access_token", fake_refresh)
+        assert oidc_mod.resolve_access_token() == "access-2"
+        loaded = creds_mod.load_credentials()
+        assert loaded is not None
+        assert loaded.access_token == "access-2"
+
+    def test_refresh_posts_refresh_token_grant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stored = _stored(expires_at=time.time() - 1)
+        creds_mod.save_credentials(stored)
+        captured: dict[str, Any] = {}
+
+        def fake_http_json(url: str, data: dict[str, Any] | None = None, **_k: object) -> dict[str, Any]:
+            captured["url"] = url
+            captured["data"] = data
+            return {
+                "access_token": "access-new",
+                "refresh_token": "refresh-new",
+                "expires_in": 300,
+                "token_type": "Bearer",
+            }
+
+        monkeypatch.setattr(oidc_mod, "_http_json", fake_http_json)
+        monkeypatch.setenv("TOGETHER_OAUTH_CLIENT_SECRET", "sekrit")
+
+        refreshed = oidc_mod.refresh_access_token(stored)
+        assert refreshed.access_token == "access-new"
+        assert captured["url"] == "https://api.together.ai/oauth/token"
+        assert captured["data"]["grant_type"] == "refresh_token"
+        assert captured["data"]["refresh_token"] == "refresh-1"
+        assert captured["data"]["client_id"] == "app_cli"
+        assert captured["data"]["client_secret"] == "sekrit"
+        loaded = creds_mod.load_credentials()
+        assert loaded is not None
+        assert loaded.access_token == "access-new"
+
+    def test_login_requires_client_id(self) -> None:
+        with pytest.raises(TogetherError, match="client_id"):
+            oidc_mod.login_with_oidc(client_id=None)
+
+    def test_resolve_returns_none_when_refresh_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        creds_mod.save_credentials(_stored(expires_at=time.time() - 1))
+
+        def fail_refresh(*_a: object, **_k: object) -> creds_mod.StoredCredentials:
+            raise TogetherError("refresh failed")
+
+        monkeypatch.setattr(oidc_mod, "refresh_access_token", fail_refresh)
+        assert oidc_mod.resolve_access_token() is None
+
+
+class TestLoginFlow:
+    def test_pkce_login_exchanges_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        disc = {
+            "issuer": "https://ums.together.ai",
+            "authorization_endpoint": "https://api.together.ai/oauth/authorize",
+            "token_endpoint": "https://api.together.ai/oauth/token",
+        }
+        monkeypatch.setattr(oidc_mod, "fetch_openid_configuration", lambda *_a, **_k: disc)
+        monkeypatch.setattr(oidc_mod, "_pkce_pair", lambda: ("v" * 43, "challenge"))
+        monkeypatch.setattr(oidc_mod.secrets, "token_urlsafe", lambda *_a, **_k: "fixed-state")
+        monkeypatch.setattr(oidc_mod.webbrowser, "open", lambda _url: True)
+
+        def fake_callback_server(handler_cls: type) -> tuple[Any, str]:
+            server = MagicMock()
+            redirect = "http://localhost:3000/login-callback"
+
+            def handle_request() -> None:
+                handler = handler_cls.__new__(handler_cls)
+                handler.path = "/login-callback?code=auth-code&state=fixed-state"
+                handler.send_response = MagicMock()
+                handler.end_headers = MagicMock()
+                handler.wfile = MagicMock()
+                handler.wfile.write = MagicMock()
+                handler.do_GET()
+
+            server.handle_request.side_effect = handle_request
+            server.server_close = MagicMock()
+            return server, redirect
+
+        monkeypatch.setattr(oidc_mod, "_callback_server", fake_callback_server)
+
+        token_calls: list[dict[str, Any]] = []
+
+        def fake_http_json(url: str, data: dict[str, Any] | None = None, **_k: object) -> dict[str, Any]:
+            token_calls.append({"url": url, "data": data})
+            return {
+                "access_token": "access-login",
+                "refresh_token": "refresh-login",
+                "expires_in": 300,
+                "id_token": "id-login",
+                "token_type": "Bearer",
+                "scope": "openid email profile",
+            }
+
+        monkeypatch.setattr(oidc_mod, "_http_json", fake_http_json)
+
+        credentials = oidc_mod.login_with_oidc(client_id="app_cli", client_secret="sekrit", open_browser=False)
+        assert credentials.access_token == "access-login"
+        assert credentials.refresh_token == "refresh-login"
+        assert token_calls[0]["data"]["grant_type"] == "authorization_code"
+        assert token_calls[0]["data"]["code"] == "auth-code"
+        assert token_calls[0]["data"]["code_verifier"] == "v" * 43
+        assert token_calls[0]["data"]["client_secret"] == "sekrit"
+        loaded = creds_mod.load_credentials()
+        assert loaded is not None
+        assert loaded.access_token == "access-login"
+
+
+class TestCliNoAuthLogin:
+    def test_login_command_does_not_require_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import together.lib.cli as cli
+
+        monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
+        monkeypatch.setenv("TOGETHER_DISABLE_VERSION_CHECK", "1")
+        monkeypatch.setenv("TOGETHER_OAUTH_CLIENT_ID", "app_cli")
+
+        require_flags: list[bool] = []
+        resolve_calls = 0
+        real_create = cli._create_client
+
+        def spy_create(*args: object, require_api_key: bool = True, **kwargs: object):  # type: ignore[no-untyped-def]
+            require_flags.append(require_api_key)
+            return real_create(*args, require_api_key=require_api_key, **kwargs)  # type: ignore[arg-type]
+
+        async def spy_resolve(_client: object) -> str:
+            nonlocal resolve_calls
+            resolve_calls += 1
+            return "proj"
+
+        def fake_login_with_oidc(**_k: object) -> creds_mod.StoredCredentials:
+            return _stored()
+
+        monkeypatch.setattr(cli, "_create_client", spy_create)
+        monkeypatch.setattr(cli, "_resolve_project_id", spy_resolve)
+        monkeypatch.setattr("together.lib.cli.api.login.login_with_oidc", fake_login_with_oidc)
+
+        try:
+            cli.app.meta(["login", "--no-browser"])
+        except SystemExit:
+            pass
+
+        assert require_flags == [False]
+        assert resolve_calls == 0
+
+    def test_resolve_cli_api_key_uses_oidc(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import together.lib.cli as cli
+
+        monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
+        creds_mod.save_credentials(_stored(expires_at=time.time() + 120))
+        assert cli._resolve_cli_api_key(None) == "access-1"
+
+    def test_resolve_cli_api_key_prefers_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import together.lib.cli as cli
+
+        monkeypatch.setenv("TOGETHER_API_KEY", "env-key")
+        creds_mod.save_credentials(_stored())
+        assert cli._resolve_cli_api_key(None) == "env-key"
+        assert cli._resolve_cli_api_key("flag-key") == "flag-key"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `tg login` / `tg logout` for OIDC authentication against `https://api.together.ai/.well-known/openid-configuration` (ENG-91941).

- Browser authorization-code + PKCE flow (same localhost callback ports as cluster SSH: 3000/10001/11110)
- Stores credentials at `~/.config/together/credentials.json` (`0o600`, overridable via `TOGETHER_CREDENTIALS_PATH`)
- Access tokens are treated as short-lived (~5 minutes); CLI silently refreshes via `grant_type=refresh_token` before API calls
- Auth precedence for CLI: `--api-key` → `TOGETHER_API_KEY` → stored OIDC access token
- `login` / `logout` are keyless (no up-front `whoami`)

### Config

| Var / flag | Purpose |
|---|---|
| `TOGETHER_OAUTH_CLIENT_ID` / `--client-id` | UMS OAuth app id (`app_…`) — required for login |
| `TOGETHER_OAUTH_CLIENT_SECRET` / `--client-secret` | Required today for confidential clients; omitted for public clients |
| `TOGETHER_BASE_URL` | Discovery origin derived from this (strips `/v1`) |

### Notes / follow-ups

- UMS issues ~5m access tokens + refresh tokens on code exchange, but together-web `/oauth/token` currently only accepts `authorization_code` in the public discovery/schema. CLI already implements refresh client-side.
- `/oauth/token` currently requires `client_secret` for confidential clients. Need the registered Together CLI OAuth app (`client_id`, redirect URIs, public vs confidential) before e2e login works in prod/QA.
- API Bearer acceptance of OIDC access tokens (vs API keys) may still be landing separately — `whoami` docs currently say API keys only.

## Test plan

- [x] Unit tests for credential store, invisible refresh, PKCE code exchange, CLI no-auth for `login`
- [x] `tg login --help` / `tg logout --help`
- [ ] E2E `tg login` once CLI OAuth app credentials + refresh grant are available

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-91941](https://linear.app/together-ai/issue/ENG-91941/implement-tg-login-to-do-oidc-authentication)

<div><a href="https://cursor.com/agents/bc-f77e47b9-8d4e-4f70-9f9b-5826323f35b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f77e47b9-8d4e-4f70-9f9b-5826323f35b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

