### PR TITLE
chore(cli): drop `tqdm` dependency (DX-458)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ dependencies = [
   "sniffio",
   "cyclopts>=4.6.0",
   "rich>=13.7.1",
-  "tqdm>=4.67.1",
-  "types-tqdm>=4.67.0.20250516",
   "filelock>=3.13.1",
   "types-pyyaml>=6.0.12.20250915",
   "tomli>=2.0.0; python_version < '3.11'",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -25,9 +25,7 @@ certifi==2026.1.4
     #   httpcore
     #   httpx
 colorama==0.4.6 ; sys_platform == 'win32'
-    # via
-    #   pytest
-    #   tqdm
+    # via pytest
 cyclopts==4.10.2
     # via together
 detect-agent==0.6.0
@@ -124,13 +122,7 @@ tomli==2.4.0 ; python_full_version < '3.11'
     #   mypy
     #   pytest
     #   together
-tqdm==4.67.3
-    # via together
 types-pyyaml==6.0.12.20250915
-    # via together
-types-requests==2.32.4.20260107
-    # via types-tqdm
-types-tqdm==4.67.3.20260303
     # via together
 typing-extensions==4.15.0
     # via
@@ -148,7 +140,6 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-urllib3==2.6.3
-    # via types-requests
+websockets==15.0.1
 yarl==1.22.0
     # via aiohttp

--- a/src/together/lib/cli/api/beta/models/download.py
+++ b/src/together/lib/cli/api/beta/models/download.py
@@ -12,17 +12,6 @@ from typing_extensions import Annotated
 
 import httpx
 from cyclopts import Parameter
-from rich.progress import (
-    TaskID,
-    Progress,
-    BarColumn,
-    TextColumn,
-    SpinnerColumn,
-    DownloadColumn,
-    TaskProgressColumn,
-    TimeRemainingColumn,
-    TransferSpeedColumn,
-)
 
 from together import omit
 from together._utils import path_template
@@ -33,8 +22,9 @@ from together.lib.cli.api.beta.models.upload import (
     FILE_CONCURRENCY,
     PART_CONCURRENCY,
     _file_etag,
-    _format_bytes,
 )
+from together.lib.cli.components.upload_progress import format_bytes
+from together.lib.cli.components.download_progress import DownloadProgressTracker
 
 PART_DOWNLOAD_TIMEOUT_SECONDS = 30 * 60
 PART_DOWNLOAD_MAX_ATTEMPTS = 5
@@ -136,73 +126,7 @@ def _check_disk_space(base_path: Path, need_bytes: int) -> None:
     base_path.mkdir(parents=True, exist_ok=True)
     usage = shutil.disk_usage(base_path)
     if usage.free < need_bytes:
-        raise ValueError(f"insufficient disk space: need {_format_bytes(need_bytes)}, have {_format_bytes(usage.free)}")
-
-
-class DownloadProgressTracker:
-    def __init__(self, *, total_bytes: int, total_files: int, enabled: bool) -> None:
-        self.enabled = enabled
-        self.total_bytes = total_bytes
-        self.total_files = total_files
-        self.downloaded_bytes = 0
-        self.completed_files = 0
-        self.skipped_files = 0
-        self._lock = asyncio.Lock()
-        self._progress: Progress | None = None
-        self._bytes_task: TaskID | None = None
-        self._files_task: TaskID | None = None
-
-    def __enter__(self) -> DownloadProgressTracker:
-        if not self.enabled:
-            return self
-        self._progress = Progress(
-            SpinnerColumn(style="bar.pulse"),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
-            TaskProgressColumn(),
-            TextColumn("•"),
-            DownloadColumn(),
-            TransferSpeedColumn(),
-            TimeRemainingColumn(),
-            console=console,
-        )
-        self._progress.start()
-        self._bytes_task = self._progress.add_task("Overall", total=max(self.total_bytes, 1))
-        self._files_task = self._progress.add_task(
-            f"Files (0/{self.total_files})",
-            total=max(self.total_files, 1),
-        )
-        return self
-
-    def __exit__(self, *_args: object) -> None:
-        if self._progress is not None:
-            self._progress.stop()
-
-    async def bytes_completed(self, count: int) -> None:
-        async with self._lock:
-            self.downloaded_bytes += count
-            if not self.enabled or self._progress is None:
-                return
-            assert self._bytes_task is not None
-            self._progress.update(self._bytes_task, completed=self.downloaded_bytes)
-
-    async def file_completed(self, file_path: str, *, skipped: bool = False) -> None:
-        async with self._lock:
-            self.completed_files += 1
-            if skipped:
-                self.skipped_files += 1
-            if not self.enabled or self._progress is None:
-                return
-            assert self._files_task is not None
-            self._progress.update(
-                self._files_task,
-                completed=self.completed_files,
-                description=f"Files ({self.completed_files}/{self.total_files})",
-            )
-            if skipped:
-                self._progress.console.print(f"[dim]↷[/dim] {file_path} skipped (already exists)")
-            else:
-                self._progress.console.print(f"[success]✓[/success] {file_path} complete")
+        raise ValueError(f"insufficient disk space: need {format_bytes(need_bytes)}, have {format_bytes(usage.free)}")
 
 
 def _preallocate_file(path: Path, size: int) -> None:
@@ -374,7 +298,7 @@ async def _download_model_files(
         enabled=show_progress and len(remote_files) > 0,
     )
     if show_progress and remote_files:
-        console.print(f"Downloading {len(remote_files)} file(s), {_format_bytes(total_bytes)} total")
+        console.print(f"Downloading {len(remote_files)} file(s), {format_bytes(total_bytes)} total")
         console.print(f"[dim]Revision:[/dim] {rev}")
     with progress:
         await _download_files(remote_files, dst, progress=progress)

--- a/src/together/lib/cli/api/beta/models/upload.py
+++ b/src/together/lib/cli/api/beta/models/upload.py
@@ -10,21 +10,11 @@ from dataclasses import dataclass
 
 import httpx
 from cyclopts import Parameter
-from rich.progress import (
-    TaskID,
-    Progress,
-    BarColumn,
-    TextColumn,
-    SpinnerColumn,
-    DownloadColumn,
-    TaskProgressColumn,
-    TimeRemainingColumn,
-    TransferSpeedColumn,
-)
 
 from together._utils import path_template
 from together.lib.cli.utils.config import CLIConfig, CLIConfigParameter
 from together.lib.cli.utils._console import console
+from together.lib.cli.components.upload_progress import UploadProgressTracker, format_bytes
 from together.lib.cli.utils._assert_explicit_project_id import assert_explicit_project_id
 
 PART_SIZE_BYTES = 20 * 1024 * 1024
@@ -143,135 +133,6 @@ def _create_upload_body(
 
 def _trim_etag(value: str) -> str:
     return value.strip().strip('"')
-
-
-def _format_bytes(num: int) -> str:
-    size = float(num)
-    for unit in ("B", "KB", "MB", "GB", "TB"):
-        if size < 1024 or unit == "TB":
-            if unit == "B":
-                return f"{int(size)} B"
-            return f"{size:.1f} {unit}"
-        size /= 1024
-    return f"{size:.1f} PB"
-
-
-class UploadProgressTracker:
-    def __init__(
-        self,
-        *,
-        total_bytes: int,
-        total_parts: int,
-        total_files: int,
-        enabled: bool,
-    ) -> None:
-        self.enabled = enabled
-        self.total_bytes = total_bytes
-        self.total_parts = total_parts
-        self.total_files = total_files
-        self.uploaded_bytes = 0
-        self.completed_parts = 0
-        self.completed_files = 0
-        self._lock = asyncio.Lock()
-        self._progress: Progress | None = None
-        self._bytes_task: TaskID | None = None
-        self._parts_task: TaskID | None = None
-        self._files_task: TaskID | None = None
-
-    @classmethod
-    def from_upload_plan(
-        cls,
-        local_files: list[LocalFile],
-        remote_files: list[dict[str, Any]],
-        *,
-        enabled: bool,
-    ) -> UploadProgressTracker:
-        local_by_path = {file.path: file for file in local_files}
-        total_bytes = 0
-        total_parts = 0
-        total_files = 0
-        for remote_file in remote_files:
-            if remote_file.get("skipUpload"):
-                continue
-            path = str(remote_file.get("path", ""))
-            local_file = local_by_path[path]
-            total_bytes += local_file.size
-            total_parts += len(local_file.parts)
-            total_files += 1
-        return cls(
-            total_bytes=total_bytes,
-            total_parts=total_parts,
-            total_files=total_files,
-            enabled=enabled,
-        )
-
-    def __enter__(self) -> UploadProgressTracker:
-        if not self.enabled:
-            return self
-        self._progress = Progress(
-            SpinnerColumn(style="bar.pulse"),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
-            TaskProgressColumn(),
-            TextColumn("•"),
-            DownloadColumn(),
-            TransferSpeedColumn(),
-            TimeRemainingColumn(),
-            console=console,
-        )
-        self._progress.start()
-        self._bytes_task = self._progress.add_task("Overall", total=max(self.total_bytes, 1))
-        self._parts_task = self._progress.add_task(
-            f"Parts (0/{self.total_parts})",
-            total=max(self.total_parts, 1),
-        )
-        self._files_task = self._progress.add_task(
-            f"Files (0/{self.total_files})",
-            total=max(self.total_files, 1),
-        )
-        return self
-
-    def __exit__(self, *_args: object) -> None:
-        if self._progress is not None:
-            self._progress.stop()
-
-    async def part_completed(
-        self,
-        *,
-        file_path: str,
-        part_number: int,
-        total_file_parts: int,
-        bytes_count: int,
-    ) -> None:
-        async with self._lock:
-            self.uploaded_bytes += bytes_count
-            self.completed_parts += 1
-            if not self.enabled or self._progress is None:
-                return
-            assert self._bytes_task is not None
-            assert self._parts_task is not None
-            self._progress.update(self._bytes_task, completed=self.uploaded_bytes)
-            self._progress.update(
-                self._parts_task,
-                completed=self.completed_parts,
-                description=f"Parts ({self.completed_parts}/{self.total_parts})",
-            )
-            self._progress.console.print(
-                f"[success]✓[/success] {file_path} part {part_number}/{total_file_parts} ({_format_bytes(bytes_count)})"
-            )
-
-    async def file_completed(self, file_path: str) -> None:
-        async with self._lock:
-            self.completed_files += 1
-            if not self.enabled or self._progress is None:
-                return
-            assert self._files_task is not None
-            self._progress.update(
-                self._files_task,
-                completed=self.completed_files,
-                description=f"Files ({self.completed_files}/{self.total_files})",
-            )
-            self._progress.console.print(f"[success]✓[/success] {file_path} complete")
 
 
 async def _read_file_part(path: Path, offset: int, size: int, chunk_size: int = 1024 * 1024) -> AsyncIterator[bytes]:
@@ -465,7 +326,7 @@ async def _upload_model_files(
         console.print(
             f"Uploading {progress.total_files} file(s), "
             f"{progress.total_parts} part(s), "
-            f"{_format_bytes(progress.total_bytes)} total"
+            f"{format_bytes(progress.total_bytes)} total"
         )
     with progress:
         complete_files = await _upload_files(local_files, remote_files, progress=progress)

--- a/src/together/lib/cli/api/files/check.py
+++ b/src/together/lib/cli/api/files/check.py
@@ -11,6 +11,7 @@ from together.lib.utils import check_file
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
+from together.lib.cli.components.check_progress import CheckProgressTracker, should_show_check_progress
 
 
 async def check(
@@ -20,7 +21,8 @@ async def check(
 ) -> None:
     """Check file for issues"""
 
-    report = check_file(file)
+    with CheckProgressTracker(file, enabled=should_show_check_progress(file, json_mode=config.json)) as tracker:
+        report = check_file(file, progress_callback=tracker.as_callback())
 
     if config.json:
         console.print_json(openapi_dumps(report).decode("utf-8"))

--- a/src/together/lib/cli/api/files/check.py
+++ b/src/together/lib/cli/api/files/check.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 from typing import Annotated
 from pathlib import Path
@@ -20,9 +19,6 @@ async def check(
     config: CLIConfigParameter,
 ) -> None:
     """Check file for issues"""
-
-    if config.json:
-        os.environ.setdefault("TOGETHER_DISABLE_TQDM", "true")
 
     report = check_file(file)
 

--- a/src/together/lib/cli/api/files/upload.py
+++ b/src/together/lib/cli/api/files/upload.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 from typing import Optional, Annotated, cast, get_args
 from pathlib import Path
@@ -14,7 +13,7 @@ from together._utils._json import openapi_dumps
 from together.lib.resources.files import FileAlreadyExistsError
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
-from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.components.upload_progress import upload_file_with_progress
 
 
 async def upload(
@@ -25,9 +24,6 @@ async def upload(
     config: CLIConfigParameter,
 ) -> None:
     """Upload file."""
-    if config.json:
-        os.environ.setdefault("TOGETHER_DISABLE_TQDM", "true")
-
     # Manually handle check here so we can exit and provide the user good error messages
     if not no_check:
         report = check_file(file)
@@ -47,11 +43,13 @@ async def upload(
         sys.exit(1)
 
     try:
-        response = await show_loading_status(
-            "Uploading file",
-            config.client.files.upload(
-                file=file, purpose=purpose, check=False, raise_if_already_exists=not config.json
-            ),
+        response = await upload_file_with_progress(
+            config.client.files.upload,
+            file,
+            enabled=not config.json,
+            purpose=purpose,
+            check=False,
+            raise_if_already_exists=not config.json,
         )
     except FileAlreadyExistsError as e:
         console.print(

--- a/src/together/lib/cli/api/files/upload.py
+++ b/src/together/lib/cli/api/files/upload.py
@@ -13,6 +13,7 @@ from together._utils._json import openapi_dumps
 from together.lib.resources.files import FileAlreadyExistsError
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
+from together.lib.cli.components.check_progress import CheckProgressTracker, should_show_check_progress
 from together.lib.cli.components.upload_progress import upload_file_with_progress
 
 
@@ -26,7 +27,12 @@ async def upload(
     """Upload file."""
     # Manually handle check here so we can exit and provide the user good error messages
     if not no_check:
-        report = check_file(file)
+        with CheckProgressTracker(file, enabled=should_show_check_progress(file, json_mode=config.json)) as tracker:
+            report = check_file(
+                file,
+                purpose=purpose or "fine-tune",
+                progress_callback=tracker.as_callback(),
+            )
         if report["is_check_passed"] is False:
             if config.json:
                 console.print_json(openapi_dumps(report).decode("utf-8"))

--- a/src/together/lib/cli/api/fine_tuning/create.py
+++ b/src/together/lib/cli/api/fine_tuning/create.py
@@ -18,6 +18,7 @@ from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
 from together.lib.resources.fine_tuning import validate_early_stopping
 from together.lib.cli.components.model_dump import print_model_dump
+from together.lib.cli.components.upload_progress import upload_file_with_progress
 
 
 def get_confirmation_message(price_line: str, warning: str) -> str:
@@ -361,13 +362,27 @@ async def create(
     # If the user passes a path to a file, try to upload it to the files API first
     # Uploads are idempotent so we can depend on this API always giving us a file ID
     if _check_path_exists(training_args["training_file"]):
-        file_upload = await config.client.files.upload(Path(training_args["training_file"]), purpose="fine-tune")
+        training_path = Path(training_args["training_file"])
+        file_upload = await upload_file_with_progress(
+            config.client.files.upload,
+            training_path,
+            enabled=not config.json,
+            description=f"Uploading training file {training_path.name}",
+            purpose="fine-tune",
+        )
         training_args["training_file"] = file_upload.id
 
     # If the user passes a path to a file, try to upload it to the files API first
     # Uploads are idempotent so we can depend on this API always giving us a file ID
     if _check_path_exists(training_args["validation_file"]):
-        file_upload = await config.client.files.upload(Path(training_args["validation_file"]), purpose="fine-tune")
+        validation_path = Path(training_args["validation_file"])
+        file_upload = await upload_file_with_progress(
+            config.client.files.upload,
+            validation_path,
+            enabled=not config.json,
+            description=f"Uploading validation file {validation_path.name}",
+            purpose="fine-tune",
+        )
         training_args["validation_file"] = file_upload.id
 
     finetune_price_estimation_result = await show_loading_status(

--- a/src/together/lib/cli/api/fine_tuning/download.py
+++ b/src/together/lib/cli/api/fine_tuning/download.py
@@ -13,7 +13,7 @@ from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.types.finetune_response import TrainingTypeFullTrainingType, TrainingTypeLoRaTrainingType
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.components.upload_progress import file_download_progress
+from together.lib.cli.components.download_progress import DownloadProgressTracker
 
 _FT_JOB_WITH_STEP_REGEX = r"^ft-[\dabcdef-]+:\d+$"
 
@@ -83,16 +83,16 @@ async def download(
     output: Path | None = output_dir
 
     try:
-        with file_download_progress(
+        with DownloadProgressTracker.for_single_file(
             enabled=not config.json,
             description=f"Downloading {remote_name}",
-        ) as progress_callback:
+        ) as tracker:
             file_path, file_size = await AsyncDownloadManager(config.client).download(
                 url=url,
                 output=output,
                 remote_name=ft_job.x_model_output_name,
                 fetch_metadata=True,
-                progress_callback=progress_callback,
+                progress_callback=tracker.as_callback(),
             )
 
         if config.json:

--- a/src/together/lib/cli/api/fine_tuning/download.py
+++ b/src/together/lib/cli/api/fine_tuning/download.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import re
 from typing import Literal, Optional, Annotated
 from pathlib import Path
@@ -14,6 +13,7 @@ from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.types.finetune_response import TrainingTypeFullTrainingType, TrainingTypeLoRaTrainingType
 from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.components.upload_progress import file_download_progress
 
 _FT_JOB_WITH_STEP_REGEX = r"^ft-[\dabcdef-]+:\d+$"
 
@@ -82,17 +82,18 @@ async def download(
         url = f"{url}&checkpoint_step={checkpoint_step}"
     output: Path | None = output_dir
 
-    # Disable tqdm for json mode
-    if config.json:
-        os.environ.setdefault("TOGETHER_DISABLE_TQDM", "true")
-
     try:
-        file_path, file_size = await AsyncDownloadManager(config.client).download(
-            url=url,
-            output=output,
-            remote_name=ft_job.x_model_output_name,
-            fetch_metadata=True,
-        )
+        with file_download_progress(
+            enabled=not config.json,
+            description=f"Downloading {remote_name}",
+        ) as progress_callback:
+            file_path, file_size = await AsyncDownloadManager(config.client).download(
+                url=url,
+                output=output,
+                remote_name=ft_job.x_model_output_name,
+                fetch_metadata=True,
+                progress_callback=progress_callback,
+            )
 
         if config.json:
             console.print_json(

--- a/src/together/lib/cli/components/check_progress.py
+++ b/src/together/lib/cli/components/check_progress.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.progress import (
+    TaskID,
+    Progress,
+    BarColumn,
+    TextColumn,
+    SpinnerColumn,
+    DownloadColumn,
+    TaskProgressColumn,
+)
+
+from together.lib.utils.files import FileCheckProgress, CheckProgressCallback
+from together.lib.cli.utils._console import console
+
+_PHASE_DESCRIPTIONS = {
+    "utf8": "Checking encoding",
+    "jsonl": "Validating JSONL",
+    "csv": "Validating CSV",
+}
+# Tiny files finish instantly; don't pay for a live display (or pollute CLI tests).
+CHECK_PROGRESS_MIN_BYTES = 1024 * 1024
+
+
+def should_show_check_progress(file: Path, *, json_mode: bool) -> bool:
+    if json_mode or not console.is_terminal:
+        return False
+    try:
+        return file.is_file() and file.stat().st_size >= CHECK_PROGRESS_MIN_BYTES
+    except OSError:
+        return False
+
+
+class CheckProgressTracker:
+    """Rich progress tracker for CLI ``files check`` / pre-upload validation."""
+
+    def __init__(self, file: Path, *, enabled: bool) -> None:
+        self.file = file
+        self.enabled = enabled
+        self._progress: Progress | None = None
+        self._task: TaskID | None = None
+
+    def __enter__(self) -> CheckProgressTracker:
+        if not self.enabled:
+            return self
+        total = max(self.file.stat().st_size, 1)
+        self._progress = Progress(
+            SpinnerColumn(style="bar.pulse"),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
+            TaskProgressColumn(),
+            TextColumn("•"),
+            DownloadColumn(),
+            console=console,
+            transient=True,
+        )
+        self._progress.start()
+        self._task = self._progress.add_task(f"Checking {self.file.name}", total=total)
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        if self._progress is not None:
+            self._progress.stop()
+
+    def as_callback(self) -> CheckProgressCallback | None:
+        if not self.enabled:
+            return None
+
+        def on_progress(event: FileCheckProgress) -> None:
+            if self._progress is None or self._task is None:
+                return
+            phase_label = _PHASE_DESCRIPTIONS.get(event.phase, "Checking")
+            self._progress.update(
+                self._task,
+                description=f"{phase_label} {self.file.name}",
+                completed=min(event.processed_bytes, max(event.total_bytes, 1)),
+                total=max(event.total_bytes, 1),
+            )
+
+        return on_progress

--- a/src/together/lib/cli/components/check_progress.py
+++ b/src/together/lib/cli/components/check_progress.py
@@ -19,6 +19,7 @@ _PHASE_DESCRIPTIONS = {
     "utf8": "Checking encoding",
     "jsonl": "Validating JSONL",
     "csv": "Validating CSV",
+    "parquet": "Validating Parquet",
 }
 # Tiny files finish instantly; don't pay for a live display (or pollute CLI tests).
 CHECK_PROGRESS_MIN_BYTES = 1024 * 1024
@@ -41,6 +42,9 @@ class CheckProgressTracker:
         self.enabled = enabled
         self._progress: Progress | None = None
         self._task: TaskID | None = None
+        self._phase: str | None = None
+        self._completed_phase_bytes = 0
+        self._current_phase_total = 0
 
     def __enter__(self) -> CheckProgressTracker:
         if not self.enabled:
@@ -71,12 +75,19 @@ class CheckProgressTracker:
         def on_progress(event: FileCheckProgress) -> None:
             if self._progress is None or self._task is None:
                 return
+            if event.phase != self._phase:
+                if self._phase is not None:
+                    self._completed_phase_bytes += self._current_phase_total
+                self._phase = event.phase
+                self._current_phase_total = event.total_bytes
             phase_label = _PHASE_DESCRIPTIONS.get(event.phase, "Checking")
+            completed = self._completed_phase_bytes + event.processed_bytes
+            total = self._completed_phase_bytes + event.total_bytes
             self._progress.update(
                 self._task,
                 description=f"{phase_label} {self.file.name}",
-                completed=min(event.processed_bytes, max(event.total_bytes, 1)),
-                total=max(event.total_bytes, 1),
+                completed=min(completed, max(total, 1)),
+                total=max(total, 1),
             )
 
         return on_progress

--- a/src/together/lib/cli/components/check_progress.py
+++ b/src/together/lib/cli/components/check_progress.py
@@ -23,6 +23,15 @@ _PHASE_DESCRIPTIONS = {
 }
 # Tiny files finish instantly; don't pay for a live display (or pollute CLI tests).
 CHECK_PROGRESS_MIN_BYTES = 1024 * 1024
+_TWO_PASS_SUFFIXES = {".jsonl", ".csv"}
+
+
+def _expected_check_work_bytes(file: Path) -> int:
+    """Total progress units for a check: two full scans for JSONL/CSV, one for everything else."""
+    size = max(file.stat().st_size, 1)
+    if file.suffix in _TWO_PASS_SUFFIXES:
+        return size * 2
+    return size
 
 
 def should_show_check_progress(file: Path, *, json_mode: bool) -> bool:
@@ -45,11 +54,13 @@ class CheckProgressTracker:
         self._phase: str | None = None
         self._completed_phase_bytes = 0
         self._current_phase_total = 0
+        self._total = 1
 
     def __enter__(self) -> CheckProgressTracker:
         if not self.enabled:
             return self
-        total = max(self.file.stat().st_size, 1)
+        total = _expected_check_work_bytes(self.file)
+        self._total = total
         self._progress = Progress(
             SpinnerColumn(style="bar.pulse"),
             TextColumn("[progress.description]{task.description}"),
@@ -82,12 +93,10 @@ class CheckProgressTracker:
                 self._current_phase_total = event.total_bytes
             phase_label = _PHASE_DESCRIPTIONS.get(event.phase, "Checking")
             completed = self._completed_phase_bytes + event.processed_bytes
-            total = self._completed_phase_bytes + event.total_bytes
             self._progress.update(
                 self._task,
                 description=f"{phase_label} {self.file.name}",
-                completed=min(completed, max(total, 1)),
-                total=max(total, 1),
+                completed=min(completed, self._total),
             )
 
         return on_progress

--- a/src/together/lib/cli/components/download_progress.py
+++ b/src/together/lib/cli/components/download_progress.py
@@ -60,7 +60,7 @@ class DownloadProgressTracker:
         )
 
     def __enter__(self) -> DownloadProgressTracker:
-        if not self.enabled:
+        if not self.enabled or not console.is_terminal:
             return self
         self._progress = Progress(
             SpinnerColumn(style="bar.pulse"),
@@ -72,6 +72,7 @@ class DownloadProgressTracker:
             TransferSpeedColumn(),
             TimeRemainingColumn(),
             console=console,
+            transient=True,
         )
         self._progress.start()
         self._bytes_task = self._progress.add_task(self.description, total=max(self.total_bytes, 1))

--- a/src/together/lib/cli/components/download_progress.py
+++ b/src/together/lib/cli/components/download_progress.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+
+from rich.progress import (
+    TaskID,
+    Progress,
+    BarColumn,
+    TextColumn,
+    SpinnerColumn,
+    DownloadColumn,
+    TaskProgressColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
+
+from together.lib.resources.files import FileDownloadProgress, DownloadProgressCallback
+from together.lib.cli.utils._console import console
+
+
+class DownloadProgressTracker:
+    """Shared Rich progress tracker for CLI file downloads."""
+
+    def __init__(
+        self,
+        *,
+        total_bytes: int,
+        total_files: int,
+        enabled: bool,
+        description: str = "Overall",
+        show_files: bool = True,
+    ) -> None:
+        self.enabled = enabled
+        self.total_bytes = total_bytes
+        self.total_files = total_files
+        self.description = description
+        self.show_files = show_files
+        self.downloaded_bytes = 0
+        self.completed_files = 0
+        self.skipped_files = 0
+        self._lock = asyncio.Lock()
+        self._progress: Progress | None = None
+        self._bytes_task: TaskID | None = None
+        self._files_task: TaskID | None = None
+
+    @classmethod
+    def for_single_file(
+        cls,
+        *,
+        enabled: bool,
+        description: str = "Downloading file",
+        total_bytes: int = 0,
+    ) -> DownloadProgressTracker:
+        return cls(
+            total_bytes=total_bytes,
+            total_files=1,
+            enabled=enabled,
+            description=description,
+            show_files=False,
+        )
+
+    def __enter__(self) -> DownloadProgressTracker:
+        if not self.enabled:
+            return self
+        self._progress = Progress(
+            SpinnerColumn(style="bar.pulse"),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
+            TaskProgressColumn(),
+            TextColumn("•"),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+            console=console,
+        )
+        self._progress.start()
+        self._bytes_task = self._progress.add_task(self.description, total=max(self.total_bytes, 1))
+        if self.show_files:
+            self._files_task = self._progress.add_task(
+                f"Files (0/{self.total_files})",
+                total=max(self.total_files, 1),
+            )
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        if self._progress is not None:
+            self._progress.stop()
+
+    def set_downloaded_bytes(self, downloaded_bytes: int, *, total_bytes: int | None = None) -> None:
+        """Sync update used by SDK download progress callbacks."""
+
+        if total_bytes is not None and total_bytes > 0 and total_bytes != self.total_bytes:
+            self.total_bytes = total_bytes
+            if self._progress is not None and self._bytes_task is not None:
+                self._progress.update(self._bytes_task, total=max(total_bytes, 1))
+        self.downloaded_bytes = downloaded_bytes
+        if not self.enabled or self._progress is None or self._bytes_task is None:
+            return
+        self._progress.update(self._bytes_task, completed=min(downloaded_bytes, max(self.total_bytes, 1)))
+
+    def as_callback(self) -> DownloadProgressCallback | None:
+        if not self.enabled:
+            return None
+
+        def on_progress(event: FileDownloadProgress) -> None:
+            self.set_downloaded_bytes(event.downloaded_bytes, total_bytes=event.total_bytes)
+
+        return on_progress
+
+    async def bytes_completed(self, count: int) -> None:
+        async with self._lock:
+            self.downloaded_bytes += count
+            if not self.enabled or self._progress is None:
+                return
+            assert self._bytes_task is not None
+            self._progress.update(self._bytes_task, completed=self.downloaded_bytes)
+
+    async def file_completed(self, file_path: str, *, skipped: bool = False) -> None:
+        async with self._lock:
+            self.completed_files += 1
+            if skipped:
+                self.skipped_files += 1
+            if not self.enabled or self._progress is None:
+                return
+            if self.show_files:
+                assert self._files_task is not None
+                self._progress.update(
+                    self._files_task,
+                    completed=self.completed_files,
+                    description=f"Files ({self.completed_files}/{self.total_files})",
+                )
+                if skipped:
+                    self._progress.console.print(f"[dim]↷[/dim] {file_path} skipped (already exists)")
+                else:
+                    self._progress.console.print(f"[success]✓[/success] {file_path} complete")

--- a/src/together/lib/cli/components/upload_progress.py
+++ b/src/together/lib/cli/components/upload_progress.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import TypeVar, Callable, Awaitable
+import asyncio
+from typing import Any, TypeVar, Callable, Awaitable
 from pathlib import Path
-from contextlib import contextmanager
-from collections.abc import Iterator
+from collections.abc import Sequence
 
 from rich.progress import (
     TaskID,
@@ -17,89 +17,187 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
-from together.lib.resources.files import (
-    FileUploadProgress,
-    FileDownloadProgress,
-    UploadProgressCallback,
-    DownloadProgressCallback,
-)
+from together.lib.resources.files import FileUploadProgress, UploadProgressCallback
 from together.lib.cli.utils._console import console
 
 T = TypeVar("T")
 
 
-def _make_transfer_progress() -> Progress:
-    return Progress(
-        SpinnerColumn(style="bar.pulse"),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
-        TaskProgressColumn(),
-        TextColumn("•"),
-        DownloadColumn(),
-        TransferSpeedColumn(),
-        TimeRemainingColumn(),
-        console=console,
-    )
+def format_bytes(num: int) -> str:
+    size = float(num)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            if unit == "B":
+                return f"{int(size)} B"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} PB"
 
 
-@contextmanager
-def file_upload_progress(
-    file: Path,
-    *,
-    enabled: bool = True,
-    description: str | None = None,
-) -> Iterator[UploadProgressCallback | None]:
-    """Render rich progress for a file upload when enabled.
+class UploadProgressTracker:
+    """Shared Rich progress tracker for CLI file uploads."""
 
-    Yields a progress callback for upload managers, or ``None`` when disabled.
-    """
+    def __init__(
+        self,
+        *,
+        total_bytes: int,
+        total_parts: int,
+        total_files: int,
+        enabled: bool,
+        description: str = "Overall",
+        show_parts: bool = True,
+        show_files: bool = True,
+    ) -> None:
+        self.enabled = enabled
+        self.total_bytes = total_bytes
+        self.total_parts = total_parts
+        self.total_files = total_files
+        self.description = description
+        self.show_parts = show_parts
+        self.show_files = show_files
+        self.uploaded_bytes = 0
+        self.completed_parts = 0
+        self.completed_files = 0
+        self._lock = asyncio.Lock()
+        self._progress: Progress | None = None
+        self._bytes_task: TaskID | None = None
+        self._parts_task: TaskID | None = None
+        self._files_task: TaskID | None = None
 
-    if not enabled:
-        yield None
-        return
+    @classmethod
+    def for_single_file(
+        cls,
+        file: Path,
+        *,
+        enabled: bool,
+        description: str | None = None,
+    ) -> UploadProgressTracker:
+        return cls(
+            total_bytes=max(file.stat().st_size, 0),
+            total_parts=1,
+            total_files=1,
+            enabled=enabled,
+            description=description or f"Uploading {file.name}",
+            show_parts=False,
+            show_files=False,
+        )
 
-    total_bytes = max(file.stat().st_size, 1)
-    task_description = description or f"Uploading {file.name}"
+    @classmethod
+    def from_upload_plan(
+        cls,
+        local_files: Sequence[Any],
+        remote_files: list[dict[str, Any]],
+        *,
+        enabled: bool,
+    ) -> UploadProgressTracker:
+        local_by_path = {file.path: file for file in local_files}
+        total_bytes = 0
+        total_parts = 0
+        total_files = 0
+        for remote_file in remote_files:
+            if remote_file.get("skipUpload"):
+                continue
+            path = str(remote_file.get("path", ""))
+            local_file = local_by_path[path]
+            total_bytes += local_file.size
+            total_parts += len(local_file.parts)
+            total_files += 1
+        return cls(
+            total_bytes=total_bytes,
+            total_parts=total_parts,
+            total_files=total_files,
+            enabled=enabled,
+        )
 
-    with _make_transfer_progress() as progress:
-        task_id = progress.add_task(task_description, total=total_bytes)
+    def __enter__(self) -> UploadProgressTracker:
+        if not self.enabled:
+            return self
+        self._progress = Progress(
+            SpinnerColumn(style="bar.pulse"),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
+            TaskProgressColumn(),
+            TextColumn("•"),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+            console=console,
+        )
+        self._progress.start()
+        self._bytes_task = self._progress.add_task(self.description, total=max(self.total_bytes, 1))
+        if self.show_parts:
+            self._parts_task = self._progress.add_task(
+                f"Parts (0/{self.total_parts})",
+                total=max(self.total_parts, 1),
+            )
+        if self.show_files:
+            self._files_task = self._progress.add_task(
+                f"Files (0/{self.total_files})",
+                total=max(self.total_files, 1),
+            )
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        if self._progress is not None:
+            self._progress.stop()
+
+    def set_uploaded_bytes(self, uploaded_bytes: int) -> None:
+        """Sync update used by SDK upload progress callbacks."""
+
+        self.uploaded_bytes = uploaded_bytes
+        if not self.enabled or self._progress is None or self._bytes_task is None:
+            return
+        self._progress.update(self._bytes_task, completed=min(uploaded_bytes, max(self.total_bytes, 1)))
+
+    def as_callback(self) -> UploadProgressCallback | None:
+        if not self.enabled:
+            return None
 
         def on_progress(event: FileUploadProgress) -> None:
-            progress.update(task_id, completed=min(event.uploaded_bytes, total_bytes))
+            self.set_uploaded_bytes(event.uploaded_bytes)
 
-        yield on_progress
+        return on_progress
 
+    async def part_completed(
+        self,
+        *,
+        file_path: str,
+        part_number: int,
+        total_file_parts: int,
+        bytes_count: int,
+    ) -> None:
+        async with self._lock:
+            self.uploaded_bytes += bytes_count
+            self.completed_parts += 1
+            if not self.enabled or self._progress is None:
+                return
+            assert self._bytes_task is not None
+            self._progress.update(self._bytes_task, completed=self.uploaded_bytes)
+            if self.show_parts:
+                assert self._parts_task is not None
+                self._progress.update(
+                    self._parts_task,
+                    completed=self.completed_parts,
+                    description=f"Parts ({self.completed_parts}/{self.total_parts})",
+                )
+                self._progress.console.print(
+                    f"[success]✓[/success] {file_path} part {part_number}/{total_file_parts} "
+                    f"({format_bytes(bytes_count)})"
+                )
 
-@contextmanager
-def file_download_progress(
-    *,
-    enabled: bool = True,
-    description: str = "Downloading file",
-) -> Iterator[DownloadProgressCallback | None]:
-    """Render rich progress for a file download when enabled.
-
-    Task total is taken from the first progress event (metadata arrives mid-download).
-    """
-
-    if not enabled:
-        yield None
-        return
-
-    progress = _make_transfer_progress()
-    progress.start()
-    task_id: TaskID | None = None
-
-    def on_progress(event: FileDownloadProgress) -> None:
-        nonlocal task_id
-        if task_id is None:
-            task_id = progress.add_task(description, total=max(event.total_bytes, 1))
-        assert task_id is not None
-        progress.update(task_id, completed=min(event.downloaded_bytes, max(event.total_bytes, 1)))
-
-    try:
-        yield on_progress
-    finally:
-        progress.stop()
+    async def file_completed(self, file_path: str) -> None:
+        async with self._lock:
+            self.completed_files += 1
+            if not self.enabled or self._progress is None:
+                return
+            if self.show_files:
+                assert self._files_task is not None
+                self._progress.update(
+                    self._files_task,
+                    completed=self.completed_files,
+                    description=f"Files ({self.completed_files}/{self.total_files})",
+                )
+                self._progress.console.print(f"[success]✓[/success] {file_path} complete")
 
 
 async def upload_file_with_progress(
@@ -110,7 +208,7 @@ async def upload_file_with_progress(
     description: str | None = None,
     **upload_kwargs: object,
 ) -> T:
-    """Run an async file upload while optionally rendering rich progress."""
+    """Run an async file upload while optionally rendering shared Rich progress."""
 
-    with file_upload_progress(file, enabled=enabled, description=description) as progress_callback:
-        return await upload(file=file, progress_callback=progress_callback, **upload_kwargs)
+    with UploadProgressTracker.for_single_file(file, enabled=enabled, description=description) as tracker:
+        return await upload(file=file, progress_callback=tracker.as_callback(), **upload_kwargs)

--- a/src/together/lib/cli/components/upload_progress.py
+++ b/src/together/lib/cli/components/upload_progress.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import TypeVar, Callable, Awaitable
+from pathlib import Path
+from contextlib import contextmanager
+from collections.abc import Iterator
+
+from rich.progress import (
+    Progress,
+    BarColumn,
+    TextColumn,
+    SpinnerColumn,
+    DownloadColumn,
+    TaskProgressColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
+
+from together.lib.resources.files import FileUploadProgress, UploadProgressCallback
+from together.lib.cli.utils._console import console
+
+T = TypeVar("T")
+
+
+@contextmanager
+def file_upload_progress(
+    file: Path,
+    *,
+    enabled: bool = True,
+    description: str | None = None,
+) -> Iterator[UploadProgressCallback | None]:
+    """Render rich progress for a file upload when enabled.
+
+    Yields a progress callback for upload managers, or ``None`` when disabled.
+    """
+
+    if not enabled:
+        yield None
+        return
+
+    total_bytes = max(file.stat().st_size, 1)
+    task_description = description or f"Uploading {file.name}"
+
+    with Progress(
+        SpinnerColumn(style="bar.pulse"),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
+        TaskProgressColumn(),
+        TextColumn("•"),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeRemainingColumn(),
+        console=console,
+    ) as progress:
+        task_id = progress.add_task(task_description, total=total_bytes)
+
+        def on_progress(event: FileUploadProgress) -> None:
+            progress.update(task_id, completed=min(event.uploaded_bytes, total_bytes))
+
+        yield on_progress
+
+
+async def upload_file_with_progress(
+    upload: Callable[..., Awaitable[T]],
+    file: Path,
+    *,
+    enabled: bool = True,
+    description: str | None = None,
+    **upload_kwargs: object,
+) -> T:
+    """Run an async file upload while optionally rendering rich progress."""
+
+    with file_upload_progress(file, enabled=enabled, description=description) as progress_callback:
+        return await upload(file=file, progress_callback=progress_callback, **upload_kwargs)

--- a/src/together/lib/cli/components/upload_progress.py
+++ b/src/together/lib/cli/components/upload_progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pprint import pformat
 from typing import Any, TypeVar, Callable, Awaitable
 from pathlib import Path
 from collections.abc import Sequence
@@ -17,8 +18,10 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
+from together.lib import FileTypeError, check_file
 from together.lib.resources.files import FileUploadProgress, UploadProgressCallback
 from together.lib.cli.utils._console import console
+from together.lib.cli.components.check_progress import CheckProgressTracker, should_show_check_progress
 
 T = TypeVar("T")
 
@@ -206,9 +209,33 @@ async def upload_file_with_progress(
     *,
     enabled: bool = True,
     description: str | None = None,
+    check: bool = True,
+    purpose: str = "fine-tune",
     **upload_kwargs: object,
 ) -> T:
-    """Run an async file upload while optionally rendering shared Rich progress."""
+    """Run an async file upload while optionally rendering shared Rich progress.
+
+    Validation runs *before* the upload bar starts so a multi-GB ``check_file``
+    pass isn't shown as a stuck 0% upload.
+    """
+
+    if check:
+        with CheckProgressTracker(
+            file, enabled=should_show_check_progress(file, json_mode=not enabled)
+        ) as check_tracker:
+            report = check_file(
+                file,
+                purpose=purpose,
+                progress_callback=check_tracker.as_callback(),
+            )
+        if report["is_check_passed"] is False:
+            raise FileTypeError(f"Invalid file supplied, failed to upload. Report:\n{pformat(report)}")
 
     with UploadProgressTracker.for_single_file(file, enabled=enabled, description=description) as tracker:
-        return await upload(file=file, progress_callback=tracker.as_callback(), **upload_kwargs)
+        return await upload(
+            file=file,
+            progress_callback=tracker.as_callback(),
+            check=False,
+            purpose=purpose,
+            **upload_kwargs,
+        )

--- a/src/together/lib/cli/components/upload_progress.py
+++ b/src/together/lib/cli/components/upload_progress.py
@@ -113,7 +113,7 @@ class UploadProgressTracker:
         )
 
     def __enter__(self) -> UploadProgressTracker:
-        if not self.enabled:
+        if not self.enabled or not console.is_terminal:
             return self
         self._progress = Progress(
             SpinnerColumn(style="bar.pulse"),
@@ -125,6 +125,7 @@ class UploadProgressTracker:
             TransferSpeedColumn(),
             TimeRemainingColumn(),
             console=console,
+            transient=True,
         )
         self._progress.start()
         self._bytes_task = self._progress.add_task(self.description, total=max(self.total_bytes, 1))

--- a/src/together/lib/cli/components/upload_progress.py
+++ b/src/together/lib/cli/components/upload_progress.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from collections.abc import Iterator
 
 from rich.progress import (
+    TaskID,
     Progress,
     BarColumn,
     TextColumn,
@@ -16,10 +17,29 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
-from together.lib.resources.files import FileUploadProgress, UploadProgressCallback
+from together.lib.resources.files import (
+    FileUploadProgress,
+    FileDownloadProgress,
+    UploadProgressCallback,
+    DownloadProgressCallback,
+)
 from together.lib.cli.utils._console import console
 
 T = TypeVar("T")
+
+
+def _make_transfer_progress() -> Progress:
+    return Progress(
+        SpinnerColumn(style="bar.pulse"),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
+        TaskProgressColumn(),
+        TextColumn("•"),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeRemainingColumn(),
+        console=console,
+    )
 
 
 @contextmanager
@@ -41,23 +61,45 @@ def file_upload_progress(
     total_bytes = max(file.stat().st_size, 1)
     task_description = description or f"Uploading {file.name}"
 
-    with Progress(
-        SpinnerColumn(style="bar.pulse"),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(bar_width=40, style="bar.complete", complete_style="bar.finished"),
-        TaskProgressColumn(),
-        TextColumn("•"),
-        DownloadColumn(),
-        TransferSpeedColumn(),
-        TimeRemainingColumn(),
-        console=console,
-    ) as progress:
+    with _make_transfer_progress() as progress:
         task_id = progress.add_task(task_description, total=total_bytes)
 
         def on_progress(event: FileUploadProgress) -> None:
             progress.update(task_id, completed=min(event.uploaded_bytes, total_bytes))
 
         yield on_progress
+
+
+@contextmanager
+def file_download_progress(
+    *,
+    enabled: bool = True,
+    description: str = "Downloading file",
+) -> Iterator[DownloadProgressCallback | None]:
+    """Render rich progress for a file download when enabled.
+
+    Task total is taken from the first progress event (metadata arrives mid-download).
+    """
+
+    if not enabled:
+        yield None
+        return
+
+    progress = _make_transfer_progress()
+    progress.start()
+    task_id: TaskID | None = None
+
+    def on_progress(event: FileDownloadProgress) -> None:
+        nonlocal task_id
+        if task_id is None:
+            task_id = progress.add_task(description, total=max(event.total_bytes, 1))
+        assert task_id is not None
+        progress.update(task_id, completed=min(event.downloaded_bytes, max(event.total_bytes, 1)))
+
+    try:
+        yield on_progress
+    finally:
+        progress.stop()
 
 
 async def upload_file_with_progress(

--- a/src/together/lib/constants.py
+++ b/src/together/lib/constants.py
@@ -76,5 +76,5 @@ REQUIRED_COLUMNS_MESSAGE = ["role"]
 POSSIBLE_ROLES_CONVERSATION = ["system", "user", "assistant", "tool"]
 
 # DO NOT USE THIS
-# Pull this from the environment variable TOGETHER_DISABLE_TQDM so cli can disable tqdm if needed
+# Deprecated compatibility export. Progress presentation is handled by CLI callers.
 DISABLE_TQDM = False

--- a/src/together/lib/resources/__init__.py
+++ b/src/together/lib/resources/__init__.py
@@ -1,10 +1,12 @@
 from .files import (
     UploadManager,
     DownloadManager,
-    FileUploadProgress,
     AsyncUploadManager,
+    FileUploadProgress,
     AsyncDownloadManager,
+    FileDownloadProgress,
     UploadProgressCallback,
+    DownloadProgressCallback,
 )
 
 __all__ = [
@@ -13,5 +15,7 @@ __all__ = [
     "UploadManager",
     "AsyncUploadManager",
     "FileUploadProgress",
+    "FileDownloadProgress",
     "UploadProgressCallback",
+    "DownloadProgressCallback",
 ]

--- a/src/together/lib/resources/__init__.py
+++ b/src/together/lib/resources/__init__.py
@@ -1,8 +1,10 @@
 from .files import (
     UploadManager,
     DownloadManager,
+    FileUploadProgress,
     AsyncUploadManager,
     AsyncDownloadManager,
+    UploadProgressCallback,
 )
 
 __all__ = [
@@ -10,4 +12,6 @@ __all__ = [
     "AsyncDownloadManager",
     "UploadManager",
     "AsyncUploadManager",
+    "FileUploadProgress",
+    "UploadProgressCallback",
 ]

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -49,6 +49,9 @@ log: logging.Logger = logging.getLogger(__name__)
 
 UPLOAD_PROGRESS_CHUNK_SIZE = 1024 * 1024
 _SAFE_FILE_ID_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+# 307/308 preserve method + body. S3 uses 307 for cross-region/new buckets; GCS resumable too.
+_UPLOAD_REPLAY_REDIRECT_STATUSES = frozenset({307, 308})
+_MAX_UPLOAD_REDIRECTS = 20
 
 
 def _validate_upload_redirect_url(redirect_url: str) -> str:
@@ -163,6 +166,111 @@ async def _aiter_file_upload_chunks(
         chunk_size=chunk_size,
     ):
         yield chunk
+
+
+def _response_body_text(response: httpx.Response) -> str:
+    try:
+        return response.content.decode()
+    except Exception:
+        return ""
+
+
+def _upload_redirect_url(response: httpx.Response, current_url: str) -> str:
+    location = response.headers.get("Location")
+    if not location:
+        raise APIStatusError(
+            f"Error during file upload: redirect {response.status_code} missing Location, headers: {response.headers}",
+            response=response,
+            body=_response_body_text(response),
+        )
+
+    next_url = str(httpx.URL(current_url).join(location))
+    try:
+        return _validate_upload_redirect_url(next_url)
+    except ValueError as e:
+        raise APIStatusError(
+            str(e),
+            response=response,
+            body=_response_body_text(response),
+        ) from e
+
+
+def _put_file_content(
+    http_client: httpx.Client,
+    url: str,
+    file: Path,
+    *,
+    file_size: int,
+    progress_callback: UploadProgressCallback | None = None,
+) -> httpx.Response:
+    """PUT a streaming file body without httpx replaying a consumed generator.
+
+    ``self._client._client`` is built with ``follow_redirects=True``. A one-shot
+    iterator cannot be replayed, so a 307/308 (or any retry after the first byte)
+    would raise ``StreamConsumed``. Disable auto-follow and re-PUT with a fresh
+    iterator after validating ``Location``.
+    """
+
+    hops = 0
+    while True:
+        response = http_client.put(
+            url=url,
+            content=_iter_file_upload_chunks(
+                file,
+                total_bytes=file_size,
+                progress_callback=progress_callback,
+            ),
+            headers={"Content-Length": str(file_size)},
+            follow_redirects=False,
+        )
+        if response.status_code not in _UPLOAD_REPLAY_REDIRECT_STATUSES:
+            return response
+        hops += 1
+        if hops > _MAX_UPLOAD_REDIRECTS:
+            raise APIStatusError(
+                f"Error during file upload: exceeded {_MAX_UPLOAD_REDIRECTS} redirects, headers: {response.headers}",
+                response=response,
+                body=_response_body_text(response),
+            )
+        url = _upload_redirect_url(response, url)
+        log.debug("Upload redirected to %s", url)
+        response.close()
+
+
+async def _aput_file_content(
+    http_client: httpx.AsyncClient,
+    url: str,
+    file: Path,
+    *,
+    file_size: int,
+    progress_callback: UploadProgressCallback | None = None,
+) -> httpx.Response:
+    """Async counterpart of ``_put_file_content``."""
+
+    hops = 0
+    while True:
+        response = await http_client.put(
+            url=url,
+            content=_aiter_file_upload_chunks(
+                file,
+                total_bytes=file_size,
+                progress_callback=progress_callback,
+            ),
+            headers={"Content-Length": str(file_size)},
+            follow_redirects=False,
+        )
+        if response.status_code not in _UPLOAD_REPLAY_REDIRECT_STATUSES:
+            return response
+        hops += 1
+        if hops > _MAX_UPLOAD_REDIRECTS:
+            raise APIStatusError(
+                f"Error during file upload: exceeded {_MAX_UPLOAD_REDIRECTS} redirects, headers: {response.headers}",
+                response=response,
+                body=_response_body_text(response),
+            )
+        url = _upload_redirect_url(response, url)
+        log.debug("Upload redirected to %s", url)
+        await response.aclose()
 
 
 def chmod_and_replace(src: Path, dst: Path) -> None:
@@ -681,14 +789,12 @@ class UploadManager(SyncAPIResource):
         file_size = os.stat(file.as_posix()).st_size
 
         assert redirect_url is not None
-        callback_response = self._client._client.put(
-            url=redirect_url,
-            content=_iter_file_upload_chunks(
-                file,
-                total_bytes=file_size,
-                progress_callback=progress_callback,
-            ),
-            headers={"Content-Length": str(file_size)},
+        callback_response = _put_file_content(
+            self._client._client,
+            redirect_url,
+            file,
+            file_size=file_size,
+            progress_callback=progress_callback,
         )
         log.debug(
             'HTTP Response: %s %s "%i %s" %s',
@@ -1108,14 +1214,12 @@ class AsyncUploadManager(AsyncAPIResource):
         file_size = os.stat(file.as_posix()).st_size
 
         assert redirect_url is not None
-        callback_response = await self._client._client.put(
-            url=redirect_url,
-            content=_aiter_file_upload_chunks(
-                file,
-                total_bytes=file_size,
-                progress_callback=progress_callback,
-            ),
-            headers={"Content-Length": str(file_size)},
+        callback_response = await _aput_file_content(
+            self._client._client,
+            redirect_url,
+            file,
+            file_size=file_size,
+            progress_callback=progress_callback,
         )
         log.debug(
             'HTTP Response: %s %s "%i %s" %s',

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -48,7 +48,8 @@ from ..._exceptions import APIStatusError, APIConnectionError, AuthenticationErr
 log: logging.Logger = logging.getLogger(__name__)
 
 UPLOAD_PROGRESS_CHUNK_SIZE = 1024 * 1024
-_SAFE_FILE_ID_RE = re.compile(r"^file-[A-Za-z0-9-]+$")
+# Path-segment safe. Prefix and punctuation are server-controlled (not always ``file-``).
+_SAFE_FILE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 # Replay PUT+body. 307/308 are spec-correct (S3/GCS); 301/302/303 match prior httpx auto-follow.
 _UPLOAD_REPLAY_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 _MAX_UPLOAD_REDIRECTS = 20
@@ -60,10 +61,70 @@ def _env_flag_enabled(name: str) -> bool:
 
 
 def _allow_http_upload_redirects(client: Any) -> bool:
+    """Whether PUT *redirect hops* may use http / non-public literals.
+
+    API-issued URLs (presigned ``Location``, multipart part URLs) are validated
+    separately via ``_validate_upload_server_url`` and already allow those.
+    Set ``TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS=1`` to also permit them on
+    subsequent 3xx ``Location`` hops, or use an ``http`` client ``base_url``.
+    """
+
     if _env_flag_enabled(_INSECURE_UPLOAD_REDIRECTS_ENV):
         return True
     base_url = getattr(client, "base_url", None)
     return getattr(base_url, "scheme", None) == "http"
+
+
+def _parse_ipv4_component(part: str) -> int | None:
+    """Parse one inet_aton IPv4 component (decimal, octal, or hex)."""
+
+    if not part:
+        return None
+    try:
+        if part.startswith("0x"):
+            return int(part, 16) if len(part) > 2 else None
+        if len(part) > 1 and part[0] == "0" and all(c in "01234567" for c in part):
+            return int(part, 8)
+        if part.isdecimal():
+            return int(part, 10)
+    except ValueError:
+        return None
+    return None
+
+
+def _parse_posix_ipv4(hostname: str) -> ipaddress.IPv4Address | None:
+    """Parse IPv4 the way POSIX ``inet_aton`` / getaddrinfo do.
+
+    ``ipaddress.ip_address`` rejects abbreviated (``127.1``), octal
+    (``0177.0.0.1``), hex-dotted, and dword forms that still resolve to
+    127.0.0.1.
+    """
+
+    parts = hostname.split(".")
+    if not parts or len(parts) > 4:
+        return None
+    nums: list[int] = []
+    for part in parts:
+        value = _parse_ipv4_component(part)
+        if value is None:
+            return None
+        nums.append(value)
+    try:
+        if len(nums) == 1:
+            return ipaddress.IPv4Address(nums[0])
+        if len(nums) == 2:
+            if nums[0] > 0xFF or nums[1] > 0xFFFFFF:
+                return None
+            return ipaddress.IPv4Address((nums[0] << 24) | nums[1])
+        if len(nums) == 3:
+            if nums[0] > 0xFF or nums[1] > 0xFF or nums[2] > 0xFFFF:
+                return None
+            return ipaddress.IPv4Address((nums[0] << 24) | (nums[1] << 16) | nums[2])
+        if any(n > 0xFF for n in nums):
+            return None
+        return ipaddress.IPv4Address((nums[0] << 24) | (nums[1] << 16) | (nums[2] << 8) | nums[3])
+    except (ValueError, ipaddress.AddressValueError):
+        return None
 
 
 def _parse_hostname_ip(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
@@ -71,16 +132,7 @@ def _parse_hostname_ip(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6A
         return ipaddress.ip_address(hostname)
     except ValueError:
         pass
-
-    # POSIX resolvers accept dword IPv4 forms that ``ipaddress.ip_address(str)`` rejects.
-    try:
-        if hostname.startswith(("0x", "0X")):
-            return ipaddress.IPv4Address(int(hostname, 16))
-        if hostname.isdecimal():
-            return ipaddress.IPv4Address(int(hostname, 10))
-    except ValueError:
-        return None
-    return None
+    return _parse_posix_ipv4(hostname.lower())
 
 
 def _ip_is_non_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
@@ -89,19 +141,27 @@ def _ip_is_non_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool
     return not candidate.is_global
 
 
-def _validate_upload_redirect_url(redirect_url: str, *, allow_http: bool = False) -> str:
+def _validate_upload_redirect_url(
+    redirect_url: str,
+    *,
+    allow_http: bool = False,
+    allow_non_public: bool = False,
+) -> str:
     """Best-effort URL-layer filter for upload PUT targets.
 
     This is not a complete SSRF defense: we do not resolve DNS, so a name like
     ``127.0.0.1.nip.io`` still passes. We do reject non-public dotted-quad / IPv6
-    literals, IPv4-mapped loopback (``::ffff:127.0.0.1``), and dword decimal/hex
-    IPv4 (``2130706433``, ``0x7f000001``) that getaddrinfo will treat as 127.0.0.1.
+    literals, IPv4-mapped loopback (``::ffff:127.0.0.1``), dword decimal/hex
+    IPv4 (``2130706433``, ``0x7f000001``), abbreviated (``127.1``), and octal
+    (``0177.0.0.1``) forms that getaddrinfo will treat as 127.0.0.1.
 
-    HTTPS is required unless ``allow_http`` is set — either the client's
-    ``base_url`` is ``http`` (local/on-prem stacks) or
-    ``TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS`` is enabled. When ``allow_http``
-    is set, localhost and non-public literals are also allowed so MinIO /
-    LocalStack endpoints like ``http://127.0.0.1:9000/...`` work.
+    HTTPS is required unless ``allow_http`` is set. Non-public / localhost
+    literals are rejected unless ``allow_http`` or ``allow_non_public`` is set.
+
+    For *redirect hops*, ``allow_http`` is True when the client's ``base_url``
+    is ``http`` or ``TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS`` is enabled.
+    API-issued URLs use ``_validate_upload_server_url`` instead, which allows
+    private http(s) storage (MinIO, internal S3) without that env var.
     """
 
     parsed = urlparse(redirect_url)
@@ -118,7 +178,7 @@ def _validate_upload_redirect_url(redirect_url: str, *, allow_http: bool = False
     if lowered == "metadata.google.internal":
         raise ValueError(f"Refusing upload redirect to local host: {redirect_url!r}")
 
-    if not allow_http:
+    if not allow_http and not allow_non_public:
         if lowered == "localhost" or lowered.endswith(".localhost"):
             raise ValueError(f"Refusing upload redirect to local host: {redirect_url!r}")
 
@@ -127,6 +187,16 @@ def _validate_upload_redirect_url(redirect_url: str, *, allow_http: bool = False
             raise ValueError(f"Refusing upload redirect to non-public address: {redirect_url!r}")
 
     return redirect_url
+
+
+def _validate_upload_server_url(url: str) -> str:
+    """Validate an API-issued upload URL (presigned Location or multipart part URL).
+
+    Trusts the Together API: private/loopback literals and plain http are
+    allowed so on-prem MinIO / internal S3 work. Redirect hops stay strict.
+    """
+
+    return _validate_upload_redirect_url(url, allow_http=True, allow_non_public=True)
 
 
 def _validate_upload_file_id(file_id: str) -> str:
@@ -193,43 +263,43 @@ def _notify_download_progress(
         progress_callback(FileDownloadProgress(downloaded_bytes=downloaded_bytes, total_bytes=total_bytes))
 
 
-def _iter_file_upload_chunks(
-    file: Path,
+def _iter_open_file_upload_chunks(
+    file_handle: IO[bytes],
     *,
     total_bytes: int,
     progress_callback: UploadProgressCallback | None = None,
     chunk_size: int = UPLOAD_PROGRESS_CHUNK_SIZE,
 ) -> Iterator[bytes]:
-    """Yield file chunks while reporting upload progress to the caller."""
+    """Yield at most ``total_bytes`` from an already-open handle (matches Content-Length)."""
 
     uploaded_bytes = 0
+    remaining = total_bytes
     _notify_upload_progress(progress_callback, uploaded_bytes, total_bytes)
+    while remaining > 0:
+        chunk = file_handle.read(min(chunk_size, remaining))
+        if not chunk:
+            raise OSError("File was truncated during upload")
+        remaining -= len(chunk)
+        yield chunk
+        uploaded_bytes += len(chunk)
+        _notify_upload_progress(progress_callback, uploaded_bytes, total_bytes)
 
-    with file.open("rb") as file_handle:
-        while True:
-            chunk = file_handle.read(chunk_size)
-            if not chunk:
-                break
-            yield chunk
-            uploaded_bytes += len(chunk)
-            _notify_upload_progress(progress_callback, uploaded_bytes, total_bytes)
 
-
-async def _aiter_file_upload_chunks(
-    file: Path,
+async def _aiter_open_file_upload_chunks(
+    file_handle: IO[bytes],
     *,
     total_bytes: int,
     progress_callback: UploadProgressCallback | None = None,
     chunk_size: int = UPLOAD_PROGRESS_CHUNK_SIZE,
 ) -> AsyncIterator[bytes]:
-    """Async chunk iterator for ``httpx.AsyncClient``.
+    """Async counterpart of ``_iter_open_file_upload_chunks``.
 
     Sync iterators are wrapped as ``SyncByteStream``, which AsyncClient rejects with
     ``Attempted to send an sync request with an AsyncClient instance.``
     """
 
-    for chunk in _iter_file_upload_chunks(
-        file,
+    for chunk in _iter_open_file_upload_chunks(
+        file_handle,
         total_bytes=total_bytes,
         progress_callback=progress_callback,
         chunk_size=chunk_size,
@@ -283,17 +353,22 @@ def _put_file_content(
 
     hops = 0
     progress_callback = _monotonic_upload_progress(progress_callback)
+    _ = file_size  # each hop fstats the fd; caller size can be stale
     while True:
-        response = http_client.put(
-            url=url,
-            content=_iter_file_upload_chunks(
-                file,
-                total_bytes=file_size,
-                progress_callback=progress_callback,
-            ),
-            headers={"Content-Length": str(file_size)},
-            follow_redirects=False,
-        )
+        # Open + fstat the same fd so Content-Length matches the streamed body even
+        # if the file is appended/truncated between hops (or vs. the caller's stat).
+        with file.open("rb") as file_handle:
+            put_size = os.fstat(file_handle.fileno()).st_size
+            response = http_client.put(
+                url=url,
+                content=_iter_open_file_upload_chunks(
+                    file_handle,
+                    total_bytes=put_size,
+                    progress_callback=progress_callback,
+                ),
+                headers={"Content-Length": str(put_size)},
+                follow_redirects=False,
+            )
         if response.status_code not in _UPLOAD_REPLAY_REDIRECT_STATUSES:
             return response
         hops += 1
@@ -321,17 +396,20 @@ async def _aput_file_content(
 
     hops = 0
     progress_callback = _monotonic_upload_progress(progress_callback)
+    _ = file_size  # each hop fstats the fd; caller size can be stale
     while True:
-        response = await http_client.put(
-            url=url,
-            content=_aiter_file_upload_chunks(
-                file,
-                total_bytes=file_size,
-                progress_callback=progress_callback,
-            ),
-            headers={"Content-Length": str(file_size)},
-            follow_redirects=False,
-        )
+        with file.open("rb") as file_handle:
+            put_size = os.fstat(file_handle.fileno()).st_size
+            response = await http_client.put(
+                url=url,
+                content=_aiter_open_file_upload_chunks(
+                    file_handle,
+                    total_bytes=put_size,
+                    progress_callback=progress_callback,
+                ),
+                headers={"Content-Length": str(put_size)},
+                follow_redirects=False,
+            )
         if response.status_code not in _UPLOAD_REPLAY_REDIRECT_STATUSES:
             return response
         hops += 1
@@ -798,7 +876,7 @@ class UploadManager(SyncAPIResource):
 
         try:
             return (
-                _validate_upload_redirect_url(redirect_url, allow_http=_allow_http_upload_redirects(self._client)),
+                _validate_upload_server_url(redirect_url),
                 _validate_upload_file_id(file_id),
             )
         except ValueError as e:
@@ -930,6 +1008,12 @@ class MultipartUploadManager(SyncAPIResource):
 
         try:
             upload_info = self._initiate_upload(url, file, checksum, file_size, num_parts, purpose, file_type)
+            upload_id = upload_info.get("upload_id")
+            file_id = upload_info.get("file_id")
+            if not upload_id or not file_id:
+                raise ValueError("Missing upload_id or file_id from initiate response")
+            file_id = _validate_upload_file_id(str(file_id))
+            upload_info["file_id"] = file_id
 
             completed_parts = self._upload_parts_concurrent(
                 file,
@@ -937,11 +1021,6 @@ class MultipartUploadManager(SyncAPIResource):
                 part_size,
                 progress_callback=progress_callback,
             )
-
-            upload_id = upload_info.get("upload_id")
-            file_id = upload_info.get("file_id")
-            if not upload_id or not file_id:
-                raise ValueError("Missing upload_id or file_id from initiate response")
 
             return self._complete_upload(url, upload_id, file_id, completed_parts)
 
@@ -1085,9 +1164,7 @@ class MultipartUploadManager(SyncAPIResource):
         upload_url = part_info.get("URL", part_info.get("UploadURL"))
         if not upload_url:
             raise ValueError("Missing upload URL in part info")
-        upload_url = _validate_upload_redirect_url(
-            str(upload_url), allow_http=_allow_http_upload_redirects(self._client)
-        )
+        upload_url = _validate_upload_server_url(str(upload_url))
 
         part_headers = part_info.get("Headers", {})
 
@@ -1228,7 +1305,7 @@ class AsyncUploadManager(AsyncAPIResource):
 
         try:
             return (
-                _validate_upload_redirect_url(redirect_url, allow_http=_allow_http_upload_redirects(self._client)),
+                _validate_upload_server_url(redirect_url),
                 _validate_upload_file_id(file_id),
             )
         except ValueError as e:
@@ -1361,6 +1438,12 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
 
         try:
             upload_info = await self._initiate_upload(url, file, checksum, file_size, num_parts, purpose, file_type)
+            upload_id = upload_info.get("upload_id")
+            file_id = upload_info.get("file_id")
+            if not upload_id or not file_id:
+                raise ValueError("Missing upload_id or file_id from initiate response")
+            file_id = _validate_upload_file_id(str(file_id))
+            upload_info["file_id"] = file_id
 
             completed_parts = await self._upload_parts_concurrent(
                 file,
@@ -1368,11 +1451,6 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
                 part_size,
                 progress_callback=progress_callback,
             )
-
-            upload_id = upload_info.get("upload_id")
-            file_id = upload_info.get("file_id")
-            if not upload_id or not file_id:
-                raise ValueError("Missing upload_id or file_id from initiate response")
 
             return await self._complete_upload(url, upload_id, file_id, completed_parts)
 
@@ -1515,9 +1593,7 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
         upload_url = part_info.get("URL", part_info.get("UploadURL"))
         if not upload_url:
             raise ValueError("Missing upload URL in part info")
-        upload_url = _validate_upload_redirect_url(
-            str(upload_url), allow_http=_allow_http_upload_redirects(self._client)
-        )
+        upload_url = _validate_upload_server_url(str(upload_url))
 
         part_headers = part_info.get("Headers", {})
 

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -52,13 +52,60 @@ _SAFE_FILE_ID_RE = re.compile(r"^file-[A-Za-z0-9-]+$")
 # 307/308 preserve method + body. S3 uses 307 for cross-region/new buckets; GCS resumable too.
 _UPLOAD_REPLAY_REDIRECT_STATUSES = frozenset({307, 308})
 _MAX_UPLOAD_REDIRECTS = 20
+_INSECURE_UPLOAD_REDIRECTS_ENV = "TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS"
 
 
-def _validate_upload_redirect_url(redirect_url: str) -> str:
-    """Reject unsafe upload redirect targets before issuing the PUT."""
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _allow_http_upload_redirects(client: Any) -> bool:
+    if _env_flag_enabled(_INSECURE_UPLOAD_REDIRECTS_ENV):
+        return True
+    base_url = getattr(client, "base_url", None)
+    return getattr(base_url, "scheme", None) == "http"
+
+
+def _parse_hostname_ip(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    try:
+        return ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+
+    # POSIX resolvers accept dword IPv4 forms that ``ipaddress.ip_address(str)`` rejects.
+    try:
+        if hostname.startswith(("0x", "0X")):
+            return ipaddress.IPv4Address(int(hostname, 16))
+        if hostname.isdecimal():
+            return ipaddress.IPv4Address(int(hostname, 10))
+    except ValueError:
+        return None
+    return None
+
+
+def _ip_is_non_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    mapped = ip.ipv4_mapped if isinstance(ip, ipaddress.IPv6Address) else None
+    candidate: ipaddress.IPv4Address | ipaddress.IPv6Address = mapped if mapped is not None else ip
+    return not candidate.is_global
+
+
+def _validate_upload_redirect_url(redirect_url: str, *, allow_http: bool = False) -> str:
+    """Best-effort URL-layer filter for upload PUT targets.
+
+    This is not a complete SSRF defense: we do not resolve DNS, so a name like
+    ``127.0.0.1.nip.io`` still passes. We do reject non-public dotted-quad / IPv6
+    literals, IPv4-mapped loopback (``::ffff:127.0.0.1``), and dword decimal/hex
+    IPv4 (``2130706433``, ``0x7f000001``) that getaddrinfo will treat as 127.0.0.1.
+
+    HTTPS is required unless ``allow_http`` is set — either the client's
+    ``base_url`` is ``http`` (local/on-prem stacks) or
+    ``TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS`` is enabled.
+    """
 
     parsed = urlparse(redirect_url)
-    if parsed.scheme != "https":
+    if parsed.scheme == "https" or (parsed.scheme == "http" and allow_http):
+        pass
+    else:
         raise ValueError(f"Refusing non-HTTPS upload redirect URL: {redirect_url!r}")
 
     hostname = parsed.hostname
@@ -69,12 +116,8 @@ def _validate_upload_redirect_url(redirect_url: str) -> str:
     if lowered in {"localhost", "metadata.google.internal"} or lowered.endswith(".localhost"):
         raise ValueError(f"Refusing upload redirect to local host: {redirect_url!r}")
 
-    try:
-        ip = ipaddress.ip_address(hostname)
-    except ValueError:
-        ip = None
-
-    if ip is not None and not ip.is_global:
+    ip = _parse_hostname_ip(hostname)
+    if ip is not None and _ip_is_non_public(ip):
         raise ValueError(f"Refusing upload redirect to non-public address: {redirect_url!r}")
 
     return redirect_url
@@ -175,7 +218,7 @@ def _response_body_text(response: httpx.Response) -> str:
         return ""
 
 
-def _upload_redirect_url(response: httpx.Response, current_url: str) -> str:
+def _upload_redirect_url(response: httpx.Response, current_url: str, *, allow_http: bool = False) -> str:
     location = response.headers.get("Location")
     if not location:
         raise APIStatusError(
@@ -186,7 +229,7 @@ def _upload_redirect_url(response: httpx.Response, current_url: str) -> str:
 
     next_url = str(httpx.URL(current_url).join(location))
     try:
-        return _validate_upload_redirect_url(next_url)
+        return _validate_upload_redirect_url(next_url, allow_http=allow_http)
     except ValueError as e:
         raise APIStatusError(
             str(e),
@@ -202,6 +245,7 @@ def _put_file_content(
     *,
     file_size: int,
     progress_callback: UploadProgressCallback | None = None,
+    allow_http: bool = False,
 ) -> httpx.Response:
     """PUT a streaming file body without httpx replaying a consumed generator.
 
@@ -232,7 +276,7 @@ def _put_file_content(
                 response=response,
                 body=_response_body_text(response),
             )
-        url = _upload_redirect_url(response, url)
+        url = _upload_redirect_url(response, url, allow_http=allow_http)
         log.debug("Upload redirected to %s", url)
         response.close()
 
@@ -244,6 +288,7 @@ async def _aput_file_content(
     *,
     file_size: int,
     progress_callback: UploadProgressCallback | None = None,
+    allow_http: bool = False,
 ) -> httpx.Response:
     """Async counterpart of ``_put_file_content``."""
 
@@ -268,7 +313,7 @@ async def _aput_file_content(
                 response=response,
                 body=_response_body_text(response),
             )
-        url = _upload_redirect_url(response, url)
+        url = _upload_redirect_url(response, url, allow_http=allow_http)
         log.debug("Upload redirected to %s", url)
         await response.aclose()
 
@@ -724,7 +769,10 @@ class UploadManager(SyncAPIResource):
             )
 
         try:
-            return _validate_upload_redirect_url(redirect_url), _validate_upload_file_id(file_id)
+            return (
+                _validate_upload_redirect_url(redirect_url, allow_http=_allow_http_upload_redirects(self._client)),
+                _validate_upload_file_id(file_id),
+            )
         except ValueError as e:
             raise APIStatusError(
                 str(e),
@@ -795,6 +843,7 @@ class UploadManager(SyncAPIResource):
             file,
             file_size=file_size,
             progress_callback=progress_callback,
+            allow_http=_allow_http_upload_redirects(self._client),
         )
         log.debug(
             'HTTP Response: %s %s "%i %s" %s',
@@ -1008,7 +1057,9 @@ class MultipartUploadManager(SyncAPIResource):
         upload_url = part_info.get("URL", part_info.get("UploadURL"))
         if not upload_url:
             raise ValueError("Missing upload URL in part info")
-        upload_url = _validate_upload_redirect_url(str(upload_url))
+        upload_url = _validate_upload_redirect_url(
+            str(upload_url), allow_http=_allow_http_upload_redirects(self._client)
+        )
 
         part_headers = part_info.get("Headers", {})
 
@@ -1148,7 +1199,10 @@ class AsyncUploadManager(AsyncAPIResource):
                 )
 
         try:
-            return _validate_upload_redirect_url(redirect_url), _validate_upload_file_id(file_id)
+            return (
+                _validate_upload_redirect_url(redirect_url, allow_http=_allow_http_upload_redirects(self._client)),
+                _validate_upload_file_id(file_id),
+            )
         except ValueError as e:
             raise APIStatusError(
                 str(e),
@@ -1220,6 +1274,7 @@ class AsyncUploadManager(AsyncAPIResource):
             file,
             file_size=file_size,
             progress_callback=progress_callback,
+            allow_http=_allow_http_upload_redirects(self._client),
         )
         log.debug(
             'HTTP Response: %s %s "%i %s" %s',
@@ -1432,7 +1487,9 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
         upload_url = part_info.get("URL", part_info.get("UploadURL"))
         if not upload_url:
             raise ValueError("Missing upload URL in part info")
-        upload_url = _validate_upload_redirect_url(str(upload_url))
+        upload_url = _validate_upload_redirect_url(
+            str(upload_url), allow_http=_allow_http_upload_redirects(self._client)
+        )
 
         part_headers = part_info.get("Headers", {})
 

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -49,8 +49,8 @@ log: logging.Logger = logging.getLogger(__name__)
 
 UPLOAD_PROGRESS_CHUNK_SIZE = 1024 * 1024
 _SAFE_FILE_ID_RE = re.compile(r"^file-[A-Za-z0-9-]+$")
-# 307/308 preserve method + body. S3 uses 307 for cross-region/new buckets; GCS resumable too.
-_UPLOAD_REPLAY_REDIRECT_STATUSES = frozenset({307, 308})
+# Replay PUT+body. 307/308 are spec-correct (S3/GCS); 301/302/303 match prior httpx auto-follow.
+_UPLOAD_REPLAY_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 _MAX_UPLOAD_REDIRECTS = 20
 _INSECURE_UPLOAD_REDIRECTS_ENV = "TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS"
 
@@ -99,7 +99,9 @@ def _validate_upload_redirect_url(redirect_url: str, *, allow_http: bool = False
 
     HTTPS is required unless ``allow_http`` is set — either the client's
     ``base_url`` is ``http`` (local/on-prem stacks) or
-    ``TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS`` is enabled.
+    ``TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS`` is enabled. When ``allow_http``
+    is set, localhost and non-public literals are also allowed so MinIO /
+    LocalStack endpoints like ``http://127.0.0.1:9000/...`` work.
     """
 
     parsed = urlparse(redirect_url)
@@ -113,12 +115,16 @@ def _validate_upload_redirect_url(redirect_url: str, *, allow_http: bool = False
         raise ValueError(f"Upload redirect URL is missing a hostname: {redirect_url!r}")
 
     lowered = hostname.lower()
-    if lowered in {"localhost", "metadata.google.internal"} or lowered.endswith(".localhost"):
+    if lowered == "metadata.google.internal":
         raise ValueError(f"Refusing upload redirect to local host: {redirect_url!r}")
 
-    ip = _parse_hostname_ip(hostname)
-    if ip is not None and _ip_is_non_public(ip):
-        raise ValueError(f"Refusing upload redirect to non-public address: {redirect_url!r}")
+    if not allow_http:
+        if lowered == "localhost" or lowered.endswith(".localhost"):
+            raise ValueError(f"Refusing upload redirect to local host: {redirect_url!r}")
+
+        ip = _parse_hostname_ip(hostname)
+        if ip is not None and _ip_is_non_public(ip):
+            raise ValueError(f"Refusing upload redirect to non-public address: {redirect_url!r}")
 
     return redirect_url
 
@@ -158,6 +164,26 @@ def _notify_upload_progress(
         progress_callback(FileUploadProgress(uploaded_bytes=uploaded_bytes, total_bytes=total_bytes))
 
 
+def _monotonic_upload_progress(
+    progress_callback: UploadProgressCallback | None,
+) -> UploadProgressCallback | None:
+    """Ignore progress that rewinds, e.g. a fresh iterator after a redirect replay."""
+
+    if progress_callback is None:
+        return None
+
+    last_uploaded = 0
+
+    def on_progress(event: FileUploadProgress) -> None:
+        nonlocal last_uploaded
+        if event.uploaded_bytes < last_uploaded:
+            return
+        last_uploaded = event.uploaded_bytes
+        progress_callback(event)
+
+    return on_progress
+
+
 def _notify_download_progress(
     progress_callback: DownloadProgressCallback | None,
     downloaded_bytes: int,
@@ -184,9 +210,9 @@ def _iter_file_upload_chunks(
             chunk = file_handle.read(chunk_size)
             if not chunk:
                 break
+            yield chunk
             uploaded_bytes += len(chunk)
             _notify_upload_progress(progress_callback, uploaded_bytes, total_bytes)
-            yield chunk
 
 
 async def _aiter_file_upload_chunks(
@@ -250,12 +276,13 @@ def _put_file_content(
     """PUT a streaming file body without httpx replaying a consumed generator.
 
     ``self._client._client`` is built with ``follow_redirects=True``. A one-shot
-    iterator cannot be replayed, so a 307/308 (or any retry after the first byte)
+    iterator cannot be replayed, so a redirect (or any retry after the first byte)
     would raise ``StreamConsumed``. Disable auto-follow and re-PUT with a fresh
     iterator after validating ``Location``.
     """
 
     hops = 0
+    progress_callback = _monotonic_upload_progress(progress_callback)
     while True:
         response = http_client.put(
             url=url,
@@ -293,6 +320,7 @@ async def _aput_file_content(
     """Async counterpart of ``_put_file_content``."""
 
     hops = 0
+    progress_callback = _monotonic_upload_progress(progress_callback)
     while True:
         response = await http_client.put(
             url=url,

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -48,7 +48,7 @@ from ..._exceptions import APIStatusError, APIConnectionError, AuthenticationErr
 log: logging.Logger = logging.getLogger(__name__)
 
 UPLOAD_PROGRESS_CHUNK_SIZE = 1024 * 1024
-_SAFE_FILE_ID_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+_SAFE_FILE_ID_RE = re.compile(r"^file-[A-Za-z0-9-]+$")
 # 307/308 preserve method + body. S3 uses 307 for cross-region/new buckets; GCS resumable too.
 _UPLOAD_REPLAY_REDIRECT_STATUSES = frozenset({307, 308})
 _MAX_UPLOAD_REDIRECTS = 20

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import math
 import stat
 import time
@@ -10,10 +11,12 @@ import asyncio
 import hashlib
 import logging
 import tempfile
+import ipaddress
 from typing import IO, Any, Dict, List, Tuple, Callable, Iterator, AsyncIterator, cast
 from pathlib import Path
 from functools import partial
 from dataclasses import dataclass
+from urllib.parse import urlparse
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
 import httpx
@@ -45,6 +48,39 @@ from ..._exceptions import APIStatusError, APIConnectionError, AuthenticationErr
 log: logging.Logger = logging.getLogger(__name__)
 
 UPLOAD_PROGRESS_CHUNK_SIZE = 1024 * 1024
+_SAFE_FILE_ID_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+
+def _validate_upload_redirect_url(redirect_url: str) -> str:
+    """Reject unsafe upload redirect targets before issuing the PUT."""
+
+    parsed = urlparse(redirect_url)
+    if parsed.scheme != "https":
+        raise ValueError(f"Refusing non-HTTPS upload redirect URL: {redirect_url!r}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(f"Upload redirect URL is missing a hostname: {redirect_url!r}")
+
+    lowered = hostname.lower()
+    if lowered in {"localhost", "metadata.google.internal"} or lowered.endswith(".localhost"):
+        raise ValueError(f"Refusing upload redirect to local host: {redirect_url!r}")
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip = None
+
+    if ip is not None and not ip.is_global:
+        raise ValueError(f"Refusing upload redirect to non-public address: {redirect_url!r}")
+
+    return redirect_url
+
+
+def _validate_upload_file_id(file_id: str) -> str:
+    if not _SAFE_FILE_ID_RE.fullmatch(file_id):
+        raise ValueError(f"Invalid upload file id returned by server: {file_id!r}")
+    return file_id
 
 
 @dataclass(frozen=True)
@@ -579,7 +615,14 @@ class UploadManager(SyncAPIResource):
                 body=response.content.decode() if hasattr(response, "content") else "",
             )
 
-        return redirect_url, file_id
+        try:
+            return _validate_upload_redirect_url(redirect_url), _validate_upload_file_id(file_id)
+        except ValueError as e:
+            raise APIStatusError(
+                str(e),
+                response=response,
+                body=response.content.decode() if hasattr(response, "content") else "",
+            ) from e
 
     def callback(self, url: str) -> FileResponse:
         response = self._client.post(
@@ -859,6 +902,7 @@ class MultipartUploadManager(SyncAPIResource):
         upload_url = part_info.get("URL", part_info.get("UploadURL"))
         if not upload_url:
             raise ValueError("Missing upload URL in part info")
+        upload_url = _validate_upload_redirect_url(str(upload_url))
 
         part_headers = part_info.get("Headers", {})
 
@@ -997,7 +1041,14 @@ class AsyncUploadManager(AsyncAPIResource):
                     body=response.content.decode() if hasattr(response, "content") else "",
                 )
 
-        return redirect_url, file_id
+        try:
+            return _validate_upload_redirect_url(redirect_url), _validate_upload_file_id(file_id)
+        except ValueError as e:
+            raise APIStatusError(
+                str(e),
+                response=response,
+                body=response.content.decode() if hasattr(response, "content") else "",
+            ) from e
 
     async def callback(self, url: str) -> FileResponse:
         response = self._client.post(
@@ -1277,6 +1328,7 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
         upload_url = part_info.get("URL", part_info.get("UploadURL"))
         if not upload_url:
             raise ValueError("Missing upload URL in part info")
+        upload_url = _validate_upload_redirect_url(str(upload_url))
 
         part_headers = part_info.get("Headers", {})
 

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -10,7 +10,7 @@ import asyncio
 import hashlib
 import logging
 import tempfile
-from typing import IO, Any, Dict, List, Tuple, Callable, Iterator, cast
+from typing import IO, Any, Dict, List, Tuple, Callable, Iterator, AsyncIterator, cast
 from pathlib import Path
 from functools import partial
 from dataclasses import dataclass
@@ -105,6 +105,28 @@ def _iter_file_upload_chunks(
             uploaded_bytes += len(chunk)
             _notify_upload_progress(progress_callback, uploaded_bytes, total_bytes)
             yield chunk
+
+
+async def _aiter_file_upload_chunks(
+    file: Path,
+    *,
+    total_bytes: int,
+    progress_callback: UploadProgressCallback | None = None,
+    chunk_size: int = UPLOAD_PROGRESS_CHUNK_SIZE,
+) -> AsyncIterator[bytes]:
+    """Async chunk iterator for ``httpx.AsyncClient``.
+
+    Sync iterators are wrapped as ``SyncByteStream``, which AsyncClient rejects with
+    ``Attempted to send an sync request with an AsyncClient instance.``
+    """
+
+    for chunk in _iter_file_upload_chunks(
+        file,
+        total_bytes=total_bytes,
+        progress_callback=progress_callback,
+        chunk_size=chunk_size,
+    ):
+        yield chunk
 
 
 def chmod_and_replace(src: Path, dst: Path) -> None:
@@ -1037,7 +1059,7 @@ class AsyncUploadManager(AsyncAPIResource):
         assert redirect_url is not None
         callback_response = await self._client._client.put(
             url=redirect_url,
-            content=_iter_file_upload_chunks(
+            content=_aiter_file_upload_chunks(
                 file,
                 total_bytes=file_size,
                 progress_callback=progress_callback,

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
 import httpx
-from tqdm import tqdm
 from filelock import FileLock
 
 from together._utils._logs import logger
@@ -56,7 +55,16 @@ class FileUploadProgress:
     total_bytes: int
 
 
+@dataclass(frozen=True)
+class FileDownloadProgress:
+    """Byte-level download progress reported by file download managers."""
+
+    downloaded_bytes: int
+    total_bytes: int
+
+
 UploadProgressCallback = Callable[[FileUploadProgress], None]
+DownloadProgressCallback = Callable[[FileDownloadProgress], None]
 
 
 def _notify_upload_progress(
@@ -66,6 +74,15 @@ def _notify_upload_progress(
 ) -> None:
     if progress_callback is not None:
         progress_callback(FileUploadProgress(uploaded_bytes=uploaded_bytes, total_bytes=total_bytes))
+
+
+def _notify_download_progress(
+    progress_callback: DownloadProgressCallback | None,
+    downloaded_bytes: int,
+    total_bytes: int,
+) -> None:
+    if progress_callback is not None:
+        progress_callback(FileDownloadProgress(downloaded_bytes=downloaded_bytes, total_bytes=total_bytes))
 
 
 def _iter_file_upload_chunks(
@@ -219,6 +236,8 @@ class DownloadManager(SyncAPIResource):
         output: Path | None = None,
         remote_name: str | None = None,
         fetch_metadata: bool = False,
+        *,
+        progress_callback: DownloadProgressCallback | None = None,
     ) -> Tuple[str, int]:
         # pre-fetch remote file name and file size
         file_path, file_size = self.get_file_metadata(url, output, remote_name, fetch_metadata)
@@ -253,66 +272,58 @@ class DownloadManager(SyncAPIResource):
                 bytes_downloaded = 0
                 retry_count = 0
                 retry_delay = DOWNLOAD_INITIAL_RETRY_DELAY
+                _notify_download_progress(progress_callback, bytes_downloaded, file_size)
 
-                DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
+                while bytes_downloaded < file_size:
+                    try:
+                        # If this is a retry, close the previous response and create a new one with Range header
+                        if bytes_downloaded > 0:
+                            response.close()
 
-                with tqdm(
-                    total=file_size,
-                    unit="B",
-                    unit_scale=True,
-                    desc=f"Downloading file {file_path.name}",
-                    disable=bool(DISABLE_TQDM),
-                ) as pbar:
-                    while bytes_downloaded < file_size:
-                        try:
-                            # If this is a retry, close the previous response and create a new one with Range header
-                            if bytes_downloaded > 0:
-                                response.close()
-
-                                log.info(f"Resuming download from byte {bytes_downloaded}")
-                                response = self._client.get(
-                                    path=url,
-                                    cast_to=httpx.Response,
-                                    stream=True,
-                                    options=RequestOptions(
-                                        headers={"Range": f"bytes={bytes_downloaded}-"},
-                                    ),
-                                )
-
-                            # Download chunks
-                            for chunk in response.iter_bytes(DOWNLOAD_BLOCK_SIZE):
-                                temp_file.write(chunk)  # type: ignore
-                                bytes_downloaded += len(chunk)
-                                pbar.update(len(chunk))
-
-                            # Successfully completed download
-                            break
-
-                        except (httpx.RequestError, httpx.StreamError, APIConnectionError) as e:
-                            if retry_count >= MAX_DOWNLOAD_RETRIES:
-                                log.error(f"Download failed after {retry_count} retries")
-                                raise DownloadError(
-                                    f"Download failed after {retry_count} retries. Last error: {str(e)}"
-                                ) from e
-
-                            retry_count += 1
-                            log.warning(
-                                f"Download interrupted at {bytes_downloaded}/{file_size} bytes. "
-                                f"Retry {retry_count}/{MAX_DOWNLOAD_RETRIES} in {retry_delay}s..."
+                            log.info(f"Resuming download from byte {bytes_downloaded}")
+                            response = self._client.get(
+                                path=url,
+                                cast_to=httpx.Response,
+                                stream=True,
+                                options=RequestOptions(
+                                    headers={"Range": f"bytes={bytes_downloaded}-"},
+                                ),
                             )
-                            time.sleep(retry_delay)
 
-                            # Exponential backoff with max delay cap
-                            retry_delay = min(retry_delay * 2, DOWNLOAD_MAX_RETRY_DELAY)
+                        # Download chunks
+                        for chunk in response.iter_bytes(DOWNLOAD_BLOCK_SIZE):
+                            temp_file.write(chunk)  # type: ignore
+                            bytes_downloaded += len(chunk)
+                            _notify_download_progress(progress_callback, bytes_downloaded, file_size)
 
-                        except APIStatusError as e:
-                            # For API errors, don't retry
-                            log.error(f"API error during download: {e}")
-                            raise APIStatusError(
-                                "Error downloading file",
-                                response=e.response,
-                                body=e.body,
+                        # Successfully completed download
+                        break
+
+                    except (httpx.RequestError, httpx.StreamError, APIConnectionError) as e:
+                        if retry_count >= MAX_DOWNLOAD_RETRIES:
+                            log.error(f"Download failed after {retry_count} retries")
+                            raise DownloadError(
+                                f"Download failed after {retry_count} retries. Last error: {str(e)}"
                             ) from e
+
+                        retry_count += 1
+                        log.warning(
+                            f"Download interrupted at {bytes_downloaded}/{file_size} bytes. "
+                            f"Retry {retry_count}/{MAX_DOWNLOAD_RETRIES} in {retry_delay}s..."
+                        )
+                        time.sleep(retry_delay)
+
+                        # Exponential backoff with max delay cap
+                        retry_delay = min(retry_delay * 2, DOWNLOAD_MAX_RETRY_DELAY)
+
+                    except APIStatusError as e:
+                        # For API errors, don't retry
+                        log.error(f"API error during download: {e}")
+                        raise APIStatusError(
+                            "Error downloading file",
+                            response=e.response,
+                            body=e.body,
+                        ) from e
 
                 # Close the response
                 response.close()
@@ -388,6 +399,8 @@ class AsyncDownloadManager(AsyncAPIResource):
         output: Path | None = None,
         remote_name: str | None = None,
         fetch_metadata: bool = False,
+        *,
+        progress_callback: DownloadProgressCallback | None = None,
     ) -> Tuple[str, int]:
         # pre-fetch remote file name and file size
         file_path, file_size = await self.get_file_metadata(url, output, remote_name, fetch_metadata)
@@ -422,66 +435,58 @@ class AsyncDownloadManager(AsyncAPIResource):
                 bytes_downloaded = 0
                 retry_count = 0
                 retry_delay = DOWNLOAD_INITIAL_RETRY_DELAY
+                _notify_download_progress(progress_callback, bytes_downloaded, file_size)
 
-                DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
+                while bytes_downloaded < file_size:
+                    try:
+                        # If this is a retry, close the previous response and create a new one with Range header
+                        if bytes_downloaded > 0:
+                            await response.aclose()
 
-                with tqdm(
-                    total=file_size,
-                    unit="B",
-                    unit_scale=True,
-                    desc=f"Downloading file {file_path.name}",
-                    disable=bool(DISABLE_TQDM),
-                ) as pbar:
-                    while bytes_downloaded < file_size:
-                        try:
-                            # If this is a retry, close the previous response and create a new one with Range header
-                            if bytes_downloaded > 0:
-                                await response.aclose()
-
-                                log.info(f"Resuming download from byte {bytes_downloaded}")
-                                response = await self._client.get(
-                                    path=url,
-                                    cast_to=httpx.Response,
-                                    stream=True,
-                                    options=RequestOptions(
-                                        headers={"Range": f"bytes={bytes_downloaded}-"},
-                                    ),
-                                )
-
-                            # Download chunks
-                            async for chunk in response.aiter_bytes(DOWNLOAD_BLOCK_SIZE):
-                                temp_file.write(chunk)  # type: ignore
-                                bytes_downloaded += len(chunk)
-                                pbar.update(len(chunk))
-
-                            # Successfully completed download
-                            break
-
-                        except (httpx.RequestError, httpx.StreamError, APIConnectionError) as e:
-                            if retry_count >= MAX_DOWNLOAD_RETRIES:
-                                log.error(f"Download failed after {retry_count} retries")
-                                raise DownloadError(
-                                    f"Download failed after {retry_count} retries. Last error: {str(e)}"
-                                ) from e
-
-                            retry_count += 1
-                            log.warning(
-                                f"Download interrupted at {bytes_downloaded}/{file_size} bytes. "
-                                f"Retry {retry_count}/{MAX_DOWNLOAD_RETRIES} in {retry_delay}s..."
+                            log.info(f"Resuming download from byte {bytes_downloaded}")
+                            response = await self._client.get(
+                                path=url,
+                                cast_to=httpx.Response,
+                                stream=True,
+                                options=RequestOptions(
+                                    headers={"Range": f"bytes={bytes_downloaded}-"},
+                                ),
                             )
-                            await self._sleep(retry_delay)
 
-                            # Exponential backoff with max delay cap
-                            retry_delay = min(retry_delay * 2, DOWNLOAD_MAX_RETRY_DELAY)
+                        # Download chunks
+                        async for chunk in response.aiter_bytes(DOWNLOAD_BLOCK_SIZE):
+                            temp_file.write(chunk)  # type: ignore
+                            bytes_downloaded += len(chunk)
+                            _notify_download_progress(progress_callback, bytes_downloaded, file_size)
 
-                        except APIStatusError as e:
-                            # For API errors, don't retry
-                            log.error(f"API error during download: {e}")
-                            raise APIStatusError(
-                                "Error downloading file",
-                                response=e.response,
-                                body=e.body,
+                        # Successfully completed download
+                        break
+
+                    except (httpx.RequestError, httpx.StreamError, APIConnectionError) as e:
+                        if retry_count >= MAX_DOWNLOAD_RETRIES:
+                            log.error(f"Download failed after {retry_count} retries")
+                            raise DownloadError(
+                                f"Download failed after {retry_count} retries. Last error: {str(e)}"
                             ) from e
+
+                        retry_count += 1
+                        log.warning(
+                            f"Download interrupted at {bytes_downloaded}/{file_size} bytes. "
+                            f"Retry {retry_count}/{MAX_DOWNLOAD_RETRIES} in {retry_delay}s..."
+                        )
+                        await self._sleep(retry_delay)
+
+                        # Exponential backoff with max delay cap
+                        retry_delay = min(retry_delay * 2, DOWNLOAD_MAX_RETRY_DELAY)
+
+                    except APIStatusError as e:
+                        # For API errors, don't retry
+                        log.error(f"API error during download: {e}")
+                        raise APIStatusError(
+                            "Error downloading file",
+                            response=e.response,
+                            body=e.body,
+                        ) from e
 
                 # Close the response
                 await response.aclose()

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -10,15 +10,15 @@ import asyncio
 import hashlib
 import logging
 import tempfile
-from typing import IO, Any, Dict, List, Tuple, cast
+from typing import IO, Any, Dict, List, Tuple, Callable, Iterator, cast
 from pathlib import Path
 from functools import partial
+from dataclasses import dataclass
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
 import httpx
 from tqdm import tqdm
 from filelock import FileLock
-from tqdm.utils import CallbackIOWrapper
 
 from together._utils._logs import logger
 
@@ -44,6 +44,50 @@ from ..types.error import DownloadError, FileTypeError
 from ..._exceptions import APIStatusError, APIConnectionError, AuthenticationError
 
 log: logging.Logger = logging.getLogger(__name__)
+
+UPLOAD_PROGRESS_CHUNK_SIZE = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class FileUploadProgress:
+    """Byte-level upload progress reported by file upload managers."""
+
+    uploaded_bytes: int
+    total_bytes: int
+
+
+UploadProgressCallback = Callable[[FileUploadProgress], None]
+
+
+def _notify_upload_progress(
+    progress_callback: UploadProgressCallback | None,
+    uploaded_bytes: int,
+    total_bytes: int,
+) -> None:
+    if progress_callback is not None:
+        progress_callback(FileUploadProgress(uploaded_bytes=uploaded_bytes, total_bytes=total_bytes))
+
+
+def _iter_file_upload_chunks(
+    file: Path,
+    *,
+    total_bytes: int,
+    progress_callback: UploadProgressCallback | None = None,
+    chunk_size: int = UPLOAD_PROGRESS_CHUNK_SIZE,
+) -> Iterator[bytes]:
+    """Yield file chunks while reporting upload progress to the caller."""
+
+    uploaded_bytes = 0
+    _notify_upload_progress(progress_callback, uploaded_bytes, total_bytes)
+
+    with file.open("rb") as file_handle:
+        while True:
+            chunk = file_handle.read(chunk_size)
+            if not chunk:
+                break
+            uploaded_bytes += len(chunk)
+            _notify_upload_progress(progress_callback, uploaded_bytes, total_bytes)
+            yield chunk
 
 
 def chmod_and_replace(src: Path, dst: Path) -> None:
@@ -523,6 +567,8 @@ class UploadManager(SyncAPIResource):
         url: str,
         file: Path,
         purpose: FilePurpose,
+        *,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
         file_size = os.stat(file.as_posix()).st_size
         file_size_gb = file_size / NUM_BYTES_IN_GB
@@ -536,9 +582,9 @@ class UploadManager(SyncAPIResource):
 
         if file_size_gb > MULTIPART_THRESHOLD_GB:
             multipart_manager = MultipartUploadManager(self._client)
-            return multipart_manager.upload(url, file, checksum, purpose)
+            return multipart_manager.upload(url, file, checksum, purpose, progress_callback=progress_callback)
         else:
-            return self._upload_single_file(url, file, checksum, purpose)
+            return self._upload_single_file(url, file, checksum, purpose, progress_callback=progress_callback)
 
     def _upload_single_file(
         self,
@@ -546,6 +592,8 @@ class UploadManager(SyncAPIResource):
         file: Path,
         checksum: str,
         purpose: FilePurpose,
+        *,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
         file_id = None
 
@@ -561,31 +609,25 @@ class UploadManager(SyncAPIResource):
         redirect_url, file_id = self.get_upload_url(url, file, checksum, purpose, filetype)  # type: ignore
 
         file_size = os.stat(file.as_posix()).st_size
-        DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
 
-        with tqdm(
-            total=file_size,
-            unit="B",
-            unit_scale=True,
-            desc=f"Uploading file {file.name}",
-            disable=bool(DISABLE_TQDM),
-        ) as pbar:
-            with file.open("rb") as f:
-                wrapped_file = cast(IO[bytes], CallbackIOWrapper(pbar.update, f, "read"))
-
-                assert redirect_url is not None
-                callback_response = self._client._client.put(
-                    url=redirect_url,
-                    content=wrapped_file.read(),
-                )
-                log.debug(
-                    'HTTP Response: %s %s "%i %s" %s',
-                    "put",
-                    redirect_url,
-                    callback_response.status_code,
-                    callback_response.reason_phrase,
-                    callback_response.headers,
-                )
+        assert redirect_url is not None
+        callback_response = self._client._client.put(
+            url=redirect_url,
+            content=_iter_file_upload_chunks(
+                file,
+                total_bytes=file_size,
+                progress_callback=progress_callback,
+            ),
+            headers={"Content-Length": str(file_size)},
+        )
+        log.debug(
+            'HTTP Response: %s %s "%i %s" %s',
+            "put",
+            redirect_url,
+            callback_response.status_code,
+            callback_response.reason_phrase,
+            callback_response.headers,
+        )
 
         assert isinstance(callback_response, httpx.Response)  # type: ignore
 
@@ -616,6 +658,8 @@ class MultipartUploadManager(SyncAPIResource):
         file: Path,
         checksum: str,
         purpose: FilePurpose,
+        *,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
         """Upload large file using multipart upload"""
 
@@ -634,7 +678,12 @@ class MultipartUploadManager(SyncAPIResource):
         try:
             upload_info = self._initiate_upload(url, file, checksum, file_size, num_parts, purpose, file_type)
 
-            completed_parts = self._upload_parts_concurrent(file, upload_info, part_size)
+            completed_parts = self._upload_parts_concurrent(
+                file,
+                upload_info,
+                part_size,
+                progress_callback=progress_callback,
+            )
 
             upload_id = upload_info.get("upload_id")
             file_id = upload_info.get("file_id")
@@ -719,52 +768,60 @@ class MultipartUploadManager(SyncAPIResource):
         file_handle: IO[bytes],
         part_info: Dict[str, Any],
         part_size: int,
-    ) -> Tuple[Future[str], int]:
-        """Submit a single part for upload and return its future and part number."""
+    ) -> Tuple[Future[str], int, int]:
+        """Submit a single part for upload and return its future, part number, and size."""
 
         part_number = part_info.get("PartNumber", part_info.get("part_number", 1))
         file_handle.seek((part_number - 1) * part_size)
         part_data = file_handle.read(part_size)
 
         future = executor.submit(self._upload_single_part, part_info, part_data)
-        return future, part_number
+        return future, part_number, len(part_data)
 
-    def _upload_parts_concurrent(self, file: Path, upload_info: Dict[str, Any], part_size: int) -> List[Dict[str, Any]]:
-        """Upload file parts concurrently with progress tracking"""
+    def _upload_parts_concurrent(
+        self,
+        file: Path,
+        upload_info: Dict[str, Any],
+        part_size: int,
+        *,
+        progress_callback: UploadProgressCallback | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Upload file parts concurrently, reporting byte progress to the caller."""
 
         parts = upload_info["parts"]
         completed_parts: List[Dict[str, Any]] = []
-
-        DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
+        file_size = os.stat(file.as_posix()).st_size
+        uploaded_bytes = 0
+        _notify_upload_progress(progress_callback, uploaded_bytes, file_size)
 
         with ThreadPoolExecutor(max_workers=self.max_concurrent_parts) as executor:
-            with tqdm(total=len(parts), desc="Uploading parts", unit="part", disable=bool(DISABLE_TQDM)) as pbar:
-                with open(file, "rb") as f:
-                    future_to_part: Dict[Future[str], int] = {}
-                    part_index = 0
+            with open(file, "rb") as f:
+                future_to_part: Dict[Future[str], Tuple[int, int]] = {}
+                part_index = 0
 
-                    while part_index < len(parts) and len(future_to_part) < self.max_concurrent_parts:
+                while part_index < len(parts) and len(future_to_part) < self.max_concurrent_parts:
+                    part_info = parts[part_index]
+                    future, part_number, part_bytes = self._submit_part(executor, f, part_info, part_size)
+                    future_to_part[future] = (part_number, part_bytes)
+                    part_index += 1
+
+                while future_to_part:
+                    done_future = next(as_completed(future_to_part))
+                    part_number, part_bytes = future_to_part.pop(done_future)
+
+                    try:
+                        etag = done_future.result()
+                        completed_parts.append({"part_number": part_number, "etag": etag})
+                        uploaded_bytes += part_bytes
+                        _notify_upload_progress(progress_callback, uploaded_bytes, file_size)
+                    except Exception as e:
+                        raise Exception(f"Failed to upload part {part_number}: {e}") from e
+
+                    if part_index < len(parts):
                         part_info = parts[part_index]
-                        future, part_number = self._submit_part(executor, f, part_info, part_size)
-                        future_to_part[future] = part_number
+                        future, next_part_number, next_part_bytes = self._submit_part(executor, f, part_info, part_size)
+                        future_to_part[future] = (next_part_number, next_part_bytes)
                         part_index += 1
-
-                    while future_to_part:
-                        done_future = next(as_completed(future_to_part))
-                        part_number = future_to_part.pop(done_future)
-
-                        try:
-                            etag = done_future.result()
-                            completed_parts.append({"part_number": part_number, "etag": etag})
-                            pbar.update(1)
-                        except Exception as e:
-                            raise Exception(f"Failed to upload part {part_number}: {e}") from e
-
-                        if part_index < len(parts):
-                            part_info = parts[part_index]
-                            future, next_part_number = self._submit_part(executor, f, part_info, part_size)
-                            future_to_part[future] = next_part_number
-                            part_index += 1
 
         completed_parts.sort(key=lambda x: x["part_number"])
         return completed_parts
@@ -928,6 +985,8 @@ class AsyncUploadManager(AsyncAPIResource):
         url: str,
         file: Path,
         purpose: FilePurpose,
+        *,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
         file_size = os.stat(file.as_posix()).st_size
         file_size_gb = file_size / NUM_BYTES_IN_GB
@@ -941,9 +1000,9 @@ class AsyncUploadManager(AsyncAPIResource):
 
         if file_size_gb > MULTIPART_THRESHOLD_GB:
             multipart_manager = AsyncMultipartUploadManager(self._client)
-            return await multipart_manager.upload(url, file, checksum, purpose)
+            return await multipart_manager.upload(url, file, checksum, purpose, progress_callback=progress_callback)
         else:
-            return await self._upload_single_file(url, file, checksum, purpose)
+            return await self._upload_single_file(url, file, checksum, purpose, progress_callback=progress_callback)
 
     async def _upload_single_file(
         self,
@@ -951,6 +1010,8 @@ class AsyncUploadManager(AsyncAPIResource):
         file: Path,
         checksum: str,
         purpose: FilePurpose,
+        *,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
         file_id = None
 
@@ -968,31 +1029,24 @@ class AsyncUploadManager(AsyncAPIResource):
 
         file_size = os.stat(file.as_posix()).st_size
 
-        DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
-
-        with tqdm(
-            total=file_size,
-            unit="B",
-            unit_scale=True,
-            desc=f"Uploading file {file.name}",
-            disable=bool(DISABLE_TQDM),
-        ) as pbar:
-            with file.open("rb") as f:
-                wrapped_file = cast(IO[bytes], CallbackIOWrapper(pbar.update, f, "read"))
-
-                assert redirect_url is not None
-                callback_response = await self._client._client.put(
-                    url=redirect_url,
-                    content=wrapped_file.read(),
-                )
-                log.debug(
-                    'HTTP Response: %s %s "%i %s" %s',
-                    "put",
-                    redirect_url,
-                    callback_response.status_code,
-                    callback_response.reason_phrase,
-                    callback_response.headers,
-                )
+        assert redirect_url is not None
+        callback_response = await self._client._client.put(
+            url=redirect_url,
+            content=_iter_file_upload_chunks(
+                file,
+                total_bytes=file_size,
+                progress_callback=progress_callback,
+            ),
+            headers={"Content-Length": str(file_size)},
+        )
+        log.debug(
+            'HTTP Response: %s %s "%i %s" %s',
+            "put",
+            redirect_url,
+            callback_response.status_code,
+            callback_response.reason_phrase,
+            callback_response.headers,
+        )
 
         assert isinstance(callback_response, httpx.Response)  # type: ignore
 
@@ -1023,6 +1077,8 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
         file: Path,
         checksum: str,
         purpose: FilePurpose,
+        *,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
         """Upload large file using multipart upload via ThreadPoolExecutor"""
 
@@ -1041,7 +1097,12 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
         try:
             upload_info = await self._initiate_upload(url, file, checksum, file_size, num_parts, purpose, file_type)
 
-            completed_parts = await self._upload_parts_concurrent(file, upload_info, part_size)
+            completed_parts = await self._upload_parts_concurrent(
+                file,
+                upload_info,
+                part_size,
+                progress_callback=progress_callback,
+            )
 
             upload_id = upload_info.get("upload_id")
             file_id = upload_info.get("file_id")
@@ -1121,60 +1182,64 @@ class AsyncMultipartUploadManager(AsyncAPIResource):
             )
 
     async def _upload_parts_concurrent(
-        self, file: Path, upload_info: Dict[str, Any], part_size: int
+        self,
+        file: Path,
+        upload_info: Dict[str, Any],
+        part_size: int,
+        *,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> List[Dict[str, Any]]:
-        """Upload file parts concurrently using ThreadPoolExecutor"""
+        """Upload file parts concurrently using ThreadPoolExecutor."""
 
         parts = upload_info["parts"]
         completed_parts: List[Dict[str, Any]] = []
+        file_size = os.stat(file.as_posix()).st_size
+        uploaded_bytes = 0
+        _notify_upload_progress(progress_callback, uploaded_bytes, file_size)
 
         # Use ThreadPoolExecutor for HTTP I/O efficiency
         loop = asyncio.get_event_loop()
 
-        DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
-
         with ThreadPoolExecutor(max_workers=self.max_concurrent_parts) as executor:
-            with tqdm(total=len(parts), desc="Uploading parts", unit="part", disable=bool(DISABLE_TQDM)) as pbar:
-                with open(file, "rb") as f:
-                    future_to_part: Dict[asyncio.Future[str], int] = {}
-                    part_index = 0
+            with open(file, "rb") as f:
+                future_to_part: Dict[asyncio.Future[str], Tuple[int, int]] = {}
+                part_index = 0
 
-                    while part_index < len(parts) and len(future_to_part) < self.max_concurrent_parts:
-                        part_info = parts[part_index]
-                        part_number = part_info.get("PartNumber", part_info.get("part_number", 1))
-                        f.seek((part_number - 1) * part_size)
-                        part_data = f.read(part_size)
+                while part_index < len(parts) and len(future_to_part) < self.max_concurrent_parts:
+                    part_info = parts[part_index]
+                    part_number = part_info.get("PartNumber", part_info.get("part_number", 1))
+                    f.seek((part_number - 1) * part_size)
+                    part_data = f.read(part_size)
 
-                        future = loop.run_in_executor(executor, self._upload_single_part_sync, part_info, part_data)
-                        future_to_part[future] = part_number
-                        part_index += 1
+                    future = loop.run_in_executor(executor, self._upload_single_part_sync, part_info, part_data)
+                    future_to_part[future] = (part_number, len(part_data))
+                    part_index += 1
 
-                    while future_to_part:
-                        done, _ = await asyncio.wait(
-                            tuple(future_to_part.keys()),
-                            return_when=asyncio.FIRST_COMPLETED,
-                        )
+                while future_to_part:
+                    done, _ = await asyncio.wait(
+                        tuple(future_to_part.keys()),
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
 
-                        for done_future in done:
-                            part_number = future_to_part.pop(done_future)
+                    for done_future in done:
+                        part_number, part_bytes = future_to_part.pop(done_future)
 
-                            try:
-                                etag = await done_future
-                                completed_parts.append({"part_number": part_number, "etag": etag})
-                                pbar.update(1)
-                            except Exception as e:
-                                raise Exception(f"Failed to upload part {part_number}: {e}") from e
+                        try:
+                            etag = await done_future
+                            completed_parts.append({"part_number": part_number, "etag": etag})
+                            uploaded_bytes += part_bytes
+                            _notify_upload_progress(progress_callback, uploaded_bytes, file_size)
+                        except Exception as e:
+                            raise Exception(f"Failed to upload part {part_number}: {e}") from e
 
-                            if part_index < len(parts):
-                                part_info = parts[part_index]
-                                next_part_number = part_info.get("PartNumber", part_info.get("part_number", 1))
-                                f.seek((next_part_number - 1) * part_size)
-                                part_data = f.read(part_size)
-                                future = loop.run_in_executor(
-                                    executor, self._upload_single_part_sync, part_info, part_data
-                                )
-                                future_to_part[future] = next_part_number
-                                part_index += 1
+                        if part_index < len(parts):
+                            part_info = parts[part_index]
+                            next_part_number = part_info.get("PartNumber", part_info.get("part_number", 1))
+                            f.seek((next_part_number - 1) * part_size)
+                            part_data = f.read(part_size)
+                            future = loop.run_in_executor(executor, self._upload_single_part_sync, part_info, part_data)
+                            future_to_part[future] = (next_part_number, len(part_data))
+                            part_index += 1
 
         completed_parts.sort(key=lambda x: x["part_number"])
         return completed_parts

--- a/src/together/lib/resources/files.py
+++ b/src/together/lib/resources/files.py
@@ -934,9 +934,11 @@ class UploadManager(SyncAPIResource):
             filetype = "jsonl"
         elif file.suffix == ".parquet":
             filetype = "parquet"
+        elif file.suffix == ".csv":
+            filetype = "csv"
         else:
             raise FileTypeError(
-                f"Unknown extension of file {file}. Only files with extensions .jsonl and .parquet are supported."
+                f"Unknown extension of file {file}. Only files with extensions .jsonl, .parquet, and .csv are supported."
             )
         redirect_url, file_id = self.get_upload_url(url, file, checksum, purpose, filetype)  # type: ignore
 
@@ -1363,9 +1365,11 @@ class AsyncUploadManager(AsyncAPIResource):
             filetype = "jsonl"
         elif file.suffix == ".parquet":
             filetype = "parquet"
+        elif file.suffix == ".csv":
+            filetype = "csv"
         else:
             raise FileTypeError(
-                f"Unknown extension of file {file}. Only files with extensions .jsonl and .parquet are supported."
+                f"Unknown extension of file {file}. Only files with extensions .jsonl, .parquet, and .csv are supported."
             )
 
         redirect_url, file_id = await self.get_upload_url(url, file, checksum, purpose, filetype)  # type: ignore

--- a/src/together/lib/utils/files.py
+++ b/src/together/lib/utils/files.py
@@ -56,6 +56,45 @@ def _notify_check_progress(
         progress_callback(FileCheckProgress(processed_bytes=processed_bytes, total_bytes=total_bytes, phase=phase))
 
 
+def _encoded_line_size(file_handle: IO[str], line: str) -> int:
+    """Byte length of a text line without calling ``tell()``.
+
+    ``TextIOWrapper.tell()`` raises ``OSError: telling position disabled by next() call``
+    while the file is being iterated, and text-mode ``tell()`` is an opaque cookie anyway.
+    """
+
+    encoding = getattr(file_handle, "encoding", None) or "utf-8"
+    errors = getattr(file_handle, "errors", None) or "strict"
+    try:
+        return len(line.encode(encoding, errors))
+    except (LookupError, UnicodeError):
+        return len(line.encode("utf-8", "replace"))
+
+
+def _iter_lines_with_progress(
+    file_handle: IO[str],
+    *,
+    total_bytes: int,
+    progress_callback: CheckProgressCallback,
+    phase: str,
+) -> Iterator[str]:
+    """Yield lines while reporting processed bytes from encoded line lengths."""
+
+    last_reported = 0
+    pos = 0
+    _notify_check_progress(progress_callback, 0, total_bytes, phase)
+    while True:
+        line = file_handle.readline()
+        if not line:
+            break
+        pos += _encoded_line_size(file_handle, line)
+        yield line
+        if pos - last_reported >= CHECK_PROGRESS_STEP_BYTES:
+            _notify_check_progress(progress_callback, min(pos, total_bytes), total_bytes, phase)
+            last_reported = pos
+    _notify_check_progress(progress_callback, total_bytes, total_bytes, phase)
+
+
 def _enumerate_lines(
     file_handle: IO[str],
     *,
@@ -65,25 +104,21 @@ def _enumerate_lines(
 ) -> Iterator[tuple[int, str]]:
     """Yield ``(index, line)`` and optionally report scan progress.
 
-    When ``progress_callback`` is None this is just ``enumerate`` — no ``tell()``.
+    When ``progress_callback`` is None this is just ``enumerate``.
     """
 
     if progress_callback is None:
         yield from enumerate(file_handle)
         return
 
-    last_reported = 0
-    _notify_check_progress(progress_callback, 0, total_bytes, phase)
-    for idx, line in enumerate(file_handle):
-        yield idx, line
-        try:
-            pos = file_handle.tell()
-        except OSError:
-            pos = last_reported
-        if pos - last_reported >= CHECK_PROGRESS_STEP_BYTES:
-            _notify_check_progress(progress_callback, min(pos, total_bytes), total_bytes, phase)
-            last_reported = pos
-    _notify_check_progress(progress_callback, total_bytes, total_bytes, phase)
+    yield from enumerate(
+        _iter_lines_with_progress(
+            file_handle,
+            total_bytes=total_bytes,
+            progress_callback=progress_callback,
+            phase=phase,
+        )
+    )
 
 
 def check_file(
@@ -139,7 +174,7 @@ def check_file(
         data_report_dict = _check_jsonl(file, purpose, progress_callback=progress_callback, total_bytes=file_size)
     elif file.suffix == ".parquet":
         report_dict["filetype"] = "parquet"
-        data_report_dict = _check_parquet(file, purpose)
+        data_report_dict = _check_parquet(file, purpose, progress_callback=progress_callback, total_bytes=file_size)
     elif file.suffix == ".csv":
         report_dict["filetype"] = "csv"
         data_report_dict = _check_csv(file, purpose, progress_callback=progress_callback, total_bytes=file_size)
@@ -227,7 +262,14 @@ def _check_csv(
         return report_dict
 
     with file.open() as f:
-        reader = csv.DictReader(f)
+        source: IO[str] | Iterator[str]
+        if progress_callback is None:
+            source = f
+        else:
+            source = _iter_lines_with_progress(
+                f, total_bytes=total_bytes, progress_callback=progress_callback, phase="csv"
+            )
+        reader = csv.DictReader(source)
         if not reader.fieldnames:
             report_dict["message"] = "CSV file is empty or has no header."
             report_dict["is_check_passed"] = False
@@ -235,8 +277,6 @@ def _check_csv(
         idx = -1
 
         try:
-            last_reported = 0
-            _notify_check_progress(progress_callback, 0, total_bytes, "csv")
             for idx, item in enumerate(reader):
                 if None in item.keys() or None in item.values():
                     raise InvalidFileFormatError(
@@ -244,15 +284,6 @@ def _check_csv(
                         line_number=idx + 1,
                         error_source="format",
                     )
-                if progress_callback is not None:
-                    try:
-                        pos = f.tell()
-                    except OSError:
-                        pos = last_reported
-                    if pos - last_reported >= CHECK_PROGRESS_STEP_BYTES:
-                        _notify_check_progress(progress_callback, min(pos, total_bytes), total_bytes, "csv")
-                        last_reported = pos
-            _notify_check_progress(progress_callback, total_bytes, total_bytes, "csv")
 
             report_dict.update(_check_samples_count(file, report_dict, idx))
             report_dict["load_csv"] = True
@@ -381,7 +412,13 @@ def _check_jsonl(
     return report_dict
 
 
-def _check_parquet(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
+def _check_parquet(
+    file: Path,
+    purpose: FilePurpose | str,
+    *,
+    progress_callback: CheckProgressCallback | None = None,
+    total_bytes: int = 0,
+) -> Dict[str, Any]:
     try:
         # Pyarrow is optional as it's large (~80MB) and isn't compatible with older systems.
         from pyarrow import ArrowInvalid, parquet
@@ -399,7 +436,9 @@ def _check_parquet(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
         return report_dict
 
     try:
+        _notify_check_progress(progress_callback, 0, total_bytes, "parquet")
         table = parquet.read_table(str(file), memory_map=True)  # type: ignore[reportUnknownMemberType]
+        _notify_check_progress(progress_callback, total_bytes, total_bytes, "parquet")
     except ArrowInvalid:
         report_dict["load_parquet"] = (
             f"An exception has occurred when loading the Parquet file {file}. Please check the file for corruption. "

--- a/src/together/lib/utils/files.py
+++ b/src/together/lib/utils/files.py
@@ -61,14 +61,26 @@ def _encoded_line_size(file_handle: IO[str], line: str) -> int:
 
     ``TextIOWrapper.tell()`` raises ``OSError: telling position disabled by next() call``
     while the file is being iterated, and text-mode ``tell()`` is an opaque cookie anyway.
+
+    Default text mode (``newline=None``) translates ``\\r\\n`` → ``\\n``, so a naive
+    re-encode undercounts CRLF files by one byte per line. Restore the stripped CR
+    when the stream has observed CRLF and this line was translated to a bare ``\\n``.
     """
 
     encoding = getattr(file_handle, "encoding", None) or "utf-8"
     errors = getattr(file_handle, "errors", None) or "strict"
     try:
-        return len(line.encode(encoding, errors))
+        size = len(line.encode(encoding, errors))
     except (LookupError, UnicodeError):
-        return len(line.encode("utf-8", "replace"))
+        size = len(line.encode("utf-8", "replace"))
+
+    if line.endswith("\n") and not line.endswith("\r\n"):
+        observed = getattr(file_handle, "newlines", None)
+        if observed == "\r\n" or observed == ("\r\n",):
+            size += 1
+        elif isinstance(observed, tuple) and "\r\n" in observed and "\n" not in observed:
+            size += 1
+    return size
 
 
 def _iter_lines_with_progress(
@@ -207,7 +219,7 @@ def _check_utf8(
     report_dict: Dict[str, Any] = {}
     try:
         # Dry-run UTF-8 decode by iterating through the file to avoid loading it entirely into memory
-        with file.open(encoding="utf-8") as f:
+        with file.open(encoding="utf-8", newline="") as f:
             for _ in _enumerate_lines(f, total_bytes=total_bytes, progress_callback=progress_callback, phase="utf8"):
                 pass
         report_dict["utf8"] = True
@@ -261,7 +273,7 @@ def _check_csv(
     if not report_dict["utf8"]:
         return report_dict
 
-    with file.open() as f:
+    with file.open(encoding="utf-8", newline="") as f:
         source: IO[str] | Iterator[str]
         if progress_callback is None:
             source = f
@@ -320,7 +332,7 @@ def _check_jsonl(
         return report_dict
 
     if purpose == "eval":
-        with file.open() as f:
+        with file.open(encoding="utf-8", newline="") as f:
             idx = -1
             try:
                 for idx, line in _enumerate_lines(
@@ -359,7 +371,7 @@ def _check_jsonl(
     else:
         # Fine-tuning (and non-eval): UTF-8, JSON-parse each non-empty line, require a JSON object per line.
         # Semantic validation runs on the server after upload.
-        with file.open() as f:
+        with file.open(encoding="utf-8", newline="") as f:
             line_index = -1
             sample_count = 0
             try:

--- a/src/together/lib/utils/files.py
+++ b/src/together/lib/utils/files.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import os
 import csv
 import json
-from typing import Any, Dict
+from typing import IO, Any, Dict, Callable, Iterator
 from pathlib import Path
 from traceback import format_exc
+from dataclasses import dataclass
 
 from together.types import FilePurpose
 from together.lib.constants import (
@@ -14,6 +15,8 @@ from together.lib.constants import (
     MAX_FILE_SIZE_GB,
     PARQUET_EXPECTED_COLUMNS,
 )
+
+CHECK_PROGRESS_STEP_BYTES = 1024 * 1024
 
 
 class InvalidFileFormatError(ValueError):
@@ -31,9 +34,63 @@ class InvalidFileFormatError(ValueError):
         self.error_source = error_source
 
 
+@dataclass(frozen=True)
+class FileCheckProgress:
+    """Byte-level validation progress reported while scanning a file."""
+
+    processed_bytes: int
+    total_bytes: int
+    phase: str
+
+
+CheckProgressCallback = Callable[[FileCheckProgress], None]
+
+
+def _notify_check_progress(
+    progress_callback: CheckProgressCallback | None,
+    processed_bytes: int,
+    total_bytes: int,
+    phase: str,
+) -> None:
+    if progress_callback is not None:
+        progress_callback(FileCheckProgress(processed_bytes=processed_bytes, total_bytes=total_bytes, phase=phase))
+
+
+def _enumerate_lines(
+    file_handle: IO[str],
+    *,
+    total_bytes: int,
+    progress_callback: CheckProgressCallback | None,
+    phase: str,
+) -> Iterator[tuple[int, str]]:
+    """Yield ``(index, line)`` and optionally report scan progress.
+
+    When ``progress_callback`` is None this is just ``enumerate`` — no ``tell()``.
+    """
+
+    if progress_callback is None:
+        yield from enumerate(file_handle)
+        return
+
+    last_reported = 0
+    _notify_check_progress(progress_callback, 0, total_bytes, phase)
+    for idx, line in enumerate(file_handle):
+        yield idx, line
+        try:
+            pos = file_handle.tell()
+        except OSError:
+            pos = last_reported
+        if pos - last_reported >= CHECK_PROGRESS_STEP_BYTES:
+            _notify_check_progress(progress_callback, min(pos, total_bytes), total_bytes, phase)
+            last_reported = pos
+    _notify_check_progress(progress_callback, total_bytes, total_bytes, phase)
+
+
 def check_file(
     file: Path | str,
     purpose: FilePurpose | str = "fine-tune",
+    *,
+    progress_callback: CheckProgressCallback | None = None,
 ) -> Dict[str, Any]:
     if not isinstance(file, Path):
         file = Path(file)
@@ -79,13 +136,13 @@ def check_file(
     data_report_dict = {}
     if file.suffix == ".jsonl":
         report_dict["filetype"] = "jsonl"
-        data_report_dict = _check_jsonl(file, purpose)
+        data_report_dict = _check_jsonl(file, purpose, progress_callback=progress_callback, total_bytes=file_size)
     elif file.suffix == ".parquet":
         report_dict["filetype"] = "parquet"
         data_report_dict = _check_parquet(file, purpose)
     elif file.suffix == ".csv":
         report_dict["filetype"] = "csv"
-        data_report_dict = _check_csv(file, purpose)
+        data_report_dict = _check_csv(file, purpose, progress_callback=progress_callback, total_bytes=file_size)
     else:
         unknown_ext_msg = (
             f"Unknown extension of file {file}. Only files with extensions .jsonl, .parquet, and .csv are supported."
@@ -99,7 +156,12 @@ def check_file(
     return report_dict
 
 
-def _check_utf8(file: Path) -> Dict[str, Any]:
+def _check_utf8(
+    file: Path,
+    *,
+    progress_callback: CheckProgressCallback | None = None,
+    total_bytes: int = 0,
+) -> Dict[str, Any]:
     """Check if the file is UTF-8 encoded.
 
     Args:
@@ -111,7 +173,7 @@ def _check_utf8(file: Path) -> Dict[str, Any]:
     try:
         # Dry-run UTF-8 decode by iterating through the file to avoid loading it entirely into memory
         with file.open(encoding="utf-8") as f:
-            for _ in f:
+            for _ in _enumerate_lines(f, total_bytes=total_bytes, progress_callback=progress_callback, phase="utf8"):
                 pass
         report_dict["utf8"] = True
     except UnicodeDecodeError as e:
@@ -135,7 +197,13 @@ def _check_samples_count(file: Path, report_dict: Dict[str, Any], idx: int) -> D
     return report_dict
 
 
-def _check_csv(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
+def _check_csv(
+    file: Path,
+    purpose: FilePurpose | str,
+    *,
+    progress_callback: CheckProgressCallback | None = None,
+    total_bytes: int = 0,
+) -> Dict[str, Any]:
     """Check if the file is a valid CSV file.
 
     Args:
@@ -153,7 +221,7 @@ def _check_csv(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
         )
         return report_dict
 
-    report_dict.update(_check_utf8(file))
+    report_dict.update(_check_utf8(file, progress_callback=progress_callback, total_bytes=total_bytes))
 
     if not report_dict["utf8"]:
         return report_dict
@@ -167,7 +235,8 @@ def _check_csv(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
         idx = -1
 
         try:
-            # for loop to iterate through the CSV rows
+            last_reported = 0
+            _notify_check_progress(progress_callback, 0, total_bytes, "csv")
             for idx, item in enumerate(reader):
                 if None in item.keys() or None in item.values():
                     raise InvalidFileFormatError(
@@ -175,6 +244,15 @@ def _check_csv(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
                         line_number=idx + 1,
                         error_source="format",
                     )
+                if progress_callback is not None:
+                    try:
+                        pos = f.tell()
+                    except OSError:
+                        pos = last_reported
+                    if pos - last_reported >= CHECK_PROGRESS_STEP_BYTES:
+                        _notify_check_progress(progress_callback, min(pos, total_bytes), total_bytes, "csv")
+                        last_reported = pos
+            _notify_check_progress(progress_callback, total_bytes, total_bytes, "csv")
 
             report_dict.update(_check_samples_count(file, report_dict, idx))
             report_dict["load_csv"] = True
@@ -198,9 +276,15 @@ def _check_csv(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
     return report_dict
 
 
-def _check_jsonl(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
+def _check_jsonl(
+    file: Path,
+    purpose: FilePurpose | str,
+    *,
+    progress_callback: CheckProgressCallback | None = None,
+    total_bytes: int = 0,
+) -> Dict[str, Any]:
     report_dict: Dict[str, Any] = {}
-    report_dict.update(_check_utf8(file))
+    report_dict.update(_check_utf8(file, progress_callback=progress_callback, total_bytes=total_bytes))
     if not report_dict["utf8"]:
         return report_dict
 
@@ -208,7 +292,9 @@ def _check_jsonl(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
         with file.open() as f:
             idx = -1
             try:
-                for idx, line in enumerate(f):
+                for idx, line in _enumerate_lines(
+                    f, total_bytes=total_bytes, progress_callback=progress_callback, phase="jsonl"
+                ):
                     json_line = json.loads(line)
 
                     if not isinstance(json_line, dict):
@@ -246,7 +332,9 @@ def _check_jsonl(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
             line_index = -1
             sample_count = 0
             try:
-                for line_index, raw_line in enumerate(f):
+                for line_index, raw_line in _enumerate_lines(
+                    f, total_bytes=total_bytes, progress_callback=progress_callback, phase="jsonl"
+                ):
                     line = raw_line.strip()
                     if not line:
                         continue

--- a/src/together/lib/utils/files.py
+++ b/src/together/lib/utils/files.py
@@ -326,94 +326,57 @@ def _check_jsonl(
     progress_callback: CheckProgressCallback | None = None,
     total_bytes: int = 0,
 ) -> Dict[str, Any]:
+    # JSONL rules are the same for eval and fine-tune: skip blank lines, require a
+    # JSON object per non-empty line. Semantic checks run on the server after upload.
+    _ = purpose
     report_dict: Dict[str, Any] = {}
     report_dict.update(_check_utf8(file, progress_callback=progress_callback, total_bytes=total_bytes))
     if not report_dict["utf8"]:
         return report_dict
 
-    if purpose == "eval":
-        with file.open(encoding="utf-8", newline="") as f:
-            idx = -1
-            try:
-                for idx, line in _enumerate_lines(
-                    f, total_bytes=total_bytes, progress_callback=progress_callback, phase="jsonl"
-                ):
-                    json_line = json.loads(line)
+    with file.open(encoding="utf-8", newline="") as f:
+        line_index = -1
+        sample_count = 0
+        try:
+            for line_index, raw_line in _enumerate_lines(
+                f, total_bytes=total_bytes, progress_callback=progress_callback, phase="jsonl"
+            ):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                json_line = json.loads(line)
 
-                    if not isinstance(json_line, dict):
-                        raise InvalidFileFormatError(
-                            message=(
-                                f"Error parsing file. Invalid format on line {idx + 1} of the input file. "
-                                "Datasets must follow text, conversational, or instruction format. For more "
-                                "information, see https://docs.together.ai/docs/fine-tuning-data-preparation"
-                            ),
-                            line_number=idx + 1,
-                            error_source="line_type",
-                        )
-                report_dict.update(_check_samples_count(file, report_dict, idx))
-                report_dict["load_json"] = True
+                if not isinstance(json_line, dict):
+                    raise InvalidFileFormatError(
+                        message=(
+                            f"Error parsing file. Invalid format on line {line_index + 1} of the input file. "
+                            "Each line must be a JSON object. Dataset requirements are described at "
+                            "https://docs.together.ai/docs/fine-tuning-data-preparation. "
+                            "Full validation runs on the server after upload."
+                        ),
+                        line_number=line_index + 1,
+                        error_source="line_type",
+                    )
+                sample_count += 1
 
-            except InvalidFileFormatError as e:
-                report_dict["load_json"] = False
-                report_dict["is_check_passed"] = False
-                report_dict["message"] = e.message
-                if e.line_number is not None:
-                    report_dict["line_number"] = e.line_number
-                if e.error_source is not None:
-                    report_dict[e.error_source] = False
-            except ValueError:
-                report_dict["load_json"] = False
-                if idx < 0:
-                    report_dict["message"] = "Unable to decode file. File may be empty or in an unsupported format. "
-                else:
-                    report_dict["message"] = f"Error parsing json payload. Unexpected format on line {idx + 1}."
-                report_dict["is_check_passed"] = False
-    else:
-        # Fine-tuning (and non-eval): UTF-8, JSON-parse each non-empty line, require a JSON object per line.
-        # Semantic validation runs on the server after upload.
-        with file.open(encoding="utf-8", newline="") as f:
-            line_index = -1
-            sample_count = 0
-            try:
-                for line_index, raw_line in _enumerate_lines(
-                    f, total_bytes=total_bytes, progress_callback=progress_callback, phase="jsonl"
-                ):
-                    line = raw_line.strip()
-                    if not line:
-                        continue
-                    json_line = json.loads(line)
+            report_dict.update(_check_samples_count(file, report_dict, sample_count - 1 if sample_count else -1))
+            report_dict["load_json"] = True
 
-                    if not isinstance(json_line, dict):
-                        raise InvalidFileFormatError(
-                            message=(
-                                f"Error parsing file. Invalid format on line {line_index + 1} of the input file. "
-                                "Each line must be a JSON object. Dataset requirements are described at "
-                                "https://docs.together.ai/docs/fine-tuning-data-preparation. "
-                                "Full validation runs on the server after upload."
-                            ),
-                            line_number=line_index + 1,
-                            error_source="line_type",
-                        )
-                    sample_count += 1
-
-                report_dict.update(_check_samples_count(file, report_dict, sample_count - 1 if sample_count else -1))
-                report_dict["load_json"] = True
-
-            except InvalidFileFormatError as e:
-                report_dict["load_json"] = False
-                report_dict["is_check_passed"] = False
-                report_dict["message"] = e.message
-                if e.line_number is not None:
-                    report_dict["line_number"] = e.line_number
-                if e.error_source is not None:
-                    report_dict[e.error_source] = False
-            except ValueError:
-                report_dict["load_json"] = False
-                if line_index < 0:
-                    report_dict["message"] = "Unable to decode file. File may be empty or in an unsupported format. "
-                else:
-                    report_dict["message"] = f"Error parsing json payload. Unexpected format on line {line_index + 1}."
-                report_dict["is_check_passed"] = False
+        except InvalidFileFormatError as e:
+            report_dict["load_json"] = False
+            report_dict["is_check_passed"] = False
+            report_dict["message"] = e.message
+            if e.line_number is not None:
+                report_dict["line_number"] = e.line_number
+            if e.error_source is not None:
+                report_dict[e.error_source] = False
+        except ValueError:
+            report_dict["load_json"] = False
+            if line_index < 0:
+                report_dict["message"] = "Unable to decode file. File may be empty or in an unsupported format. "
+            else:
+                report_dict["message"] = f"Error parsing json payload. Unexpected format on line {line_index + 1}."
+            report_dict["is_check_passed"] = False
 
     if "text_field" not in report_dict:
         report_dict["text_field"] = True

--- a/src/together/lib/utils/files.py
+++ b/src/together/lib/utils/files.py
@@ -7,8 +7,6 @@ from typing import Any, Dict
 from pathlib import Path
 from traceback import format_exc
 
-from tqdm import tqdm
-
 from together.types import FilePurpose
 from together.lib.constants import (
     MIN_SAMPLES,
@@ -206,18 +204,11 @@ def _check_jsonl(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
     if not report_dict["utf8"]:
         return report_dict
 
-    DISABLE_TQDM = os.environ.get("TOGETHER_DISABLE_TQDM", "false").lower() == "true"
-
     if purpose == "eval":
         with file.open() as f:
             idx = -1
             try:
-                for idx, line in tqdm(
-                    enumerate(f),
-                    desc="Validating file",
-                    unit=" lines",
-                    disable=bool(DISABLE_TQDM),
-                ):
+                for idx, line in enumerate(f):
                     json_line = json.loads(line)
 
                     if not isinstance(json_line, dict):
@@ -255,12 +246,7 @@ def _check_jsonl(file: Path, purpose: FilePurpose | str) -> Dict[str, Any]:
             line_index = -1
             sample_count = 0
             try:
-                for line_index, raw_line in tqdm(
-                    enumerate(f),
-                    desc="Validating file",
-                    unit=" lines",
-                    disable=bool(DISABLE_TQDM),
-                ):
+                for line_index, raw_line in enumerate(f):
                     line = raw_line.strip()
                     if not line:
                         continue

--- a/src/together/resources/files.py
+++ b/src/together/resources/files.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import httpx
 
 from together.types import FilePurpose
-from together.lib.resources.files import FileAlreadyExistsError
+from together.lib.resources.files import FileAlreadyExistsError, UploadProgressCallback
 
 from ..lib import FileTypeError, UploadManager, AsyncUploadManager, check_file
 from ..types import FilePurpose
@@ -155,6 +155,7 @@ class FilesResource(SyncAPIResource):
         purpose: FilePurpose | str = "fine-tune",
         check: bool = True,
         raise_if_already_exists: bool = False,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
         if check:
             report_dict = check_file(file)
@@ -171,7 +172,7 @@ class FilesResource(SyncAPIResource):
 
         try:
             upload_manager = UploadManager(self._client)
-            result = upload_manager.upload("/files", file, purpose)
+            result = upload_manager.upload("/files", file, purpose, progress_callback=progress_callback)
 
             return FileResponse(
                 id=result.id,
@@ -341,6 +342,7 @@ class AsyncFilesResource(AsyncAPIResource):
         purpose: FilePurpose | str = "fine-tune",
         check: bool = True,
         raise_if_already_exists: bool = False,
+        progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
         if check:
             report_dict = check_file(file)
@@ -357,7 +359,7 @@ class AsyncFilesResource(AsyncAPIResource):
 
         try:
             upload_manager = AsyncUploadManager(self._client)
-            result = await upload_manager.upload("/files", file, purpose)
+            result = await upload_manager.upload("/files", file, purpose, progress_callback=progress_callback)
 
             return FileResponse(
                 id=result.id,

--- a/src/together/resources/files.py
+++ b/src/together/resources/files.py
@@ -157,11 +157,6 @@ class FilesResource(SyncAPIResource):
         raise_if_already_exists: bool = False,
         progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
-        if check:
-            report_dict = check_file(file)
-            if not report_dict["is_check_passed"]:
-                raise FileTypeError(f"Invalid file supplied, failed to upload. Report:\n{pformat(report_dict)}")
-
         if isinstance(file, str):
             file = Path(file)
 
@@ -169,6 +164,11 @@ class FilesResource(SyncAPIResource):
             raise ValueError(f"Invalid purpose '{purpose}'. Must be one of: {get_args(FilePurpose)}")
 
         purpose = cast(FilePurpose, purpose)
+
+        if check:
+            report_dict = check_file(file, purpose=purpose)
+            if not report_dict["is_check_passed"]:
+                raise FileTypeError(f"Invalid file supplied, failed to upload. Report:\n{pformat(report_dict)}")
 
         try:
             upload_manager = UploadManager(self._client)
@@ -344,11 +344,6 @@ class AsyncFilesResource(AsyncAPIResource):
         raise_if_already_exists: bool = False,
         progress_callback: UploadProgressCallback | None = None,
     ) -> FileResponse:
-        if check:
-            report_dict = check_file(file)
-            if not report_dict["is_check_passed"]:
-                raise FileTypeError(f"Invalid file supplied, failed to upload. Report:\n{pformat(report_dict)}")
-
         if isinstance(file, str):
             file = Path(file)
 
@@ -356,6 +351,11 @@ class AsyncFilesResource(AsyncAPIResource):
             raise ValueError(f"Invalid purpose '{purpose}'. Must be one of: {get_args(FilePurpose)}")
 
         purpose = cast(FilePurpose, purpose)
+
+        if check:
+            report_dict = check_file(file, purpose=purpose)
+            if not report_dict["is_check_passed"]:
+                raise FileTypeError(f"Invalid file supplied, failed to upload. Report:\n{pformat(report_dict)}")
 
         try:
             upload_manager = AsyncUploadManager(self._client)

--- a/tests/cli/test_files.py
+++ b/tests/cli/test_files.py
@@ -255,6 +255,17 @@ class TestFilesUpload:
         check_mock.assert_called_once()
         upload_mock.assert_not_called()
 
+    def test_upload_eval_jsonl_trailing_blank_passes_check(self, tmp_path: Path, cli_runner: CliRunner) -> None:
+        f = tmp_path / "data.jsonl"
+        f.write_text('{"text": "hello"}\n{"text": "world"}\n\n')
+        uploaded = _file_response(id="uploaded-id", purpose="eval")
+        with patch("together.resources.files.AsyncFilesResource.upload", new_callable=AsyncMock) as upload_mock:
+            upload_mock.return_value = uploaded
+            result = cli_runner.invoke(["files", "upload", str(f), "--purpose", "eval"])
+        assert result.exit_code == 0
+        upload_mock.assert_called_once()
+        assert "uploaded-id" in result.output
+
     def test_upload_does_not_check_if_disabled(self, tmp_path: Path, cli_runner: CliRunner) -> None:
         f = tmp_path / "data.jsonl"
         f.write_text("{}\n")

--- a/tests/cli/test_files.py
+++ b/tests/cli/test_files.py
@@ -269,4 +269,19 @@ class TestFilesUpload:
         upload_mock.assert_called_once()
         call_kw = upload_mock.call_args.kwargs
         assert call_kw["check"] is False
+        assert call_kw["progress_callback"] is not None
         assert "uploaded-id" in result.output
+
+    def test_upload_json_mode_disables_progress_callback(self, tmp_path: Path, cli_runner: CliRunner) -> None:
+        f = tmp_path / "data.jsonl"
+        f.write_text("{}\n")
+        uploaded = _file_response(id="uploaded-id", purpose="fine-tune")
+        with patch.object(_files_upload_cli, "check_file") as check_mock, patch(
+            "together.resources.files.AsyncFilesResource.upload", new_callable=AsyncMock
+        ) as upload_mock:
+            check_mock.return_value = {"is_check_passed": True}
+            upload_mock.return_value = uploaded
+            result = cli_runner.invoke(["files", "upload", str(f), "--json"])
+        assert result.exit_code == 0
+        call_kw = upload_mock.call_args.kwargs
+        assert call_kw["progress_callback"] is None

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -507,6 +507,73 @@ def test_check_file_reports_progress_callback(tmp_path: Path, monkeypatch: pytes
         phase_events = [event for event in events if event.phase == phase]
         assert phase_events[0].processed_bytes == 0
         assert phase_events[-1].processed_bytes == phase_events[-1].total_bytes == file.stat().st_size
+        assert any(0 < event.processed_bytes < event.total_bytes for event in phase_events)
+
+
+def test_check_csv_reports_progress_callback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("together.lib.utils.files.CHECK_PROGRESS_STEP_BYTES", 8)
+    file = tmp_path / "valid.csv"
+    with file.open("w") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["text"])
+        writer.writeheader()
+        for index in range(20):
+            writer.writerow({"text": f"row-{index}-{'x' * 16}"})
+
+    events: list[FileCheckProgress] = []
+    report = check_file(file, purpose="eval", progress_callback=events.append)
+
+    assert report["is_check_passed"]
+    assert {event.phase for event in events} == {"utf8", "csv"}
+    csv_events = [event for event in events if event.phase == "csv"]
+    assert csv_events[0].processed_bytes == 0
+    assert csv_events[-1].processed_bytes == csv_events[-1].total_bytes == file.stat().st_size
+    assert any(0 < event.processed_bytes < event.total_bytes for event in csv_events)
+
+
+def test_check_parquet_reports_progress_callback(tmp_path: Path) -> None:
+    pyarrow = pytest.importorskip("pyarrow")
+    parquet = pytest.importorskip("pyarrow.parquet")
+
+    file = tmp_path / "valid.parquet"
+    table = pyarrow.table(
+        {
+            "input_ids": [[1, 2], [3, 4]],
+            "attention_mask": [[1, 1], [1, 1]],
+            "labels": [[1, 2], [3, 4]],
+            "position_ids": [[0, 1], [0, 1]],
+        }
+    )
+    parquet.write_table(table, file)
+
+    events: list[FileCheckProgress] = []
+    report = check_file(file, progress_callback=events.append)
+
+    assert report["is_check_passed"]
+    parquet_events = [event for event in events if event.phase == "parquet"]
+    assert parquet_events
+    assert parquet_events[0].processed_bytes == 0
+    assert parquet_events[-1].processed_bytes == parquet_events[-1].total_bytes == file.stat().st_size
+
+
+def test_check_progress_tracker_does_not_reset_across_phases(tmp_path: Path) -> None:
+    from together.lib.cli.components.check_progress import CheckProgressTracker
+
+    file = tmp_path / "valid.jsonl"
+    file.write_bytes(b"x" * 100)
+    with CheckProgressTracker(file, enabled=True) as tracker:
+        callback = tracker.as_callback()
+        assert callback is not None
+        callback(FileCheckProgress(processed_bytes=0, total_bytes=100, phase="utf8"))
+        callback(FileCheckProgress(processed_bytes=100, total_bytes=100, phase="utf8"))
+        callback(FileCheckProgress(processed_bytes=0, total_bytes=100, phase="jsonl"))
+        assert tracker._progress is not None and tracker._task is not None
+        task = tracker._progress.tasks[tracker._task]
+        assert task.completed == 100
+        assert task.total == 200
+        callback(FileCheckProgress(processed_bytes=100, total_bytes=100, phase="jsonl"))
+        task = tracker._progress.tasks[tracker._task]
+        assert task.completed == 200
+        assert task.total == 200
 
 
 def test_should_show_check_progress(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -197,6 +197,18 @@ def test_check_jsonl_valid_conversational_multimodal_single_turn(tmp_path: Path)
     assert report["has_min_samples"]
 
 
+@pytest.mark.parametrize("purpose", ["fine-tune", "eval"])
+def test_check_jsonl_allows_trailing_blank_line(tmp_path: Path, purpose: str):
+    file = tmp_path / "trailing_blank.jsonl"
+    file.write_text('{"text": "hello"}\n{"text": "world"}\n\n')
+
+    report = check_file(file, purpose=purpose)
+
+    assert report["is_check_passed"]
+    assert report["num_samples"] == 2
+    assert report["load_json"] is True
+
+
 def test_check_jsonl_empty_file(tmp_path: Path):
     # Create an empty JSONL file
     file = tmp_path / "empty.jsonl"

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -576,6 +576,30 @@ def test_check_progress_tracker_does_not_reset_across_phases(tmp_path: Path) -> 
         assert task.total == 200
 
 
+def test_encoded_line_size_counts_crlf(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from together.lib.utils.files import _encoded_line_size
+
+    file = tmp_path / "crlf.jsonl"
+    line1 = b'{"text": "hello"}\r\n'
+    line2 = b'{"text": "world"}\r\n'
+    file.write_bytes(line1 + line2)
+
+    with file.open(encoding="utf-8") as handle:
+        first = handle.readline()
+        assert first.endswith("\n") and not first.endswith("\r\n")
+        assert _encoded_line_size(handle, first) == len(line1)
+
+    monkeypatch.setattr("together.lib.utils.files.CHECK_PROGRESS_STEP_BYTES", 1)
+    events: list[FileCheckProgress] = []
+    report = check_file(file, progress_callback=events.append)
+    assert report["is_check_passed"]
+    jsonl_events = [event for event in events if event.phase == "jsonl"]
+    mid = [event for event in jsonl_events if 0 < event.processed_bytes < event.total_bytes]
+    assert mid
+    assert mid[0].processed_bytes == len(line1)
+    assert jsonl_events[-1].processed_bytes == jsonl_events[-1].total_bytes == file.stat().st_size
+
+
 def test_should_show_check_progress(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from together.lib.cli.components import check_progress as check_progress_mod
     from together.lib.cli.components.check_progress import should_show_check_progress

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -573,19 +573,51 @@ def test_check_progress_tracker_does_not_reset_across_phases(tmp_path: Path) -> 
     file = tmp_path / "valid.jsonl"
     file.write_bytes(b"x" * 100)
     with CheckProgressTracker(file, enabled=True) as tracker:
+        assert tracker._progress is not None and tracker._task is not None
+        task = tracker._progress.tasks[tracker._task]
+        assert task.completed == 0
+        assert task.total == 200
+
         callback = tracker.as_callback()
         assert callback is not None
         callback(FileCheckProgress(processed_bytes=0, total_bytes=100, phase="utf8"))
+        task = tracker._progress.tasks[tracker._task]
+        assert task.completed == 0
+        assert task.total == 200
+
         callback(FileCheckProgress(processed_bytes=100, total_bytes=100, phase="utf8"))
-        callback(FileCheckProgress(processed_bytes=0, total_bytes=100, phase="jsonl"))
-        assert tracker._progress is not None and tracker._task is not None
         task = tracker._progress.tasks[tracker._task]
         assert task.completed == 100
         assert task.total == 200
+
+        callback(FileCheckProgress(processed_bytes=0, total_bytes=100, phase="jsonl"))
+        task = tracker._progress.tasks[tracker._task]
+        assert task.completed == 100
+        assert task.total == 200
+
         callback(FileCheckProgress(processed_bytes=100, total_bytes=100, phase="jsonl"))
         task = tracker._progress.tasks[tracker._task]
         assert task.completed == 200
         assert task.total == 200
+
+
+def test_check_progress_tracker_parquet_is_single_pass(tmp_path: Path) -> None:
+    from together.lib.cli.components.check_progress import CheckProgressTracker
+
+    file = tmp_path / "valid.parquet"
+    file.write_bytes(b"x" * 100)
+    with CheckProgressTracker(file, enabled=True) as tracker:
+        assert tracker._progress is not None and tracker._task is not None
+        callback = tracker.as_callback()
+        assert callback is not None
+        callback(FileCheckProgress(processed_bytes=0, total_bytes=100, phase="parquet"))
+        task = tracker._progress.tasks[tracker._task]
+        assert task.completed == 0
+        assert task.total == 100
+        callback(FileCheckProgress(processed_bytes=100, total_bytes=100, phase="parquet"))
+        task = tracker._progress.tasks[tracker._task]
+        assert task.completed == 100
+        assert task.total == 100
 
 
 def test_encoded_line_size_counts_crlf(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from together.lib.utils.files import check_file
+from together.lib.utils.files import FileCheckProgress, check_file
 
 
 def test_check_jsonl_valid_general(tmp_path: Path):
@@ -489,3 +489,50 @@ def test_check_file_unknown_extension(tmp_path: Path) -> None:
     assert not report["is_check_passed"]
     assert "Unknown extension" in report["message"]
     assert report["message"] == report["filetype"]
+
+
+def test_check_file_reports_progress_callback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("together.lib.utils.files.CHECK_PROGRESS_STEP_BYTES", 8)
+    file = tmp_path / "valid.jsonl"
+    content = [{"text": "Hello, world!"}, {"text": "How are you?"}]
+    file.write_text("\n".join(json.dumps(item) for item in content) + "\n")
+
+    events: list[FileCheckProgress] = []
+    report = check_file(file, progress_callback=events.append)
+
+    assert report["is_check_passed"]
+    assert events
+    assert {event.phase for event in events} == {"utf8", "jsonl"}
+    for phase in ("utf8", "jsonl"):
+        phase_events = [event for event in events if event.phase == phase]
+        assert phase_events[0].processed_bytes == 0
+        assert phase_events[-1].processed_bytes == phase_events[-1].total_bytes == file.stat().st_size
+
+
+def test_should_show_check_progress(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from together.lib.cli.components import check_progress as check_progress_mod
+    from together.lib.cli.components.check_progress import should_show_check_progress
+
+    class _Console:
+        is_terminal = True
+
+    monkeypatch.setattr(check_progress_mod, "console", _Console())
+    monkeypatch.setattr(check_progress_mod, "CHECK_PROGRESS_MIN_BYTES", 10)
+
+    missing = tmp_path / "missing.jsonl"
+    assert should_show_check_progress(missing, json_mode=False) is False
+
+    tiny = tmp_path / "tiny.jsonl"
+    tiny.write_text("{}\n")
+    assert should_show_check_progress(tiny, json_mode=False) is False
+
+    large = tmp_path / "large.jsonl"
+    large.write_bytes(b"x" * 10)
+    assert should_show_check_progress(large, json_mode=False) is True
+    assert should_show_check_progress(large, json_mode=True) is False
+
+    class _NonTerminalConsole:
+        is_terminal = False
+
+    monkeypatch.setattr(check_progress_mod, "console", _NonTerminalConsole())
+    assert should_show_check_progress(large, json_mode=False) is False

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import json
+from typing import cast
 from pathlib import Path
 
+import httpx
 import pytest
 from httpx import (
     Request,
@@ -8,14 +12,19 @@ from httpx import (
     SyncByteStream,
     AsyncByteStream,
 )
+from respx import MockRouter
 from pytest_mock import MockerFixture
+from respx.models import Call
 
 from together import Together, AsyncTogether
 from together.types import (
     FileResponse,
 )
+from together._exceptions import APIStatusError
 from together.lib.resources.files import (
     FileUploadProgress,
+    _put_file_content,
+    _aput_file_content,
     _validate_upload_file_id,
     _validate_upload_redirect_url,
 )
@@ -183,3 +192,210 @@ async def test_async_file_upload_reports_progress_callback(mocker: MockerFixture
     assert events
     assert events[0] == FileUploadProgress(uploaded_bytes=0, total_bytes=len(content_str.encode()))
     assert events[-1].uploaded_bytes == events[-1].total_bytes == len(content_str.encode())
+
+
+def _finalize_json(content_str: str, filename: str = "valid.jsonl") -> dict[str, object]:
+    return {
+        "id": "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
+        "bytes": len(content_str),
+        "created_at": 1234567890,
+        "filename": filename,
+        "FileType": "jsonl",
+        "purpose": "fine-tune",
+        "object": "file",
+        "Processed": True,
+    }
+
+
+@pytest.mark.respx
+def test_put_file_content_replays_body_on_307(respx_mock: MockRouter, tmp_path: Path) -> None:
+    file = tmp_path / "valid.jsonl"
+    payload = b'{"text": "hello"}\n'
+    file.write_bytes(payload)
+
+    first = respx_mock.put("https://s3.amazonaws.com/upload").mock(
+        return_value=httpx.Response(
+            307,
+            headers={"Location": "https://s3.us-west-2.amazonaws.com/upload"},
+        )
+    )
+    second = respx_mock.put("https://s3.us-west-2.amazonaws.com/upload").mock(return_value=httpx.Response(200))
+
+    with httpx.Client(follow_redirects=True) as client:
+        response = _put_file_content(
+            client,
+            "https://s3.amazonaws.com/upload",
+            file,
+            file_size=len(payload),
+        )
+
+    assert response.status_code == 200
+    assert first.call_count == 1
+    assert second.call_count == 1
+    first_request = cast(Call, first.calls[0]).request
+    second_request = cast(Call, second.calls[0]).request
+    assert first_request.content == payload
+    assert second_request.content == payload
+    assert first_request.headers["Content-Length"] == str(len(payload))
+    assert second_request.headers["Content-Length"] == str(len(payload))
+
+
+@pytest.mark.respx
+async def test_aput_file_content_replays_body_on_307(respx_mock: MockRouter, tmp_path: Path) -> None:
+    file = tmp_path / "valid.jsonl"
+    payload = b'{"text": "hello"}\n'
+    file.write_bytes(payload)
+
+    first = respx_mock.put("https://s3.amazonaws.com/upload").mock(
+        return_value=httpx.Response(
+            307,
+            headers={"Location": "https://s3.us-west-2.amazonaws.com/upload"},
+        )
+    )
+    second = respx_mock.put("https://s3.us-west-2.amazonaws.com/upload").mock(return_value=httpx.Response(200))
+
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        response = await _aput_file_content(
+            client,
+            "https://s3.amazonaws.com/upload",
+            file,
+            file_size=len(payload),
+        )
+
+    assert response.status_code == 200
+    assert first.call_count == 1
+    assert second.call_count == 1
+    assert cast(Call, first.calls[0]).request.content == payload
+    assert cast(Call, second.calls[0]).request.content == payload
+
+
+@pytest.mark.respx
+def test_put_file_content_rejects_unsafe_redirect(respx_mock: MockRouter, tmp_path: Path) -> None:
+    file = tmp_path / "valid.jsonl"
+    payload = b'{"text": "hello"}\n'
+    file.write_bytes(payload)
+
+    respx_mock.put("https://s3.amazonaws.com/upload").mock(
+        return_value=httpx.Response(307, headers={"Location": "https://127.0.0.1/steal"})
+    )
+
+    with httpx.Client(follow_redirects=True) as client:
+        with pytest.raises(APIStatusError, match="non-public address"):
+            _put_file_content(
+                client,
+                "https://s3.amazonaws.com/upload",
+                file,
+                file_size=len(payload),
+            )
+
+
+def test_file_upload_follows_storage_307(mocker: MockerFixture, tmp_path: Path) -> None:
+    content_str = json.dumps({"text": "Hello, world!"}) + "\n"
+    content_bytes = content_str.encode()
+    mock_request = mocker.MagicMock()
+    mock_request.headers = {}
+    responses = [
+        Response(
+            status_code=302,
+            headers={
+                "Location": "https://s3.amazonaws.com/upload",
+                "X-Together-File-Id": "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
+            },
+            request=mock_request,
+        ),
+        Response(
+            status_code=307,
+            headers={"Location": "https://s3.us-west-2.amazonaws.com/upload"},
+            request=mock_request,
+        ),
+        Response(status_code=200, request=mock_request),
+        Response(status_code=200, json=_finalize_json(content_str), request=mock_request),
+    ]
+    put_urls: list[str] = []
+    put_bodies: list[bytes] = []
+    put_follow_redirects: list[object] = []
+
+    def send_and_consume(request: Request, *args: object, **kwargs: object) -> Response:  # noqa: ARG001
+        stream = request.stream
+        if request.method == "PUT":
+            put_urls.append(str(request.url))
+            put_follow_redirects.append(kwargs.get("follow_redirects"))
+            chunks: list[bytes] = []
+            if isinstance(stream, SyncByteStream):
+                for chunk in stream:
+                    chunks.append(chunk)
+                stream.close()
+            put_bodies.append(b"".join(chunks))
+        return responses.pop(0)
+
+    client = Together(api_key="fake_api_key")
+    mocker.patch.object(client._client, "send", side_effect=send_and_consume)
+
+    file = tmp_path / "valid.jsonl"
+    file.write_text(content_str)
+
+    response = client.files.upload(file, purpose="fine-tune")
+
+    assert isinstance(response, FileResponse)
+    assert put_urls == [
+        "https://s3.amazonaws.com/upload",
+        "https://s3.us-west-2.amazonaws.com/upload",
+    ]
+    assert put_bodies == [content_bytes, content_bytes]
+    assert put_follow_redirects == [False, False]
+
+
+async def test_async_file_upload_follows_storage_307(mocker: MockerFixture, tmp_path: Path) -> None:
+    content_str = json.dumps({"text": "Hello, world!"}) + "\n"
+    content_bytes = content_str.encode()
+    mock_request = mocker.MagicMock()
+    mock_request.headers = {}
+    responses = [
+        Response(
+            status_code=302,
+            headers={
+                "Location": "https://s3.amazonaws.com/upload",
+                "X-Together-File-Id": "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
+            },
+            request=mock_request,
+        ),
+        Response(
+            status_code=307,
+            headers={"Location": "https://s3.us-west-2.amazonaws.com/upload"},
+            request=mock_request,
+        ),
+        Response(status_code=200, request=mock_request),
+        Response(status_code=200, json=_finalize_json(content_str), request=mock_request),
+    ]
+    put_urls: list[str] = []
+    put_bodies: list[bytes] = []
+
+    async def send_and_consume(request: Request, *args: object, **kwargs: object) -> Response:  # noqa: ARG001
+        stream = request.stream
+        if request.method == "PUT":
+            put_urls.append(str(request.url))
+            assert kwargs.get("follow_redirects") is False
+            chunks: list[bytes] = []
+            if isinstance(stream, AsyncByteStream):
+                async for chunk in stream:
+                    chunks.append(chunk)
+                await stream.aclose()
+            else:
+                raise AssertionError(f"Expected AsyncByteStream, got {type(stream)!r}")
+            put_bodies.append(b"".join(chunks))
+        return responses.pop(0)
+
+    client = AsyncTogether(api_key="fake_api_key")
+    mocker.patch.object(client._client, "send", side_effect=send_and_consume)
+
+    file = tmp_path / "valid.jsonl"
+    file.write_text(content_str)
+
+    response = await client.files.upload(file, purpose="fine-tune")
+
+    assert isinstance(response, FileResponse)
+    assert put_urls == [
+        "https://s3.amazonaws.com/upload",
+        "https://s3.us-west-2.amazonaws.com/upload",
+    ]
+    assert put_bodies == [content_bytes, content_bytes]

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -26,6 +26,7 @@ from together.lib.resources.files import (
     _put_file_content,
     _aput_file_content,
     _validate_upload_file_id,
+    _validate_upload_server_url,
     _allow_http_upload_redirects,
     _validate_upload_redirect_url,
 )
@@ -112,6 +113,10 @@ def test_file_upload(mocker: MockerFixture, tmp_path: Path):
         ("https://10.0.0.5/upload", False),
         ("https://2130706433/x", False),
         ("https://0x7f000001/x", False),
+        ("https://127.1/steal", False),
+        ("https://127.0.1/steal", False),
+        ("https://0177.0.0.1/steal", False),
+        ("https://0x7f.0.0.1/steal", False),
         ("https://[::ffff:127.0.0.1]/x", False),
         ("https://[::1]/upload", False),
     ],
@@ -137,6 +142,17 @@ def test_validate_upload_redirect_url_allows_http_when_requested():
         _validate_upload_redirect_url("http://metadata.google.internal/upload", allow_http=True)
 
 
+def test_validate_upload_server_url_allows_private_http_storage():
+    assert _validate_upload_server_url("https://10.0.0.5:9000/upload") == "https://10.0.0.5:9000/upload"
+    assert _validate_upload_server_url("http://127.0.0.1:9000/upload") == "http://127.0.0.1:9000/upload"
+    assert _validate_upload_server_url("http://localhost:9000/upload") == "http://localhost:9000/upload"
+    assert _validate_upload_server_url("https://127.1/upload") == "https://127.1/upload"
+    with pytest.raises(ValueError, match="local host"):
+        _validate_upload_server_url("http://metadata.google.internal/upload")
+    with pytest.raises(ValueError, match="non-HTTPS"):
+        _validate_upload_redirect_url("http://10.0.0.5/upload", allow_non_public=True)
+
+
 def test_allow_http_upload_redirects_from_client_and_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS", raising=False)
 
@@ -155,6 +171,10 @@ def test_allow_http_upload_redirects_from_client_and_env(monkeypatch: pytest.Mon
     [
         "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
         "file-abc123def456ghi789",
+        "file_abc123def456",
+        "file-foo.bar",
+        "preprocess",
+        "ft-abc_123.def",
     ],
 )
 def test_validate_upload_file_id_accepts_together_ids(file_id: str):
@@ -170,8 +190,8 @@ def test_validate_upload_file_id_accepts_together_ids(file_id: str):
         "file-../evil",
         "file?x=1",
         "file-foo/bar",
-        "file-foo.bar",
-        "preprocess",
+        "file-foo\\bar",
+        ".",
     ],
 )
 def test_validate_upload_file_id_rejects_traversal(file_id: str):
@@ -510,3 +530,54 @@ async def test_async_file_upload_follows_storage_307(mocker: MockerFixture, tmp_
         "https://s3.us-west-2.amazonaws.com/upload",
     ]
     assert put_bodies == [content_bytes, content_bytes]
+
+
+@pytest.mark.respx
+def test_put_file_content_rejects_abbreviated_loopback_redirect(respx_mock: MockRouter, tmp_path: Path) -> None:
+    file = tmp_path / "valid.jsonl"
+    payload = b'{"text": "hello"}\n'
+    file.write_bytes(payload)
+
+    respx_mock.put("https://s3.amazonaws.com/upload").mock(
+        return_value=httpx.Response(307, headers={"Location": "https://127.1/steal"})
+    )
+
+    with httpx.Client(follow_redirects=True) as client:
+        with pytest.raises(APIStatusError, match="non-public address"):
+            _put_file_content(
+                client,
+                "https://s3.amazonaws.com/upload",
+                file,
+                file_size=len(payload),
+            )
+
+
+@pytest.mark.respx
+def test_put_file_content_survives_file_growth_between_redirects(respx_mock: MockRouter, tmp_path: Path) -> None:
+    file = tmp_path / "valid.jsonl"
+    payload = b'{"text": "hello"}\n'
+    extra = b'{"text": "more"}\n'
+    file.write_bytes(payload)
+
+    def grow_then_redirect(_request: httpx.Request) -> httpx.Response:
+        file.write_bytes(payload + extra)
+        return httpx.Response(307, headers={"Location": "https://s3.us-west-2.amazonaws.com/upload"})
+
+    first = respx_mock.put("https://s3.amazonaws.com/upload").mock(side_effect=grow_then_redirect)
+    second = respx_mock.put("https://s3.us-west-2.amazonaws.com/upload").mock(return_value=httpx.Response(200))
+
+    with httpx.Client(follow_redirects=True) as client:
+        response = _put_file_content(
+            client,
+            "https://s3.amazonaws.com/upload",
+            file,
+            file_size=len(payload),
+        )
+
+    assert response.status_code == 200
+    first_request = cast(Call, first.calls[0]).request
+    second_request = cast(Call, second.calls[0]).request
+    assert first_request.content == payload
+    assert first_request.headers["Content-Length"] == str(len(payload))
+    assert second_request.content == payload + extra
+    assert second_request.headers["Content-Length"] == str(len(payload) + len(extra))

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -10,6 +10,40 @@ from together import Together
 from together.types import (
     FileResponse,
 )
+from together.lib.resources.files import FileUploadProgress
+
+
+def _mock_upload_responses(mocker: MockerFixture, *, content_str: str, filename: str = "valid.jsonl"):
+    mock_request = mocker.MagicMock()
+    mock_request.headers = {}  # response.request headers have to be set otherwise it will confuse the framework and not parse the response into an object
+
+    mock_presigned_response = Response(
+        status_code=302,
+        headers={
+            "Location": "https://mock-presigned-url.com",
+            "X-Together-File-Id": "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
+        },
+        request=mock_request,
+    )
+    mock_upload_response = Response(
+        status_code=200,
+        request=mock_request,
+    )
+    mock_finalize_response = Response(
+        status_code=200,
+        json={
+            "id": "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
+            "bytes": len(content_str),
+            "created_at": 1234567890,
+            "filename": filename,
+            "FileType": "jsonl",
+            "purpose": "fine-tune",
+            "object": "file",
+            "Processed": True,
+        },
+        request=mock_request,
+    )
+    return [mock_presigned_response, mock_upload_response, mock_finalize_response]
 
 
 def test_file_upload(mocker: MockerFixture, tmp_path: Path):
@@ -19,43 +53,8 @@ def test_file_upload(mocker: MockerFixture, tmp_path: Path):
     content_str = "\n".join(json.dumps(item) for item in content)
     content_bytes = content_str.encode()
 
-    mock_request = mocker.MagicMock()
-    mock_request.headers = {}  # response.request headers have to be set otherwise it will confuse the framework and not parse the response into an object
-
-    # Mock response 1: POST /files (get presigned URL)
-    mock_presigned_response = Response(
-        status_code=302,
-        headers={
-            "Location": "https://mock-presigned-url.com",
-            "X-Together-File-Id": "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
-        },
-        request=mock_request,
-    )
-
-    # Mock response 2: PUT to presigned URL (upload file)
-    mock_upload_response = Response(
-        status_code=200,
-        request=mock_request,
-    )
-
-    # Mock response 3: POST /files/{file_id}/preprocess (finalize)
-    mock_finalize_response = Response(
-        status_code=200,
-        json={
-            "id": "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
-            "bytes": len(content_str),
-            "created_at": 1234567890,
-            "filename": "valid.jsonl",
-            "FileType": "jsonl",
-            "purpose": "fine-tune",
-            "object": "file",
-            "Processed": True,
-        },
-        request=mock_request,
-    )
-
     mock_send_requestor = mocker.MagicMock()
-    mock_send_requestor.side_effect = [mock_presigned_response, mock_upload_response, mock_finalize_response]
+    mock_send_requestor.side_effect = _mock_upload_responses(mocker, content_str=content_str)
 
     # Mock the post method directly on the client
     client = Together(api_key="fake_api_key")
@@ -82,3 +81,36 @@ def test_file_upload(mocker: MockerFixture, tmp_path: Path):
     assert response.object == "file"
     assert response.processed == True
     assert response.purpose == "fine-tune"
+
+
+def test_file_upload_reports_progress_without_tqdm(mocker: MockerFixture, tmp_path: Path):
+    content_str = json.dumps({"text": "Hello, world!"}) + "\n"
+    responses = _mock_upload_responses(mocker, content_str=content_str)
+
+    def send_and_consume(request, *args, **kwargs):  # noqa: ARG001
+        # Consume streamed upload bodies so progress callbacks fire under the mock.
+        if request.stream is not None:
+            for _ in request.stream:
+                pass
+            request.stream.close()
+        return responses.pop(0)
+
+    client = Together(api_key="fake_api_key")
+    mocker.patch.object(client._client, "send", side_effect=send_and_consume)
+    tqdm_spy = mocker.patch("together.lib.resources.files.tqdm")
+
+    file = tmp_path / "valid.jsonl"
+    file.write_text(content_str)
+
+    events: list[FileUploadProgress] = []
+    response = client.files.upload(
+        file,
+        purpose="fine-tune",
+        progress_callback=events.append,
+    )
+
+    assert isinstance(response, FileResponse)
+    assert events
+    assert events[0] == FileUploadProgress(uploaded_bytes=0, total_bytes=len(content_str.encode()))
+    assert events[-1].uploaded_bytes == events[-1].total_bytes == len(content_str.encode())
+    tqdm_spy.assert_not_called()

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -102,6 +102,43 @@ def test_file_upload(mocker: MockerFixture, tmp_path: Path):
     assert response.purpose == "fine-tune"
 
 
+def test_file_upload_eval_jsonl_allows_trailing_blank(mocker: MockerFixture, tmp_path: Path):
+    content = [{"text": "Hello, world!"}, {"text": "How are you?"}]
+    content_str = "\n".join(json.dumps(item) for item in content) + "\n\n"
+    content_bytes = content_str.encode()
+
+    mock_send_requestor = mocker.MagicMock()
+    mock_send_requestor.side_effect = _mock_upload_responses(mocker, content_str=content_str)
+
+    client = Together(api_key="fake_api_key")
+    mocker.patch.object(client._client, "send", mock_send_requestor)
+
+    file = tmp_path / "valid.jsonl"
+    file.write_bytes(content_bytes)
+
+    response = client.files.upload(file, purpose="eval")
+
+    assert isinstance(response, FileResponse)
+    assert response.filename == "valid.jsonl"
+
+
+def test_file_upload_eval_csv(mocker: MockerFixture, tmp_path: Path):
+    content_str = "text\nhello\nworld\n"
+    mock_send_requestor = mocker.MagicMock()
+    mock_send_requestor.side_effect = _mock_upload_responses(mocker, content_str=content_str, filename="data.csv")
+
+    client = Together(api_key="fake_api_key")
+    mocker.patch.object(client._client, "send", mock_send_requestor)
+
+    file = tmp_path / "data.csv"
+    file.write_text(content_str)
+
+    response = client.files.upload(file, purpose="eval")
+
+    assert isinstance(response, FileResponse)
+    assert response.filename == "data.csv"
+
+
 @pytest.mark.parametrize(
     ("url", "should_pass"),
     [

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -127,8 +127,14 @@ def test_validate_upload_redirect_url(url: str, should_pass: bool):
 def test_validate_upload_redirect_url_allows_http_when_requested():
     http_url = "http://bucket.s3.us-west-2.amazonaws.com/key"
     assert _validate_upload_redirect_url(http_url, allow_http=True) == http_url
-    with pytest.raises(ValueError, match="non-public address"):
-        _validate_upload_redirect_url("http://127.0.0.1/upload", allow_http=True)
+    assert (
+        _validate_upload_redirect_url("http://127.0.0.1:9000/upload", allow_http=True) == "http://127.0.0.1:9000/upload"
+    )
+    assert (
+        _validate_upload_redirect_url("http://localhost:9000/upload", allow_http=True) == "http://localhost:9000/upload"
+    )
+    with pytest.raises(ValueError, match="local host"):
+        _validate_upload_redirect_url("http://metadata.google.internal/upload", allow_http=True)
 
 
 def test_allow_http_upload_redirects_from_client_and_env(monkeypatch: pytest.MonkeyPatch):
@@ -254,14 +260,15 @@ def _finalize_json(content_str: str, filename: str = "valid.jsonl") -> dict[str,
 
 
 @pytest.mark.respx
-def test_put_file_content_replays_body_on_307(respx_mock: MockRouter, tmp_path: Path) -> None:
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+def test_put_file_content_replays_body_on_redirect(status: int, respx_mock: MockRouter, tmp_path: Path) -> None:
     file = tmp_path / "valid.jsonl"
     payload = b'{"text": "hello"}\n'
     file.write_bytes(payload)
 
     first = respx_mock.put("https://s3.amazonaws.com/upload").mock(
         return_value=httpx.Response(
-            307,
+            status,
             headers={"Location": "https://s3.us-west-2.amazonaws.com/upload"},
         )
     )
@@ -287,14 +294,15 @@ def test_put_file_content_replays_body_on_307(respx_mock: MockRouter, tmp_path: 
 
 
 @pytest.mark.respx
-async def test_aput_file_content_replays_body_on_307(respx_mock: MockRouter, tmp_path: Path) -> None:
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+async def test_aput_file_content_replays_body_on_redirect(status: int, respx_mock: MockRouter, tmp_path: Path) -> None:
     file = tmp_path / "valid.jsonl"
     payload = b'{"text": "hello"}\n'
     file.write_bytes(payload)
 
     first = respx_mock.put("https://s3.amazonaws.com/upload").mock(
         return_value=httpx.Response(
-            307,
+            status,
             headers={"Location": "https://s3.us-west-2.amazonaws.com/upload"},
         )
     )
@@ -333,6 +341,63 @@ def test_put_file_content_rejects_unsafe_redirect(respx_mock: MockRouter, tmp_pa
                 file,
                 file_size=len(payload),
             )
+
+
+@pytest.mark.respx
+def test_put_file_content_allows_local_redirect_when_requested(respx_mock: MockRouter, tmp_path: Path) -> None:
+    file = tmp_path / "valid.jsonl"
+    payload = b'{"text": "hello"}\n'
+    file.write_bytes(payload)
+
+    respx_mock.put("http://127.0.0.1:9000/upload").mock(
+        return_value=httpx.Response(
+            302,
+            headers={"Location": "http://127.0.0.1:9000/data"},
+        )
+    )
+    respx_mock.put("http://127.0.0.1:9000/data").mock(return_value=httpx.Response(200))
+
+    with httpx.Client(follow_redirects=True) as client:
+        response = _put_file_content(
+            client,
+            "http://127.0.0.1:9000/upload",
+            file,
+            file_size=len(payload),
+            allow_http=True,
+        )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.respx
+def test_put_file_content_progress_does_not_rewind_on_redirect(respx_mock: MockRouter, tmp_path: Path) -> None:
+    file = tmp_path / "valid.jsonl"
+    payload = b'{"text": "hello"}\n' * 8
+    file.write_bytes(payload)
+
+    respx_mock.put("https://s3.amazonaws.com/upload").mock(
+        return_value=httpx.Response(
+            307,
+            headers={"Location": "https://s3.us-west-2.amazonaws.com/upload"},
+        )
+    )
+    respx_mock.put("https://s3.us-west-2.amazonaws.com/upload").mock(return_value=httpx.Response(200))
+
+    events: list[FileUploadProgress] = []
+    with httpx.Client(follow_redirects=True) as client:
+        response = _put_file_content(
+            client,
+            "https://s3.amazonaws.com/upload",
+            file,
+            file_size=len(payload),
+            progress_callback=events.append,
+        )
+
+    assert response.status_code == 200
+    uploaded = [event.uploaded_bytes for event in events]
+    assert uploaded == sorted(uploaded)
+    assert events[0].uploaded_bytes == 0
+    assert events[-1].uploaded_bytes == events[-1].total_bytes == len(payload)
 
 
 def test_file_upload_follows_storage_307(mocker: MockerFixture, tmp_path: Path) -> None:

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -5,10 +5,11 @@ from httpx import (
     Request,
     Response,
     SyncByteStream,
+    AsyncByteStream,
 )
 from pytest_mock import MockerFixture
 
-from together import Together
+from together import Together, AsyncTogether
 from together.types import (
     FileResponse,
 )
@@ -106,6 +107,41 @@ def test_file_upload_reports_progress_callback(mocker: MockerFixture, tmp_path: 
 
     events: list[FileUploadProgress] = []
     response = client.files.upload(
+        file,
+        purpose="fine-tune",
+        progress_callback=events.append,
+    )
+
+    assert isinstance(response, FileResponse)
+    assert events
+    assert events[0] == FileUploadProgress(uploaded_bytes=0, total_bytes=len(content_str.encode()))
+    assert events[-1].uploaded_bytes == events[-1].total_bytes == len(content_str.encode())
+
+
+async def test_async_file_upload_reports_progress_callback(mocker: MockerFixture, tmp_path: Path):
+    content_str = json.dumps({"text": "Hello, world!"}) + "\n"
+    responses = _mock_upload_responses(mocker, content_str=content_str)
+
+    async def send_and_consume(request: Request, *args: object, **kwargs: object) -> Response:  # noqa: ARG001
+        # Consume streamed upload bodies so progress callbacks fire under the mock.
+        # Also asserts AsyncClient gets an AsyncByteStream (sync iterators raise RuntimeError).
+        stream = request.stream
+        if isinstance(stream, AsyncByteStream):
+            async for _chunk in stream:
+                pass
+            await stream.aclose()
+        else:
+            raise AssertionError(f"Expected AsyncByteStream, got {type(stream)!r}")
+        return responses.pop(0)
+
+    client = AsyncTogether(api_key="fake_api_key")
+    mocker.patch.object(client._client, "send", side_effect=send_and_consume)
+
+    file = tmp_path / "valid.jsonl"
+    file.write_text(content_str)
+
+    events: list[FileUploadProgress] = []
+    response = await client.files.upload(
         file,
         purpose="fine-tune",
         progress_callback=events.append,

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -119,12 +119,33 @@ def test_validate_upload_redirect_url(url: str, should_pass: bool):
             _validate_upload_redirect_url(url)
 
 
-def test_validate_upload_file_id():
-    assert _validate_upload_file_id("file-30b2f515-c146-4780-80e6-d8a84f4caaaa").startswith("file-")
-    with pytest.raises(ValueError):
-        _validate_upload_file_id("../evil")
-    with pytest.raises(ValueError):
-        _validate_upload_file_id("file?x=1")
+@pytest.mark.parametrize(
+    "file_id",
+    [
+        "file-30b2f515-c146-4780-80e6-d8a84f4caaaa",
+        "file-abc123def456ghi789",
+    ],
+)
+def test_validate_upload_file_id_accepts_together_ids(file_id: str):
+    assert _validate_upload_file_id(file_id) == file_id
+
+
+@pytest.mark.parametrize(
+    "file_id",
+    [
+        "..",
+        ".",
+        "../evil",
+        "file-../evil",
+        "file?x=1",
+        "file-foo/bar",
+        "file-foo.bar",
+        "preprocess",
+    ],
+)
+def test_validate_upload_file_id_rejects_traversal(file_id: str):
+    with pytest.raises(ValueError, match="Invalid upload file id"):
+        _validate_upload_file_id(file_id)
 
 
 def test_file_upload_reports_progress_callback(mocker: MockerFixture, tmp_path: Path):

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -2,7 +2,9 @@ import json
 from pathlib import Path
 
 from httpx import (
+    Request,
     Response,
+    SyncByteStream,
 )
 from pytest_mock import MockerFixture
 
@@ -87,12 +89,13 @@ def test_file_upload_reports_progress_callback(mocker: MockerFixture, tmp_path: 
     content_str = json.dumps({"text": "Hello, world!"}) + "\n"
     responses = _mock_upload_responses(mocker, content_str=content_str)
 
-    def send_and_consume(request, *args, **kwargs):  # noqa: ARG001
+    def send_and_consume(request: Request, *args: object, **kwargs: object) -> Response:  # noqa: ARG001
         # Consume streamed upload bodies so progress callbacks fire under the mock.
-        if request.stream is not None:
-            for _ in request.stream:
+        stream = request.stream
+        if isinstance(stream, SyncByteStream):
+            for _chunk in stream:
                 pass
-            request.stream.close()
+            stream.close()
         return responses.pop(0)
 
     client = Together(api_key="fake_api_key")

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from httpx import (
     Request,
     Response,
@@ -13,7 +14,11 @@ from together import Together, AsyncTogether
 from together.types import (
     FileResponse,
 )
-from together.lib.resources.files import FileUploadProgress
+from together.lib.resources.files import (
+    FileUploadProgress,
+    _validate_upload_file_id,
+    _validate_upload_redirect_url,
+)
 
 
 def _mock_upload_responses(mocker: MockerFixture, *, content_str: str, filename: str = "valid.jsonl"):
@@ -84,6 +89,33 @@ def test_file_upload(mocker: MockerFixture, tmp_path: Path):
     assert response.object == "file"
     assert response.processed == True
     assert response.purpose == "fine-tune"
+
+
+@pytest.mark.parametrize(
+    ("url", "should_pass"),
+    [
+        ("https://bucket.s3.us-west-2.amazonaws.com/key", True),
+        ("https://mock-presigned-url.com/upload", True),
+        ("http://bucket.s3.amazonaws.com/key", False),
+        ("https://127.0.0.1/upload", False),
+        ("https://localhost/upload", False),
+        ("https://10.0.0.5/upload", False),
+    ],
+)
+def test_validate_upload_redirect_url(url: str, should_pass: bool):
+    if should_pass:
+        assert _validate_upload_redirect_url(url) == url
+    else:
+        with pytest.raises(ValueError):
+            _validate_upload_redirect_url(url)
+
+
+def test_validate_upload_file_id():
+    assert _validate_upload_file_id("file-30b2f515-c146-4780-80e6-d8a84f4caaaa").startswith("file-")
+    with pytest.raises(ValueError):
+        _validate_upload_file_id("../evil")
+    with pytest.raises(ValueError):
+        _validate_upload_file_id("file?x=1")
 
 
 def test_file_upload_reports_progress_callback(mocker: MockerFixture, tmp_path: Path):

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -83,7 +83,7 @@ def test_file_upload(mocker: MockerFixture, tmp_path: Path):
     assert response.purpose == "fine-tune"
 
 
-def test_file_upload_reports_progress_without_tqdm(mocker: MockerFixture, tmp_path: Path):
+def test_file_upload_reports_progress_callback(mocker: MockerFixture, tmp_path: Path):
     content_str = json.dumps({"text": "Hello, world!"}) + "\n"
     responses = _mock_upload_responses(mocker, content_str=content_str)
 
@@ -97,7 +97,6 @@ def test_file_upload_reports_progress_without_tqdm(mocker: MockerFixture, tmp_pa
 
     client = Together(api_key="fake_api_key")
     mocker.patch.object(client._client, "send", side_effect=send_and_consume)
-    tqdm_spy = mocker.patch("together.lib.resources.files.tqdm")
 
     file = tmp_path / "valid.jsonl"
     file.write_text(content_str)
@@ -113,4 +112,3 @@ def test_file_upload_reports_progress_without_tqdm(mocker: MockerFixture, tmp_pa
     assert events
     assert events[0] == FileUploadProgress(uploaded_bytes=0, total_bytes=len(content_str.encode()))
     assert events[-1].uploaded_bytes == events[-1].total_bytes == len(content_str.encode())
-    tqdm_spy.assert_not_called()

--- a/tests/unit/test_files_resource.py
+++ b/tests/unit/test_files_resource.py
@@ -26,6 +26,7 @@ from together.lib.resources.files import (
     _put_file_content,
     _aput_file_content,
     _validate_upload_file_id,
+    _allow_http_upload_redirects,
     _validate_upload_redirect_url,
 )
 
@@ -109,6 +110,10 @@ def test_file_upload(mocker: MockerFixture, tmp_path: Path):
         ("https://127.0.0.1/upload", False),
         ("https://localhost/upload", False),
         ("https://10.0.0.5/upload", False),
+        ("https://2130706433/x", False),
+        ("https://0x7f000001/x", False),
+        ("https://[::ffff:127.0.0.1]/x", False),
+        ("https://[::1]/upload", False),
     ],
 )
 def test_validate_upload_redirect_url(url: str, should_pass: bool):
@@ -117,6 +122,26 @@ def test_validate_upload_redirect_url(url: str, should_pass: bool):
     else:
         with pytest.raises(ValueError):
             _validate_upload_redirect_url(url)
+
+
+def test_validate_upload_redirect_url_allows_http_when_requested():
+    http_url = "http://bucket.s3.us-west-2.amazonaws.com/key"
+    assert _validate_upload_redirect_url(http_url, allow_http=True) == http_url
+    with pytest.raises(ValueError, match="non-public address"):
+        _validate_upload_redirect_url("http://127.0.0.1/upload", allow_http=True)
+
+
+def test_allow_http_upload_redirects_from_client_and_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS", raising=False)
+
+    https_client = Together(api_key="fake_api_key")
+    assert _allow_http_upload_redirects(https_client) is False
+
+    http_client = Together(api_key="fake_api_key", base_url="http://127.0.0.1:4010")
+    assert _allow_http_upload_redirects(http_client) is True
+
+    monkeypatch.setenv("TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS", "1")
+    assert _allow_http_upload_redirects(https_client) is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_upload_progress.py
+++ b/tests/unit/test_upload_progress.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+from pathlib import Path
+
+import pytest
+
+from together.lib import FileTypeError
+from together.lib.cli.components.upload_progress import upload_file_with_progress
+
+
+async def test_upload_file_with_progress_validates_before_upload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file = tmp_path / "data.jsonl"
+    file.write_text('{"text": "hello"}\n')
+    order: list[str] = []
+
+    def fake_check_file(*_args: object, **_kwargs: object) -> dict[str, Any]:
+        order.append("check")
+        return {"is_check_passed": True, "message": "Checks passed"}
+
+    async def fake_upload(**kwargs: object) -> str:
+        order.append("upload")
+        assert kwargs["check"] is False
+        return "ok"
+
+    monkeypatch.setattr("together.lib.cli.components.upload_progress.check_file", fake_check_file)
+
+    result = await upload_file_with_progress(fake_upload, file, enabled=False, description="Uploading")
+    assert result == "ok"
+    assert order == ["check", "upload"]
+
+
+async def test_upload_file_with_progress_skips_check_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file = tmp_path / "data.jsonl"
+    file.write_text('{"text": "hello"}\n')
+
+    def fake_check_file(*_args: object, **_kwargs: object) -> dict[str, Any]:
+        raise AssertionError("check_file should not run when check=False")
+
+    async def fake_upload(**kwargs: object) -> str:
+        assert kwargs["check"] is False
+        return "ok"
+
+    monkeypatch.setattr("together.lib.cli.components.upload_progress.check_file", fake_check_file)
+
+    result = await upload_file_with_progress(fake_upload, file, enabled=False, check=False)
+    assert result == "ok"
+
+
+async def test_upload_file_with_progress_failed_check_does_not_upload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file = tmp_path / "data.jsonl"
+    file.write_text("{}\n")
+    uploaded = False
+
+    def fake_check_file(*_args: object, **_kwargs: object) -> dict[str, Any]:
+        return {"is_check_passed": False, "message": "nope"}
+
+    async def fake_upload(**_kwargs: object) -> str:
+        nonlocal uploaded
+        uploaded = True
+        return "ok"
+
+    monkeypatch.setattr("together.lib.cli.components.upload_progress.check_file", fake_check_file)
+
+    with pytest.raises(FileTypeError, match="nope"):
+        await upload_file_with_progress(fake_upload, file, enabled=False)
+    assert uploaded is False

--- a/tests/unit/test_upload_progress.py
+++ b/tests/unit/test_upload_progress.py
@@ -71,3 +71,33 @@ async def test_upload_file_with_progress_failed_check_does_not_upload(
     with pytest.raises(FileTypeError, match="nope"):
         await upload_file_with_progress(fake_upload, file, enabled=False)
     assert uploaded is False
+
+
+def test_upload_progress_tracker_skips_render_when_not_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from together.lib.cli.components import upload_progress as upload_progress_mod
+    from together.lib.cli.components.upload_progress import UploadProgressTracker
+
+    class _NonTerminalConsole:
+        is_terminal = False
+
+    monkeypatch.setattr(upload_progress_mod, "console", _NonTerminalConsole())
+    file = tmp_path / "data.jsonl"
+    file.write_text("{}\n")
+    with UploadProgressTracker.for_single_file(file, enabled=True) as tracker:
+        assert tracker._progress is None
+        assert tracker.as_callback() is not None
+
+
+def test_download_progress_tracker_skips_render_when_not_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    from together.lib.cli.components import download_progress as download_progress_mod
+    from together.lib.cli.components.download_progress import DownloadProgressTracker
+
+    class _NonTerminalConsole:
+        is_terminal = False
+
+    monkeypatch.setattr(download_progress_mod, "console", _NonTerminalConsole())
+    with DownloadProgressTracker.for_single_file(enabled=True, total_bytes=10) as tracker:
+        assert tracker._progress is None
+        assert tracker.as_callback() is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1454,9 +1454,7 @@ dependencies = [
     { name = "rich" },
     { name = "sniffio" },
     { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-8-together-pydantic-v1' and extra == 'group-8-together-pydantic-v2')" },
-    { name = "tqdm" },
     { name = "types-pyyaml" },
-    { name = "types-tqdm" },
     { name = "typing-extensions" },
 ]
 
@@ -1523,10 +1521,8 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.1" },
     { name = "sniffio" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
-    { name = "tqdm", specifier = ">=4.67.1" },
     { name = "types-aiofiles", marker = "extra == 'aiofiles'" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
-    { name = "types-tqdm", specifier = ">=4.67.0.20250516" },
     { name = "typing-extensions", specifier = ">=4.14,<5" },
     { name = "websockets", marker = "extra == 'realtime'", specifier = ">=13,<16" },
 ]
@@ -1609,18 +1605,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.67.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'group-8-together-pydantic-v1' and extra == 'group-8-together-pydantic-v2')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
-]
-
-[[package]]
 name = "types-aiofiles"
 version = "25.1.0.20251011"
 source = { registry = "https://pypi.org/simple" }
@@ -1636,30 +1620,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.32.4.20260107"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676, upload-time = "2026-01-07T03:20:52.929Z" },
-]
-
-[[package]]
-name = "types-tqdm"
-version = "4.67.3.20260303"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "types-requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/64/3e7cb0f40c4bf9578098b6873df33a96f7e0de90f3a039e614d22bfde40a/types_tqdm-4.67.3.20260303.tar.gz", hash = "sha256:7bfddb506a75aedb4030fabf4f05c5638c9a3bbdf900d54ec6c82be9034bfb96", size = 18117, upload-time = "2026-03-03T04:03:49.679Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/32/e4a1fce59155c74082f1a42d0ffafa59652bfb8cff35b04d56333877748e/types_tqdm-4.67.3.20260303-py3-none-any.whl", hash = "sha256:459decf677e4b05cef36f9012ef8d6e20578edefb6b78c15bd0b546247eda62d", size = 24572, upload-time = "2026-03-03T04:03:48.913Z" },
 ]
 
 [[package]]
@@ -1681,15 +1641,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **DX-458**: remove presentation (`tqdm`) from file transfer/check logic, surface progress to CLI callers via Rich, and harden upload redirect handling.

### Core behavior
- Upload/download managers no longer print; they report progress through optional callbacks (`FileUploadProgress` / `FileDownloadProgress`)
- `check_file` no longer uses `tqdm`; it reports `FileCheckProgress` via optional callback (byte + phase)
- SDK stays quiet by default when no callback is provided
- Removed `tqdm` / `types-tqdm` dependencies and `TOGETHER_DISABLE_TQDM` CLI toggles
- Kept deprecated `DISABLE_TQDM = False` export for compatibility

### CLI Rich progress
Shared trackers live under `lib/cli/components/`:
- **`UploadProgressTracker`** (extracted from beta models upload) used by:
  - `tg files upload`
  - `tg fine-tuning create` (local training/validation file uploads)
  - `tg beta models upload`
- **`DownloadProgressTracker`** used by:
  - `tg fine-tuning download`
  - `tg beta models download`
- **`CheckProgressTracker`** used by:
  - `tg files check`
  - pre-upload validation in `tg files upload`
  - Shown for large files on an interactive TTY; skipped in `--json` / non-TTY / small files

`tg files upload` validates **before** starting the upload progress bar (`check=False` on the upload call), so validation and upload are separate phases.

### Upload transfer details
- Single-file uploads stream chunks with `Content-Length` and report byte progress
- Async uploads use an async chunk iterator (`_aiter_file_upload_chunks`) so `httpx.AsyncClient` is not fed a sync stream
- Multipart uploads report cumulative uploaded bytes as parts complete
- Follows upload redirect hops safely (handles intermediate 307-style redirect chains)

### Upload URL / SSRF hardening
- Validate API-issued upload URLs and redirect hops before PUT
- Reject non-HTTPS by default; reject localhost / non-public IP literals (including IPv4-mapped, dword/hex/octal forms)
- API-issued storage URLs (`_validate_upload_server_url`) allow private http(s) for on-prem MinIO / internal S3
- Redirect hops stay stricter unless `base_url` is `http` or `TOGETHER_ALLOW_INSECURE_UPLOAD_REDIRECTS` is set
- Validate `file_id` shape before using it in callback paths
- Note: hostname DNS is not resolved client-side, so this is best-effort URL-layer filtering (documented on the helper)

### Tests
- Unit coverage for upload/download progress callbacks, async streaming, redirect/file-id validation, and file-check progress
- CLI coverage for interactive vs `--json` progress behavior
- Expanded `tests/unit/test_files_checks.py` / `tests/unit/test_upload_progress.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DX-458](https://linear.app/together-ai/issue/DX-458/drop-tqdm-printing-from-file-uploader)

<div><a href="https://cursor.com/agents/bc-bb48cb6d-f6c3-4e87-80de-889843d89bf7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb48cb6d-f6c3-4e87-80de-889843d89bf7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

