### PR TITLE
feat(cli): support shadowing to an existing deployment (DX-831)

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -707,7 +707,7 @@ beta_endpoints_app.command(
 )
 beta_endpoints_app.command(
     (f"{_CLI}.beta.endpoints.shadow:shadow"),
-    help="Mirror sampled live traffic to a new deployment without serving its responses",
+    help="Mirror sampled live traffic to a new or existing deployment without serving its responses",
     help_epilogue=BETA_ENDPOINTS_SHADOW_HELP_EXAMPLES,
     sort_key=9999,
 )

--- a/src/together/lib/cli/api/beta/endpoints/shadow.py
+++ b/src/together/lib/cli/api/beta/endpoints/shadow.py
@@ -24,7 +24,7 @@ from together.types.beta.shadow_endpoint_source_param import (
     SamplingAdaptiveUniform,
     SamplingAdaptiveKeyBased,
 )
-from together.lib.cli.api.beta.endpoints._utils._parameters import ModelParameter, EndpointPromptParameter
+from together.lib.cli.api.beta.endpoints._utils._parameters import ModelPromptParameter, EndpointPromptParameter
 from together.lib.cli.api.beta.endpoints._utils._resolve_model import (
     resolve_endpoint,
     construct_model_path,
@@ -34,6 +34,7 @@ from together.lib.cli.api.beta.endpoints._utils._resolve_config import (
     construct_config_path,
 )
 from together.lib.cli.api.beta.endpoints._utils._build_autoscaling import build_autoscaling
+from together.lib.cli.api.beta.endpoints._utils._find_endpoint_by_deployment import resolve_deployment_id
 
 
 async def shadow(
@@ -45,20 +46,37 @@ async def shadow(
         ),
         EndpointPromptParameter(),
     ],
-    model: ModelParameter,
+    model: Annotated[
+        Optional[str],
+        Parameter(
+            help="""Model to deploy as the shadow target. Required unless --target-deployment-id is set. Accepted forms:
+
+- Public model name (for example, zai-org/GLM-5.2).
+- Private model name, with or without the project slug.
+- Private model ID (ml_...).
+- Fully qualified model resource path returned by the API."""
+        ),
+        ModelPromptParameter(instructions="What model would you like to shadow traffic to?", message="Model"),
+    ] = None,
     config_id: Annotated[
         Optional[str],
         Parameter(
             help=(
                 "Config revision ID (cr_...) for the shadow deployment. Automatically selected only when one "
-                "compatible config exists."
+                "compatible config exists. Ignored with --target-deployment-id."
             ),
             name="config",
         ),
     ] = None,
     name: Annotated[
         Optional[str],
-        Parameter(help="Shadow deployment name; defaults to the model name with a short suffix"),
+        Parameter(
+            help=(
+                "Shadow deployment name when creating a new deployment (defaults to the model name with a short "
+                "suffix); with --target-deployment-id, names the shadow target (defaults to "
+                "<deployment-name>-target)"
+            )
+        ),
     ] = None,
     rate: Annotated[
         Optional[float],
@@ -85,17 +103,81 @@ async def shadow(
         bool,
         Parameter(help="Run the multi-LoRA kernel so adapters can be loaded after deployment"),
     ] = False,
+    target_deployment_id: Annotated[
+        Optional[str],
+        Parameter(
+            help=(
+                "Existing deployment ID (dep_...) or name under the source endpoint to receive mirrored traffic; "
+                "skips creating a new deployment"
+            ),
+        ),
+    ] = None,
     *,
     config: CLIConfigParameter,
 ) -> None:
-    """Create a shadow deployment and mirror sampled live traffic without serving its responses.
+    """Mirror sampled live traffic to a shadow deployment without serving its responses.
 
-    The target deployment stays out of live traffic and active rollouts; weight-0
+    Pass MODEL to create a fresh shadow deployment, or --target-deployment-id to attach an
+    existing deployment. The target stays out of live traffic and active rollouts; weight-0
     traffic-split warm-up deployments are valid shadow targets.
     """
     rate, target_qps = await resolve_rate_or_target_qps(rate, target_qps, config=config)
+    model = await resolve_model_or_target_deployment(
+        model,
+        target_deployment_id,
+        config_id=config_id,
+        enable_lora=enable_lora,
+        config=config,
+    )
 
     endpoint_id = (await resolve_endpoint(config, endpoint_id_or_name)).id
+
+    sampling = build_sampling(rate=rate, key=key, target_qps=target_qps, window=window)
+    source = ShadowSourceParam(endpoint=ShadowEndpointSourceParam(sampling=sampling))
+    shadow_name = build_shadow_name(rate, key, target_qps, window)
+
+    if target_deployment_id is not None:
+        deployment_endpoint, resolved_deployment_id = await resolve_deployment_id(config.client, target_deployment_id)
+        if deployment_endpoint.id != endpoint_id:
+            raise ValueError(
+                f"Deployment {resolved_deployment_id} belongs to endpoint {deployment_endpoint.id}, not {endpoint_id}."
+            )
+
+        # If the shadow experiment already exists, we then just want to add the target to the existing experiment
+        # This logic is turned on if the create fails with an error about the experiment already existing
+        experiment = await create_or_find_shadow_experiment(config.client, endpoint_id, shadow_name, source)
+        assert experiment.id is not None
+
+        deployment = await show_loading_status(
+            "Loading shadow deployment...",
+            config.client.beta.endpoints.deployments.retrieve(
+                id=resolved_deployment_id,
+                endpoint_id=endpoint_id,
+            ),
+        )
+        assert deployment.id is not None
+        target_name = name if name is not None else f"{deployment.name}-target"
+
+        await show_loading_status(
+            "Adding shadow experiment to deployment...",
+            config.client.beta.endpoints.shadow_experiments.targets.create(
+                endpoint_id=endpoint_id,
+                experiment_id=experiment.id,
+                name=target_name,
+                target_deployment_id=deployment.id,
+            ),
+        )
+
+        if config.json:
+            payload: dict[str, Any] = {"deployment": deployment, "shadow_experiment": experiment}
+            console.print_json(openapi_dumps(payload).decode("utf-8"))
+            return
+
+        console.print("[green]√[/green] Existing deployment added as shadow target; traffic mirroring started.")
+        await retrieve(endpoint_id, config=config)
+        return
+
+    assert model is not None
     resolved = await resolve_model_and_config(config, model, config_id=config_id)
     resolved_model, config_value = resolved.model, resolved.config
 
@@ -113,13 +195,10 @@ async def shadow(
         short_uuid = str(uuid.uuid4())[:8]
         name = f"{resolved_model.name}-{short_uuid}".replace("/", "-")
 
-    sampling = build_sampling(rate=rate, key=key, target_qps=target_qps, window=window)
-    source = ShadowSourceParam(endpoint=ShadowEndpointSourceParam(sampling=sampling))
-    shadow_name = build_shadow_name(rate, key, target_qps, window)
-
     # If the shadow experiment already exists, we then just want to add the target to the existing experiment
     # This logic is turned on if the create fails with an error about the experiment already existing
     experiment = await create_or_find_shadow_experiment(config.client, endpoint_id, shadow_name, source)
+    assert experiment.id is not None
 
     deployment = await show_loading_status(
         "Creating shadow deployment...",
@@ -134,7 +213,6 @@ async def shadow(
     )
 
     assert deployment.id is not None
-    assert experiment.id is not None
 
     await show_loading_status(
         "Adding shadow experiment to deployment...",
@@ -147,12 +225,48 @@ async def shadow(
     )
 
     if config.json:
-        payload: dict[str, Any] = {"deployment": deployment, "shadow_experiment": experiment}
+        payload = {"deployment": deployment, "shadow_experiment": experiment}
         console.print_json(openapi_dumps(payload).decode("utf-8"))
         return
 
     console.print("[green]√[/green] Shadow deployment created and traffic mirroring started.")
     await retrieve(endpoint_id, config=config)
+
+
+async def resolve_model_or_target_deployment(
+    model: str | None,
+    target_deployment_id: str | None,
+    *,
+    config_id: str | None,
+    enable_lora: bool,
+    config: CLIConfig,
+) -> str | None:
+    if target_deployment_id is not None:
+        if model is not None:
+            raise ValueError("Do not pass MODEL with --target-deployment-id.")
+        if config_id is not None:
+            raise ValueError("Do not pass --config with --target-deployment-id.")
+        if enable_lora:
+            raise ValueError("Do not pass --enable-lora with --target-deployment-id.")
+        return None
+
+    if model is not None:
+        return model
+
+    if config.non_interactive:
+        raise ValueError("Either MODEL or --target-deployment-id must be provided.")
+
+    try:
+        prompt = ModelPromptParameter(
+            instructions="What model would you like to shadow traffic to?",
+            message="Model",
+        )
+        await prompt.preprompt(config)
+        value = await prompt.prompt("model")
+        console.print("")
+        return cast(str, value)
+    except Exception as e:
+        raise ValueError("Either MODEL or --target-deployment-id must be provided.") from e
 
 
 async def resolve_rate_or_target_qps(

--- a/src/together/lib/cli/api/beta/endpoints/shadow.py
+++ b/src/together/lib/cli/api/beta/endpoints/shadow.py
@@ -9,7 +9,7 @@ from cyclopts import Parameter
 from cyclopts.validators import Number as CycloptsNumberValidator
 
 from together import APIError, AsyncClient
-from together.types.beta import ShadowSourceParam, ShadowEndpointSourceParam
+from together.types.beta import Endpoint, ShadowSourceParam, ShadowEndpointSourceParam
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfig, CLIConfigParameter
 from together.types.beta.endpoints import ShadowExperiment
@@ -38,18 +38,22 @@ from together.lib.cli.api.beta.endpoints._utils._find_endpoint_by_deployment imp
 
 
 async def shadow(
-    endpoint_id_or_name: Annotated[
+    endpoint_or_deployment: Annotated[
         str,
         Parameter(
             name="endpoint",
-            help="Source endpoint whose live requests will be mirrored; accepts an endpoint ID (ep_...) or name",
+            help=(
+                "Source endpoint (ep_... or name) when creating a new shadow deployment, or an existing "
+                "deployment (dep_... or name) to attach as the shadow target"
+            ),
         ),
         EndpointPromptParameter(),
     ],
     model: Annotated[
         Optional[str],
         Parameter(
-            help="""Model to deploy as the shadow target. Required unless --target-deployment-id is set. Accepted forms:
+            help="""Model to deploy as the shadow target. Required when ENDPOINT is an endpoint ID/name; omit when
+ENDPOINT is an existing deployment. Accepted forms:
 
 - Public model name (for example, zai-org/GLM-5.2).
 - Private model name, with or without the project slug.
@@ -63,7 +67,7 @@ async def shadow(
         Parameter(
             help=(
                 "Config revision ID (cr_...) for the shadow deployment. Automatically selected only when one "
-                "compatible config exists. Ignored with --target-deployment-id."
+                "compatible config exists. Not used when shadowing an existing deployment."
             ),
             name="config",
         ),
@@ -73,7 +77,7 @@ async def shadow(
         Parameter(
             help=(
                 "Shadow deployment name when creating a new deployment (defaults to the model name with a short "
-                "suffix); with --target-deployment-id, names the shadow target (defaults to "
+                "suffix); when shadowing an existing deployment, names the shadow target (defaults to "
                 "<deployment-name>-target)"
             )
         ),
@@ -103,45 +107,32 @@ async def shadow(
         bool,
         Parameter(help="Run the multi-LoRA kernel so adapters can be loaded after deployment"),
     ] = False,
-    target_deployment_id: Annotated[
-        Optional[str],
-        Parameter(
-            help=(
-                "Existing deployment ID (dep_...) or name under the source endpoint to receive mirrored traffic; "
-                "skips creating a new deployment"
-            ),
-        ),
-    ] = None,
     *,
     config: CLIConfigParameter,
 ) -> None:
     """Mirror sampled live traffic to a shadow deployment without serving its responses.
 
-    Pass MODEL to create a fresh shadow deployment, or --target-deployment-id to attach an
-    existing deployment. The target stays out of live traffic and active rollouts; weight-0
-    traffic-split warm-up deployments are valid shadow targets.
+    Pass an endpoint and MODEL to create a fresh shadow deployment, or pass an existing
+    deployment ID (dep_...) as ENDPOINT to attach it as the shadow target. The target stays
+    out of live traffic and active rollouts; weight-0 traffic-split warm-up deployments are
+    valid shadow targets.
     """
     rate, target_qps = await resolve_rate_or_target_qps(rate, target_qps, config=config)
-    model = await resolve_model_or_target_deployment(
-        model,
-        target_deployment_id,
-        config_id=config_id,
-        enable_lora=enable_lora,
-        config=config,
-    )
-
-    endpoint_id = (await resolve_endpoint(config, endpoint_id_or_name)).id
 
     sampling = build_sampling(rate=rate, key=key, target_qps=target_qps, window=window)
     source = ShadowSourceParam(endpoint=ShadowEndpointSourceParam(sampling=sampling))
     shadow_name = build_shadow_name(rate, key, target_qps, window)
 
-    if target_deployment_id is not None:
-        deployment_endpoint, resolved_deployment_id = await resolve_deployment_id(config.client, target_deployment_id)
-        if deployment_endpoint.id != endpoint_id:
-            raise ValueError(
-                f"Deployment {resolved_deployment_id} belongs to endpoint {deployment_endpoint.id}, not {endpoint_id}."
-            )
+    existing_deployment = await maybe_resolve_existing_deployment(
+        config,
+        endpoint_or_deployment,
+        model=model,
+        config_id=config_id,
+        enable_lora=enable_lora,
+    )
+    if existing_deployment is not None:
+        endpoint, resolved_deployment_id = existing_deployment
+        endpoint_id = endpoint.id
 
         # If the shadow experiment already exists, we then just want to add the target to the existing experiment
         # This logic is turned on if the create fails with an error about the experiment already existing
@@ -177,7 +168,9 @@ async def shadow(
         await retrieve(endpoint_id, config=config)
         return
 
-    assert model is not None
+    model = await resolve_model_for_create(model, config=config)
+
+    endpoint_id = (await resolve_endpoint(config, endpoint_or_deployment)).id
     resolved = await resolve_model_and_config(config, model, config_id=config_id)
     resolved_model, config_value = resolved.model, resolved.config
 
@@ -233,28 +226,55 @@ async def shadow(
     await retrieve(endpoint_id, config=config)
 
 
-async def resolve_model_or_target_deployment(
-    model: str | None,
-    target_deployment_id: str | None,
+async def maybe_resolve_existing_deployment(
+    config: CLIConfig,
+    endpoint_or_deployment: str,
     *,
+    model: str | None,
     config_id: str | None,
     enable_lora: bool,
-    config: CLIConfig,
-) -> str | None:
-    if target_deployment_id is not None:
-        if model is not None:
-            raise ValueError("Do not pass MODEL with --target-deployment-id.")
-        if config_id is not None:
-            raise ValueError("Do not pass --config with --target-deployment-id.")
-        if enable_lora:
-            raise ValueError("Do not pass --enable-lora with --target-deployment-id.")
+) -> tuple[Endpoint, str] | None:
+    """Return ``(endpoint, deployment_id)`` when the first positional is an existing deployment."""
+    explicitly_deployment = endpoint_or_deployment.startswith("dep_")
+    explicitly_endpoint = endpoint_or_deployment.startswith("ep_")
+
+    if explicitly_endpoint:
         return None
 
+    if not explicitly_deployment and model is not None:
+        # Create path: ENDPOINT + MODEL
+        return None
+
+    if not explicitly_deployment and model is None:
+        # Ambiguous bare name with no MODEL: only treat as deployment when one uniquely matches.
+        # Otherwise fall through to the create path (which will prompt/require MODEL).
+        try:
+            endpoint, deployment_id = await resolve_deployment_id(config.client, endpoint_or_deployment)
+        except ValueError:
+            return None
+    else:
+        endpoint, deployment_id = await resolve_deployment_id(config.client, endpoint_or_deployment)
+
+    if model is not None:
+        raise ValueError("Do not pass MODEL when ENDPOINT is an existing deployment.")
+    if config_id is not None:
+        raise ValueError("Do not pass --config when ENDPOINT is an existing deployment.")
+    if enable_lora:
+        raise ValueError("Do not pass --enable-lora when ENDPOINT is an existing deployment.")
+
+    return endpoint, deployment_id
+
+
+async def resolve_model_for_create(
+    model: str | None,
+    *,
+    config: CLIConfig,
+) -> str:
     if model is not None:
         return model
 
     if config.non_interactive:
-        raise ValueError("Either MODEL or --target-deployment-id must be provided.")
+        raise ValueError("MODEL is required when ENDPOINT is an endpoint ID or name.")
 
     try:
         prompt = ModelPromptParameter(
@@ -266,7 +286,7 @@ async def resolve_model_or_target_deployment(
         console.print("")
         return cast(str, value)
     except Exception as e:
-        raise ValueError("Either MODEL or --target-deployment-id must be provided.") from e
+        raise ValueError("MODEL is required when ENDPOINT is an endpoint ID or name.") from e
 
 
 async def resolve_rate_or_target_qps(

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -383,7 +383,7 @@ BETA_ENDPOINTS_SHADOW_HELP_EXAMPLES = """[dim]Examples:[/dim]
     --config cr_yyyyyyyyyyyy --rate 0.05 --name my-shadow[/primary]
 
 [dim]-[/dim] Mirror traffic to an existing deployment:
-  [primary]tg beta endpoints shadow my-endpoint --target-deployment-id dep_xxxxxxxxxxxx --rate 0.1[/primary]
+  [primary]tg beta endpoints shadow dep_xxxxxxxxxxxx --rate 0.1[/primary]
 
 [dim]Note:[/dim] Shadow targets cannot be live traffic-split members or active rollout participants.
 """

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -382,6 +382,9 @@ BETA_ENDPOINTS_SHADOW_HELP_EXAMPLES = """[dim]Examples:[/dim]
   [primary]tg beta endpoints shadow my-endpoint ml_xxxxxxxxxxxx \\
     --config cr_yyyyyyyyyyyy --rate 0.05 --name my-shadow[/primary]
 
+[dim]-[/dim] Mirror traffic to an existing deployment:
+  [primary]tg beta endpoints shadow my-endpoint --target-deployment-id dep_xxxxxxxxxxxx --rate 0.1[/primary]
+
 [dim]Note:[/dim] Shadow targets cannot be live traffic-split members or active rollout participants.
 """
 

--- a/tests/cli/test_beta_endpoints_shadow.py
+++ b/tests/cli/test_beta_endpoints_shadow.py
@@ -14,8 +14,9 @@ from tests.cli.utils import CliRunner
 from together.lib.cli.utils.config import CLIConfig
 from together.lib.cli.api.beta.endpoints.shadow import (
     build_shadow_name,
+    resolve_model_for_create,
     resolve_rate_or_target_qps,
-    resolve_model_or_target_deployment,
+    maybe_resolve_existing_deployment,
 )
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
@@ -176,8 +177,6 @@ def _shadow_existing_deployment_cli_args(**overrides: str) -> list[str]:
         "--project",
         "proj",
         "--endpoint",
-        "ep_1",
-        "--target-deployment-id",
         "dep_existing",
         "--rate",
         "0.1",
@@ -294,79 +293,127 @@ class TestResolveRateOrTargetQps:
                 await resolve_rate_or_target_qps(None, None, config=self._config())
 
 
-class TestResolveModelOrTargetDeployment:
-    def _config(self, *, non_interactive: bool = False) -> CLIConfig:
-        return CLIConfig(client=MagicMock(), non_interactive=non_interactive, json=False, project_id="proj")
+class TestMaybeResolveExistingDeployment:
+    def _config(self, client: MagicMock | None = None) -> CLIConfig:
+        return CLIConfig(client=client or MagicMock(), non_interactive=True, json=False, project_id="proj")
 
     @pytest.mark.asyncio
-    async def test_passthrough_model(self) -> None:
+    async def test_endpoint_id_is_not_existing_deployment(self) -> None:
         assert (
-            await resolve_model_or_target_deployment(
-                "ml_1",
-                None,
+            await maybe_resolve_existing_deployment(
+                self._config(),
+                "ep_1",
+                model=None,
                 config_id=None,
                 enable_lora=False,
-                config=self._config(),
-            )
-            == "ml_1"
-        )
-
-    @pytest.mark.asyncio
-    async def test_target_deployment_skips_model(self) -> None:
-        assert (
-            await resolve_model_or_target_deployment(
-                None,
-                "dep_existing",
-                config_id=None,
-                enable_lora=False,
-                config=self._config(),
             )
             is None
         )
 
     @pytest.mark.asyncio
-    async def test_rejects_model_with_target_deployment(self) -> None:
-        with pytest.raises(ValueError, match="Do not pass MODEL with --target-deployment-id"):
-            await resolve_model_or_target_deployment(
-                "ml_1",
-                "dep_existing",
+    async def test_endpoint_plus_model_is_create_path(self) -> None:
+        assert (
+            await maybe_resolve_existing_deployment(
+                self._config(),
+                "my-endpoint",
+                model="ml_1",
                 config_id=None,
                 enable_lora=False,
-                config=self._config(),
             )
+            is None
+        )
 
     @pytest.mark.asyncio
-    async def test_rejects_config_with_target_deployment(self) -> None:
-        with pytest.raises(ValueError, match="Do not pass --config with --target-deployment-id"):
-            await resolve_model_or_target_deployment(
-                None,
+    async def test_dep_id_resolves_existing_deployment(self) -> None:
+        endpoint = MagicMock(id="ep_1")
+        with patch(
+            "together.lib.cli.api.beta.endpoints.shadow.resolve_deployment_id",
+            AsyncMock(return_value=(endpoint, "dep_existing")),
+        ):
+            result = await maybe_resolve_existing_deployment(
+                self._config(),
                 "dep_existing",
-                config_id="cr_1",
-                enable_lora=False,
-                config=self._config(),
-            )
-
-    @pytest.mark.asyncio
-    async def test_rejects_enable_lora_with_target_deployment(self) -> None:
-        with pytest.raises(ValueError, match="Do not pass --enable-lora with --target-deployment-id"):
-            await resolve_model_or_target_deployment(
-                None,
-                "dep_existing",
-                config_id=None,
-                enable_lora=True,
-                config=self._config(),
-            )
-
-    @pytest.mark.asyncio
-    async def test_non_interactive_requires_model_or_target(self) -> None:
-        with pytest.raises(ValueError, match="Either MODEL or --target-deployment-id must be provided"):
-            await resolve_model_or_target_deployment(
-                None,
-                None,
+                model=None,
                 config_id=None,
                 enable_lora=False,
-                config=self._config(non_interactive=True),
             )
+        assert result == (endpoint, "dep_existing")
+
+    @pytest.mark.asyncio
+    async def test_rejects_model_with_dep_id(self) -> None:
+        with patch(
+            "together.lib.cli.api.beta.endpoints.shadow.resolve_deployment_id",
+            AsyncMock(return_value=(MagicMock(id="ep_1"), "dep_existing")),
+        ):
+            with pytest.raises(ValueError, match="Do not pass MODEL when ENDPOINT is an existing deployment"):
+                await maybe_resolve_existing_deployment(
+                    self._config(),
+                    "dep_existing",
+                    model="ml_1",
+                    config_id=None,
+                    enable_lora=False,
+                )
+
+    @pytest.mark.asyncio
+    async def test_rejects_config_with_dep_id(self) -> None:
+        with patch(
+            "together.lib.cli.api.beta.endpoints.shadow.resolve_deployment_id",
+            AsyncMock(return_value=(MagicMock(id="ep_1"), "dep_existing")),
+        ):
+            with pytest.raises(ValueError, match="Do not pass --config when ENDPOINT is an existing deployment"):
+                await maybe_resolve_existing_deployment(
+                    self._config(),
+                    "dep_existing",
+                    model=None,
+                    config_id="cr_1",
+                    enable_lora=False,
+                )
+
+    @pytest.mark.asyncio
+    async def test_rejects_enable_lora_with_dep_id(self) -> None:
+        with patch(
+            "together.lib.cli.api.beta.endpoints.shadow.resolve_deployment_id",
+            AsyncMock(return_value=(MagicMock(id="ep_1"), "dep_existing")),
+        ):
+            with pytest.raises(ValueError, match="Do not pass --enable-lora when ENDPOINT is an existing deployment"):
+                await maybe_resolve_existing_deployment(
+                    self._config(),
+                    "dep_existing",
+                    model=None,
+                    config_id=None,
+                    enable_lora=True,
+                )
+
+    @pytest.mark.asyncio
+    async def test_bare_name_falls_through_when_not_a_deployment(self) -> None:
+        with patch(
+            "together.lib.cli.api.beta.endpoints.shadow.resolve_deployment_id",
+            AsyncMock(side_effect=ValueError("not found")),
+        ):
+            assert (
+                await maybe_resolve_existing_deployment(
+                    self._config(),
+                    "my-endpoint",
+                    model=None,
+                    config_id=None,
+                    enable_lora=False,
+                )
+                is None
+            )
+
+
+class TestResolveModelForCreate:
+    def _config(self, *, non_interactive: bool = False) -> CLIConfig:
+        return CLIConfig(client=MagicMock(), non_interactive=non_interactive, json=False, project_id="proj")
+
+    @pytest.mark.asyncio
+    async def test_passthrough_model(self) -> None:
+        assert await resolve_model_for_create("ml_1", config=self._config()) == "ml_1"
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_requires_model(self) -> None:
+        with pytest.raises(ValueError, match="MODEL is required when ENDPOINT is an endpoint ID or name"):
+            await resolve_model_for_create(None, config=self._config(non_interactive=True))
 
     @pytest.mark.asyncio
     async def test_prompts_for_model(self) -> None:
@@ -374,16 +421,7 @@ class TestResolveModelOrTargetDeployment:
         with patch("together.lib.cli.api.beta.endpoints.shadow.ModelPromptParameter") as ModelPromptParameter:
             ModelPromptParameter.return_value.preprompt = AsyncMock()
             ModelPromptParameter.return_value.prompt = prompt
-            assert (
-                await resolve_model_or_target_deployment(
-                    None,
-                    None,
-                    config_id=None,
-                    enable_lora=False,
-                    config=self._config(),
-                )
-                == "ml_1"
-            )
+            assert await resolve_model_for_create(None, config=self._config()) == "ml_1"
 
 
 class TestBetaEndpointShadow:
@@ -729,7 +767,6 @@ class TestBetaEndpointShadow:
         respx_mock: MockRouter,
         cli_runner: CliRunner,
     ) -> None:
-        _mock_endpoint(respx_mock)
         _mock_existing_deployment_lookup(respx_mock)
         create_experiment_route = respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments").mock(
             return_value=httpx.Response(200, json=_shadow_experiment_body())
@@ -765,7 +802,6 @@ class TestBetaEndpointShadow:
         respx_mock: MockRouter,
         cli_runner: CliRunner,
     ) -> None:
-        _mock_endpoint(respx_mock)
         _mock_existing_deployment_lookup(respx_mock)
         respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments").mock(
             return_value=httpx.Response(200, json=_shadow_experiment_body())
@@ -795,7 +831,6 @@ class TestBetaEndpointShadow:
         respx_mock: MockRouter,
         cli_runner: CliRunner,
     ) -> None:
-        _mock_endpoint(respx_mock)
         _mock_existing_deployment_lookup(respx_mock)
         respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments").mock(
             return_value=httpx.Response(
@@ -828,20 +863,28 @@ class TestBetaEndpointShadow:
         assert target_body["targetDeploymentId"] == "dep_existing"
 
     @pytest.mark.respx(base_url=base_url)
-    def test_shadow_existing_deployment_rejects_wrong_endpoint(
+    def test_shadow_existing_deployment_not_found(
         self,
         respx_mock: MockRouter,
         cli_runner: CliRunner,
     ) -> None:
-        _mock_endpoint(respx_mock)
-        _mock_existing_deployment_lookup(respx_mock, endpoint_id="ep_other", retrieve=False)
+        respx_mock.get("/projects/proj/endpoints").mock(
+            return_value=httpx.Response(200, json={"object": "list", "data": [], "next_cursor": None})
+        )
 
         result = cli_runner.invoke(_shadow_existing_deployment_cli_args())
 
         assert result.exit_code != 0
-        assert "belongs to endpoint ep_other" in result.output
+        assert "Deployment dep_existing not found" in result.output
 
-    def test_shadow_rejects_model_with_target_deployment_id(self, cli_runner: CliRunner) -> None:
+    @pytest.mark.respx(base_url=base_url)
+    def test_shadow_rejects_model_with_deployment_id(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_existing_deployment_lookup(respx_mock, retrieve=False)
+
         result = cli_runner.invoke(
             [
                 "beta",
@@ -850,11 +893,9 @@ class TestBetaEndpointShadow:
                 "--project",
                 "proj",
                 "--endpoint",
-                "ep_1",
+                "dep_existing",
                 "--model",
                 "ml_1",
-                "--target-deployment-id",
-                "dep_existing",
                 "--rate",
                 "0.1",
                 "--non-interactive",
@@ -862,9 +903,9 @@ class TestBetaEndpointShadow:
         )
 
         assert result.exit_code != 0
-        assert "Do not pass MODEL with --target-deployment-id" in result.output
+        assert "Do not pass MODEL when ENDPOINT is an existing deployment" in result.output
 
-    def test_shadow_requires_model_or_target_deployment_id(self, cli_runner: CliRunner) -> None:
+    def test_shadow_requires_model_for_endpoint(self, cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(
             [
                 "beta",
@@ -881,4 +922,4 @@ class TestBetaEndpointShadow:
         )
 
         assert result.exit_code != 0
-        assert "Either MODEL or --target-deployment-id must be provided" in result.output
+        assert "MODEL is required when ENDPOINT is an endpoint ID or name" in result.output

--- a/tests/cli/test_beta_endpoints_shadow.py
+++ b/tests/cli/test_beta_endpoints_shadow.py
@@ -12,7 +12,11 @@ from respx.models import Call
 
 from tests.cli.utils import CliRunner
 from together.lib.cli.utils.config import CLIConfig
-from together.lib.cli.api.beta.endpoints.shadow import build_shadow_name, resolve_rate_or_target_qps
+from together.lib.cli.api.beta.endpoints.shadow import (
+    build_shadow_name,
+    resolve_rate_or_target_qps,
+    resolve_model_or_target_deployment,
+)
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -164,6 +168,78 @@ def _shadow_cli_args(**overrides: str) -> list[str]:
     return args
 
 
+def _shadow_existing_deployment_cli_args(**overrides: str) -> list[str]:
+    args = [
+        "beta",
+        "endpoints",
+        "shadow",
+        "--project",
+        "proj",
+        "--endpoint",
+        "ep_1",
+        "--target-deployment-id",
+        "dep_existing",
+        "--rate",
+        "0.1",
+        "--json",
+    ]
+    for key, value in overrides.items():
+        flag = f"--{key.replace('_', '-')}"
+        if flag in args:
+            index = args.index(flag)
+            args[index + 1] = value
+        else:
+            args.extend([flag, value])
+    return args
+
+
+def _mock_existing_deployment_lookup(
+    respx_mock: MockRouter,
+    *,
+    deployment_id: str = "dep_existing",
+    endpoint_id: str = "ep_1",
+    deployment_name: str = "existing-shadow",
+    retrieve: bool = True,
+) -> None:
+    respx_mock.get("/projects/proj/endpoints").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    _endpoint_body(
+                        id=endpoint_id,
+                        deployments=[
+                            {
+                                "id": deployment_id,
+                                "name": deployment_name,
+                                "modelId": "ml_1",
+                                "state": "DEPLOYMENT_STATE_READY",
+                                "readyReplicas": 1,
+                                "desiredReplicas": 1,
+                                "createdAt": "2026-01-01T00:00:00Z",
+                                "autoscaling": {"minReplicas": 1, "maxReplicas": 1},
+                            }
+                        ],
+                    )
+                ],
+                "next_cursor": None,
+            },
+        )
+    )
+    if retrieve:
+        respx_mock.get(f"/projects/proj/endpoints/{endpoint_id}/deployments/{deployment_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json=_deployment_body(
+                    deployment_id=deployment_id,
+                    name=deployment_name,
+                    **({"endpointId": endpoint_id} if endpoint_id != "ep_1" else {}),
+                ),
+            )
+        )
+
+
 class TestBuildShadowName:
     def test_uniform_rate_only(self) -> None:
         assert build_shadow_name(0.1, None, None, None) == "shadow-rate-0.1"
@@ -216,6 +292,98 @@ class TestResolveRateOrTargetQps:
             PromptParameter.return_value.prompt = prompt
             with pytest.raises(ValueError, match="Rate must be between 0.0 and 1.0"):
                 await resolve_rate_or_target_qps(None, None, config=self._config())
+
+
+class TestResolveModelOrTargetDeployment:
+    def _config(self, *, non_interactive: bool = False) -> CLIConfig:
+        return CLIConfig(client=MagicMock(), non_interactive=non_interactive, json=False, project_id="proj")
+
+    @pytest.mark.asyncio
+    async def test_passthrough_model(self) -> None:
+        assert (
+            await resolve_model_or_target_deployment(
+                "ml_1",
+                None,
+                config_id=None,
+                enable_lora=False,
+                config=self._config(),
+            )
+            == "ml_1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_target_deployment_skips_model(self) -> None:
+        assert (
+            await resolve_model_or_target_deployment(
+                None,
+                "dep_existing",
+                config_id=None,
+                enable_lora=False,
+                config=self._config(),
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_model_with_target_deployment(self) -> None:
+        with pytest.raises(ValueError, match="Do not pass MODEL with --target-deployment-id"):
+            await resolve_model_or_target_deployment(
+                "ml_1",
+                "dep_existing",
+                config_id=None,
+                enable_lora=False,
+                config=self._config(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_config_with_target_deployment(self) -> None:
+        with pytest.raises(ValueError, match="Do not pass --config with --target-deployment-id"):
+            await resolve_model_or_target_deployment(
+                None,
+                "dep_existing",
+                config_id="cr_1",
+                enable_lora=False,
+                config=self._config(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_enable_lora_with_target_deployment(self) -> None:
+        with pytest.raises(ValueError, match="Do not pass --enable-lora with --target-deployment-id"):
+            await resolve_model_or_target_deployment(
+                None,
+                "dep_existing",
+                config_id=None,
+                enable_lora=True,
+                config=self._config(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_requires_model_or_target(self) -> None:
+        with pytest.raises(ValueError, match="Either MODEL or --target-deployment-id must be provided"):
+            await resolve_model_or_target_deployment(
+                None,
+                None,
+                config_id=None,
+                enable_lora=False,
+                config=self._config(non_interactive=True),
+            )
+
+    @pytest.mark.asyncio
+    async def test_prompts_for_model(self) -> None:
+        prompt = AsyncMock(return_value="ml_1")
+        with patch("together.lib.cli.api.beta.endpoints.shadow.ModelPromptParameter") as ModelPromptParameter:
+            ModelPromptParameter.return_value.preprompt = AsyncMock()
+            ModelPromptParameter.return_value.prompt = prompt
+            assert (
+                await resolve_model_or_target_deployment(
+                    None,
+                    None,
+                    config_id=None,
+                    enable_lora=False,
+                    config=self._config(),
+                )
+                == "ml_1"
+            )
 
 
 class TestBetaEndpointShadow:
@@ -554,3 +722,163 @@ class TestBetaEndpointShadow:
         assert experiment_body["source"] == {
             "endpoint": {"sampling": {"adaptiveUniform": {"targetQps": 5.0}}},
         }
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_shadow_uses_existing_deployment(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint(respx_mock)
+        _mock_existing_deployment_lookup(respx_mock)
+        create_experiment_route = respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments").mock(
+            return_value=httpx.Response(200, json=_shadow_experiment_body())
+        )
+        create_target_route = respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments/exp_1/targets").mock(
+            return_value=httpx.Response(
+                200,
+                json=_shadow_target_body(
+                    name="existing-shadow-target",
+                    target_deployment_id="dep_existing",
+                ),
+            )
+        )
+
+        result = cli_runner.invoke(_shadow_existing_deployment_cli_args())
+
+        assert result.exit_code == 0, result.output
+        assert create_experiment_route.call_count == 1
+
+        target_body = json.loads(cast(Call, create_target_route.calls[0]).request.content.decode())
+        assert target_body == {
+            "name": "existing-shadow-target",
+            "targetDeploymentId": "dep_existing",
+        }
+
+        output = json.loads(result.output)
+        assert output["deployment"]["id"] == "dep_existing"
+        assert output["shadow_experiment"]["id"] == "exp_1"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_shadow_existing_deployment_custom_target_name(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint(respx_mock)
+        _mock_existing_deployment_lookup(respx_mock)
+        respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments").mock(
+            return_value=httpx.Response(200, json=_shadow_experiment_body())
+        )
+        create_target_route = respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments/exp_1/targets").mock(
+            return_value=httpx.Response(
+                200,
+                json=_shadow_target_body(
+                    name="candidate",
+                    target_deployment_id="dep_existing",
+                ),
+            )
+        )
+
+        result = cli_runner.invoke(_shadow_existing_deployment_cli_args(name="candidate"))
+
+        assert result.exit_code == 0, result.output
+        target_body = json.loads(cast(Call, create_target_route.calls[0]).request.content.decode())
+        assert target_body == {
+            "name": "candidate",
+            "targetDeploymentId": "dep_existing",
+        }
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_shadow_existing_deployment_reuses_experiment(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint(respx_mock)
+        _mock_existing_deployment_lookup(respx_mock)
+        respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments").mock(
+            return_value=httpx.Response(
+                409,
+                json={"error": {"message": "Shadow experiment already exists", "type": "conflict"}},
+            )
+        )
+        list_route = respx_mock.get("/projects/proj/endpoints/ep_1/shadowExperiments").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [_shadow_experiment_body(name="shadow-rate-0.1")],
+                    "next_cursor": None,
+                },
+            )
+        )
+        create_target_route = respx_mock.post("/projects/proj/endpoints/ep_1/shadowExperiments/exp_1/targets").mock(
+            return_value=httpx.Response(
+                200,
+                json=_shadow_target_body(target_deployment_id="dep_existing"),
+            )
+        )
+
+        result = cli_runner.invoke(_shadow_existing_deployment_cli_args())
+
+        assert result.exit_code == 0, result.output
+        assert list_route.call_count == 1
+        target_body = json.loads(cast(Call, create_target_route.calls[0]).request.content.decode())
+        assert target_body["targetDeploymentId"] == "dep_existing"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_shadow_existing_deployment_rejects_wrong_endpoint(
+        self,
+        respx_mock: MockRouter,
+        cli_runner: CliRunner,
+    ) -> None:
+        _mock_endpoint(respx_mock)
+        _mock_existing_deployment_lookup(respx_mock, endpoint_id="ep_other", retrieve=False)
+
+        result = cli_runner.invoke(_shadow_existing_deployment_cli_args())
+
+        assert result.exit_code != 0
+        assert "belongs to endpoint ep_other" in result.output
+
+    def test_shadow_rejects_model_with_target_deployment_id(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(
+            [
+                "beta",
+                "endpoints",
+                "shadow",
+                "--project",
+                "proj",
+                "--endpoint",
+                "ep_1",
+                "--model",
+                "ml_1",
+                "--target-deployment-id",
+                "dep_existing",
+                "--rate",
+                "0.1",
+                "--non-interactive",
+            ]
+        )
+
+        assert result.exit_code != 0
+        assert "Do not pass MODEL with --target-deployment-id" in result.output
+
+    def test_shadow_requires_model_or_target_deployment_id(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(
+            [
+                "beta",
+                "endpoints",
+                "shadow",
+                "--project",
+                "proj",
+                "--endpoint",
+                "ep_1",
+                "--rate",
+                "0.1",
+                "--non-interactive",
+            ]
+        )
+
+        assert result.exit_code != 0
+        assert "Either MODEL or --target-deployment-id must be provided" in result.output


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `tg beta endpoints shadow` can attach an existing deployment as a shadow target by passing a `dep_...` (or deployment name) as the first positional `ENDPOINT` arg — parent endpoint is inferred.
- No new flag: dropped `--target-deployment-id` per review feedback.
- Create-new-deployment path unchanged: `ENDPOINT` + `MODEL`.

## Usage
```bash
# Attach an existing deployment
tg beta endpoints shadow dep_xxxxxxxxxxxx --rate 0.1

# Create a new shadow deployment (unchanged)
tg beta endpoints shadow my-endpoint Qwen/Qwen2.5-7B --rate 0.1
```

## Test plan
- [x] `uv run pytest tests/cli/test_beta_endpoints_shadow.py -v` (34 passed)
- [x] Unit coverage for `dep_` vs `ep_` / MODEL create-path detection
- [x] CLI coverage for attach existing deployment, custom target name, experiment reuse, not-found, MODEL+dep_ rejection
- [x] Existing create-new-deployment shadow path still green
- [x] Help epilogue shows `tg beta endpoints shadow dep_... --rate 0.1`

Fixes DX-831
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DX-831](https://linear.app/together-ai/issue/DX-831/support-shadowing-to-an-existing-deployment-in-the-cli)

<div><a href="https://cursor.com/agents/bc-cb321a77-217a-4b06-8ba0-64cec2adb392?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb321a77-217a-4b06-8ba0-64cec2adb392&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

