### PR TITLE
feat(cli): warn about implicit volume version when there are multiple versions - ENG-91965

### DIFF
--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -108,7 +108,7 @@ class VolumeMount:
 
     name: str
     mount_path: str
-    version: int = 0
+    version: Optional[int] = None  # None means not set in config; deploy still mounts version 0
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> VolumeMount:
@@ -635,6 +635,22 @@ class Jig:
             del self.state.secrets[name]
             self.state.save()
 
+    def validate_volumes(self) -> None:
+        """Warn when a mounted volume has multiple versions but no version is set in the config."""
+        for vm in self.config.deploy.volume_mounts:
+            if vm.version is not None:
+                continue
+            try:
+                volume = self.api.volumes.retrieve(vm.name)
+            except APIError:
+                continue  # missing/inaccessible volumes are surfaced by the deployment call itself
+            versions = {int(v) for v in volume.version_history or {}} | {volume.current_version or 0}
+            if len(versions) > 1:
+                console.print(
+                    f"\N{WARNING SIGN} No version set for volume {vm.name}, using version 0. "
+                    f"The following versions are available: {', '.join(str(v) for v in sorted(versions))}"
+                )
+
     # == Build / Push / Deploy / Track ==
 
     def build(self, tag: str = "latest", warmup: bool = False, docker_args: str | None = None) -> None:
@@ -800,6 +816,8 @@ class Jig:
             console.print("\N{CHECK MARK} Build complete (--build-only)")
             return
 
+        self.validate_volumes()
+
         deploy_data: dict[str, Any] = {
             "name": self.name,
             "description": self.config.deploy.description,
@@ -814,7 +832,7 @@ class Jig:
             "storage": self.config.deploy.storage,
             "autoscaling": self.config.deploy.autoscaling,
             "termination_grace_period_seconds": self.config.deploy.termination_grace_period_seconds,
-            "volumes": [asdict(vm) for vm in self.config.deploy.volume_mounts],
+            "volumes": [{**asdict(vm), "version": vm.version or 0} for vm in self.config.deploy.volume_mounts],
         }
 
         if self.config.deploy.health_check_path:

--- a/src/together/lib/cli/api/beta/jig/jig.py
+++ b/src/together/lib/cli/api/beta/jig/jig.py
@@ -647,7 +647,7 @@ class Jig:
             versions = {int(v) for v in volume.version_history or {}} | {volume.current_version or 0}
             if len(versions) > 1:
                 console.print(
-                    f"\N{WARNING SIGN} No version set for volume {vm.name}, using version 0. "
+                    f"\N{WARNING SIGN} No version set for volume '{vm.name}', using version 0. "
                     f"The following versions are available: {', '.join(str(v) for v in sorted(versions))}"
                 )
 


### PR DESCRIPTION
If mounted volume has more than one version, and explicit version is not specified print a message saying version 0 is being used.