### PR TITLE
feat(CLI): add tg batches commands for the batch API

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -52,6 +52,7 @@ from together.lib.cli.utils._help_examples import (
     BETA_ENDPOINTS_HELP_EXAMPLES,
     JIG_JOB_STATUS_HELP_EXAMPLES,
     JIG_SECRETS_SET_HELP_EXAMPLES,
+    BATCHES_DOWNLOAD_HELP_EXAMPLES,
     ENDPOINTS_CREATE_HELP_EXAMPLES,
     ENDPOINTS_UPDATE_HELP_EXAMPLES,
     BETA_ENDPOINTS_AB_HELP_EXAMPLES,
@@ -548,9 +549,15 @@ batches_app.command(
     (f"{_CLI}.batches.submit:submit"),
     help="Submit a new batch job",
     help_epilogue=BATCHES_SUBMIT_HELP_EXAMPLES,
+    sort_key=1,
 )
 batches_app.command((f"{_CLI}.batches.list:list"), alias="ls", help="List batch jobs")
 batches_app.command((f"{_CLI}.batches.retrieve:retrieve"), alias="get", help="Get batch job details")
+batches_app.command(
+    (f"{_CLI}.batches.download:download"),
+    help="Download batch job output (and error) files",
+    help_epilogue=BATCHES_DOWNLOAD_HELP_EXAMPLES,
+)
 batches_app.command((f"{_CLI}.batches.cancel:cancel"), help="Cancel a batch job")
 
 ## Telemetry API commands

--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -31,6 +31,7 @@ from together.lib.cli.utils._help_examples import (
     EVALS_HELP_EXAMPLES,
     FILES_HELP_EXAMPLES,
     MODELS_HELP_EXAMPLES,
+    BATCHES_HELP_EXAMPLES,
     JIG_LOGS_HELP_EXAMPLES,
     JIG_PUSH_HELP_EXAMPLES,
     ENDPOINTS_HELP_EXAMPLES,
@@ -47,6 +48,7 @@ from together.lib.cli.utils._help_examples import (
     FILES_UPLOAD_HELP_EXAMPLES,
     BETA_CLUSTERS_HELP_EXAMPLES,
     MODELS_UPLOAD_HELP_EXAMPLES,
+    BATCHES_SUBMIT_HELP_EXAMPLES,
     BETA_ENDPOINTS_HELP_EXAMPLES,
     JIG_JOB_STATUS_HELP_EXAMPLES,
     JIG_SECRETS_SET_HELP_EXAMPLES,
@@ -539,6 +541,17 @@ evals_app.command(
 evals_app.command((f"{_CLI}.evals.list:list"), alias="ls", help="List eval jobs")
 evals_app.command((f"{_CLI}.evals.retrieve:retrieve"), alias="get", help="Get eval job details")
 evals_app.command((f"{_CLI}.evals.status:status"), help="Get an eval job's status")
+
+## Batches API commands
+batches_app = app.command(App(name="batches", help="Submit and manage batch jobs", help_epilogue=BATCHES_HELP_EXAMPLES))
+batches_app.command(
+    (f"{_CLI}.batches.submit:submit"),
+    help="Submit a new batch job",
+    help_epilogue=BATCHES_SUBMIT_HELP_EXAMPLES,
+)
+batches_app.command((f"{_CLI}.batches.list:list"), alias="ls", help="List batch jobs")
+batches_app.command((f"{_CLI}.batches.retrieve:retrieve"), alias="get", help="Get batch job details")
+batches_app.command((f"{_CLI}.batches.cancel:cancel"), help="Cancel a batch job")
 
 ## Telemetry API commands
 telemetry_app = app.command(App(name="telemetry", help="Configure CLI telemetry"))

--- a/src/together/lib/cli/api/batches/_utils.py
+++ b/src/together/lib/cli/api/batches/_utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Literal
+from typing_extensions import TypeAlias
+
+BatchApiType: TypeAlias = Literal["chat.completions", "audio.transcriptions", "audio.translations"]
+BatchEndpoint: TypeAlias = Literal["/v1/chat/completions", "/v1/audio/transcriptions", "/v1/audio/translations"]
+
+API_TO_ENDPOINT: dict[BatchApiType, BatchEndpoint] = {
+    "chat.completions": "/v1/chat/completions",
+    "audio.transcriptions": "/v1/audio/transcriptions",
+    "audio.translations": "/v1/audio/translations",
+}
+
+ENDPOINT_TO_API: dict[str, BatchApiType] = {endpoint: api for api, endpoint in API_TO_ENDPOINT.items()}
+
+
+def format_endpoint(endpoint: str | None) -> str:
+    if not endpoint:
+        return ""
+    return ENDPOINT_TO_API.get(endpoint, endpoint)

--- a/src/together/lib/cli/api/batches/_utils.py
+++ b/src/together/lib/cli/api/batches/_utils.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from typing import Literal
 from typing_extensions import TypeAlias
 
+from together.lib.utils.tools import format_datetime
+from together.types.batch_job import BatchJob
+from together.lib.cli.utils._console import console
+
 BatchApiType: TypeAlias = Literal["chat.completions", "audio.transcriptions", "audio.translations"]
 BatchEndpoint: TypeAlias = Literal["/v1/chat/completions", "/v1/audio/transcriptions", "/v1/audio/translations"]
 
@@ -14,8 +18,69 @@ API_TO_ENDPOINT: dict[BatchApiType, BatchEndpoint] = {
 
 ENDPOINT_TO_API: dict[str, BatchApiType] = {endpoint: api for api, endpoint in API_TO_ENDPOINT.items()}
 
+STATUS_COLORS = {
+    "VALIDATING": "yellow",
+    "IN_PROGRESS": "yellow",
+    "COMPLETED": "green",
+    "FAILED": "red",
+    "EXPIRED": "red",
+    "CANCELLED": "red",
+}
+
+_INCOMPLETE_STATUSES = frozenset({"VALIDATING", "IN_PROGRESS"})
+_DOWNLOADABLE_STATUSES = frozenset({"COMPLETED", "FAILED", "EXPIRED", "CANCELLED"})
+_PROGRESS_BAR_WIDTH = 20
+
 
 def format_endpoint(endpoint: str | None) -> str:
     if not endpoint:
         return ""
     return ENDPOINT_TO_API.get(endpoint, endpoint)
+
+
+def format_status(status: str | None) -> str:
+    if not status:
+        return ""
+    color = STATUS_COLORS.get(status, "white")
+    return f"[bold {color}]{status.capitalize()}[/bold {color}]"
+
+
+def format_progress(progress: float) -> str:
+    pct = max(0.0, min(100.0, progress))
+    filled = round((pct / 100.0) * _PROGRESS_BAR_WIDTH)
+    bar = "█" * filled + "░" * (_PROGRESS_BAR_WIDTH - filled)
+    return f"[yellow]{bar}[/yellow] [bold]{pct:g}%[/bold]"
+
+
+def print_batch_detail(job: BatchJob) -> None:
+    """Print a curated human-readable view of a batch job."""
+    console.print("Batch job details:")
+    if job.created_at:
+        console.print(f" - Created at {format_datetime(job.created_at)}")
+    if job.status == "COMPLETED" and job.completed_at:
+        console.print(f" - Completed at {format_datetime(job.completed_at)}")
+
+    api = format_endpoint(job.endpoint)
+    if api:
+        console.print(f" - {api}")
+
+    if job.x_model_id:
+        console.print(f" - {job.x_model_id}")
+
+    if job.output_file_id:
+        console.print(f" - Output file ID {job.output_file_id}")
+
+    if job.error_file_id:
+        console.print(f" - [red]An error occurred[/red]")
+        console.print(f" - Error file ID {job.error_file_id}")
+
+    if job.error:
+        console.print(f" - [red]An error occurred[/red]")
+        console.print(job.error)
+
+    if job.status in _INCOMPLETE_STATUSES and job.progress is not None:
+        console.print(f"{format_progress(job.progress)} {format_status(job.status)}")
+
+    if job.status in _DOWNLOADABLE_STATUSES and job.id and (job.output_file_id or job.error_file_id):
+        console.print("\nDownload results with:")
+        console.print(f"[dim]-[/dim] [primary]tg batches download {job.id} --output ./out[/primary]")

--- a/src/together/lib/cli/api/batches/_utils.py
+++ b/src/together/lib/cli/api/batches/_utils.py
@@ -79,8 +79,11 @@ def print_batch_detail(job: BatchJob) -> None:
         if job.error:
             console.print(f"   {escape_rich_markup(job.error)}")
 
-    if job.status in _INCOMPLETE_STATUSES and job.progress is not None:
-        console.print(f"{format_progress(job.progress)} {format_status(job.status)}")
+    if job.status:
+        if job.status in _INCOMPLETE_STATUSES and job.progress is not None:
+            console.print(f"{format_progress(job.progress)} {format_status(job.status)}")
+        else:
+            console.print(format_status(job.status))
 
     if job.status in _DOWNLOADABLE_STATUSES and job.id and (job.output_file_id or job.error_file_id):
         console.print("\nDownload results with:")

--- a/src/together/lib/cli/api/batches/_utils.py
+++ b/src/together/lib/cli/api/batches/_utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Literal
 from typing_extensions import TypeAlias
 
+from rich.markup import escape as escape_rich_markup
+
 from together.lib.utils.tools import format_datetime
 from together.types.batch_job import BatchJob
 from together.lib.cli.utils._console import console
@@ -70,13 +72,12 @@ def print_batch_detail(job: BatchJob) -> None:
     if job.output_file_id:
         console.print(f" - Output file ID {job.output_file_id}")
 
-    if job.error_file_id:
-        console.print(f" - [red]An error occurred[/red]")
-        console.print(f" - Error file ID {job.error_file_id}")
-
-    if job.error:
-        console.print(f" - [red]An error occurred[/red]")
-        console.print(job.error)
+    if job.error_file_id or job.error:
+        console.print(" - [red]An error occurred[/red]")
+        if job.error_file_id:
+            console.print(f" - Error file ID {job.error_file_id}")
+        if job.error:
+            console.print(f"   {escape_rich_markup(job.error)}")
 
     if job.status in _INCOMPLETE_STATUSES and job.progress is not None:
         console.print(f"{format_progress(job.progress)} {format_status(job.status)}")

--- a/src/together/lib/cli/api/batches/cancel.py
+++ b/src/together/lib/cli/api/batches/cancel.py
@@ -8,7 +8,7 @@ from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.components.model_dump import print_model_dump
+from together.lib.cli.api.batches._utils import print_batch_detail
 
 
 async def cancel(
@@ -23,4 +23,4 @@ async def cancel(
         return
 
     console.print("[green]√[/green] Cancelled batch job")
-    print_model_dump(response, show_nulls=False)
+    print_batch_detail(response)

--- a/src/together/lib/cli/api/batches/cancel.py
+++ b/src/together/lib/cli/api/batches/cancel.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from cyclopts import Parameter
+
+from together._utils._json import openapi_dumps
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.components.model_dump import print_model_dump
+
+
+async def cancel(
+    batch_id: Annotated[str, Parameter(help="The ID of the batch job to cancel")],
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """Cancel a batch job."""
+    response = await show_loading_status("Cancelling batch job...", config.client.batches.cancel(batch_id))
+    if config.json:
+        console.print_json(openapi_dumps(response).decode("utf-8"))
+        return
+
+    console.print("[green]√[/green] Cancelled batch job")
+    print_model_dump(response, show_nulls=False)

--- a/src/together/lib/cli/api/batches/download.py
+++ b/src/together/lib/cli/api/batches/download.py
@@ -135,14 +135,11 @@ async def download(
         )
 
     if config.json:
-        payload: dict[str, str] = {
-            "batch_id": id,
-            "output_file_id": output_file_id,
-        }
-        if job.error_file_id:
-            payload["error_file_id"] = job.error_file_id
-        console.print_json(openapi_dumps(payload).decode("utf-8"))
-        return
+        _fail(
+            json_mode=True,
+            error="Pass --output to download batch result files; --json does not print file contents to stdout.",
+            rich_message="",
+        )
 
     await stream_file_content_to_stdout(config.client, output_file_id)
     if job.error_file_id:

--- a/src/together/lib/cli/api/batches/download.py
+++ b/src/together/lib/cli/api/batches/download.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import sys
+import base64
+from typing import Any, Optional, Annotated
+from pathlib import Path
+
+from cyclopts import Parameter, validators
+
+from together._utils._json import openapi_dumps
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.api.files.retrieve_content import download_file_content
+
+_TERMINAL_STATUSES = frozenset({"COMPLETED", "FAILED", "EXPIRED", "CANCELLED"})
+
+
+def _is_directory_output(path: Path) -> bool:
+    return path.is_dir() or path.suffix == ""
+
+
+def _error_output_path(output: Path) -> Path:
+    """Where to write the error file when *output* is a concrete file path."""
+    suffix = output.suffix or ".jsonl"
+    return output.with_name(f"{output.stem}.errors{suffix}")
+
+
+async def download(
+    id: Annotated[str, Parameter(help="The ID of the batch job")],
+    output: Annotated[
+        Optional[Path],
+        Parameter(
+            name=["--output", "-o"],
+            help="File or directory to save batch result files to; omit to print output to stdout",
+            validator=validators.Path(file_okay=True, dir_okay=True),
+        ),
+    ] = None,
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """Download output (and error) files for a batch job."""
+    job = await show_loading_status("Retrieving batch job...", config.client.batches.retrieve(id))
+    status = job.status or ""
+
+    if status not in _TERMINAL_STATUSES:
+        console.print(
+            f"[red]Batch job is not ready to download yet[/red] "
+            f"(status: {status or 'unknown'}). "
+            f"Check progress with [primary]tg batches get {id}[/primary]."
+        )
+        sys.exit(1)
+
+    if not job.output_file_id and not job.error_file_id:
+        console.print(f"[red]Batch job has no output or error files to download[/red] (status: {status}).")
+        sys.exit(1)
+
+    if output is not None:
+        saved: list[dict[str, str]] = []
+        directory_output = _is_directory_output(output)
+        error_file_id = job.error_file_id
+
+        if job.output_file_id:
+            out_path = await download_file_content(
+                config.client,
+                job.output_file_id,
+                output=output,
+                loading_message="Downloading batch output...",
+            )
+            assert isinstance(out_path, Path)
+            saved.append({"kind": "output", "id": job.output_file_id, "path": str(out_path)})
+        elif error_file_id and not directory_output:
+            # No output file — write the error file to the exact path the user asked for.
+            err_path = await download_file_content(
+                config.client,
+                error_file_id,
+                output=output,
+                loading_message="Downloading batch errors...",
+            )
+            assert isinstance(err_path, Path)
+            saved.append({"kind": "error", "id": error_file_id, "path": str(err_path)})
+            error_file_id = None
+
+        if error_file_id:
+            err_dest = output if directory_output else _error_output_path(output)
+            err_path = await download_file_content(
+                config.client,
+                error_file_id,
+                output=err_dest,
+                loading_message="Downloading batch errors...",
+            )
+            assert isinstance(err_path, Path)
+            saved.append({"kind": "error", "id": error_file_id, "path": str(err_path)})
+
+        if config.json:
+            console.print_json(openapi_dumps({"batch_id": id, "files": saved}).decode("utf-8"))
+            return
+
+        for item in saved:
+            label = "Output" if item["kind"] == "output" else "Errors"
+            console.print(f"[green]√[/green] {label} saved to [blue]{item['path']}[/blue]")
+        return
+
+    if not job.output_file_id:
+        console.print(
+            "[red]Batch job has no output file[/red]. "
+            "Use [primary]--output[/primary] to download the error file instead."
+        )
+        sys.exit(1)
+
+    raw = await download_file_content(
+        config.client,
+        job.output_file_id,
+        stdout=True,
+        loading_message="Downloading batch output...",
+    )
+    assert isinstance(raw, bytes)
+
+    if config.json:
+        try:
+            payload: dict[str, Any] = {
+                "batch_id": id,
+                "output_file_id": job.output_file_id,
+                "content": raw.decode("utf-8"),
+            }
+        except UnicodeDecodeError:
+            payload = {
+                "batch_id": id,
+                "output_file_id": job.output_file_id,
+                "content_base64": base64.b64encode(raw).decode("ascii"),
+            }
+        if job.error_file_id:
+            payload["error_file_id"] = job.error_file_id
+        console.print_json(openapi_dumps(payload).decode("utf-8"))
+        return
+
+    console.print(raw.decode("utf-8"))
+    if job.error_file_id:
+        console.print(f"\n[dim]Error file also available: tg batches download {id} --output ./out[/dim]")

--- a/src/together/lib/cli/api/batches/download.py
+++ b/src/together/lib/cli/api/batches/download.py
@@ -98,7 +98,13 @@ async def download(
             error_file_id = None
 
         if error_file_id:
-            err_dest = output if directory_output else _error_output_path(output)
+            if directory_output and saved:
+                # Server filenames are not unique across output/error files.
+                err_dest = _error_output_path(Path(saved[0]["path"]))
+            elif directory_output:
+                err_dest = output
+            else:
+                err_dest = _error_output_path(output)
             err_path = await download_file_content(
                 config.client,
                 error_file_id,

--- a/src/together/lib/cli/api/batches/download.py
+++ b/src/together/lib/cli/api/batches/download.py
@@ -1,29 +1,36 @@
 from __future__ import annotations
 
 import sys
-import base64
-from typing import Any, Optional, Annotated
+from typing import NoReturn, Optional, Annotated
 from pathlib import Path
 
 from cyclopts import Parameter, validators
 
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
-from together.lib.cli.utils._console import console
+from together.lib.cli.utils._console import console, error_console
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.api.files.retrieve_content import download_file_content
+from together.lib.cli.api.files.retrieve_content import (
+    is_directory_output,
+    download_file_content,
+    stream_file_content_to_stdout,
+)
 
 _TERMINAL_STATUSES = frozenset({"COMPLETED", "FAILED", "EXPIRED", "CANCELLED"})
-
-
-def _is_directory_output(path: Path) -> bool:
-    return path.is_dir() or path.suffix == ""
 
 
 def _error_output_path(output: Path) -> Path:
     """Where to write the error file when *output* is a concrete file path."""
     suffix = output.suffix or ".jsonl"
     return output.with_name(f"{output.stem}.errors{suffix}")
+
+
+def _fail(*, json_mode: bool, error: str, rich_message: str) -> NoReturn:
+    if json_mode:
+        console.print_json(openapi_dumps({"error": error}).decode("utf-8"))
+    else:
+        console.print(rich_message)
+    sys.exit(1)
 
 
 async def download(
@@ -44,20 +51,29 @@ async def download(
     status = job.status or ""
 
     if status not in _TERMINAL_STATUSES:
-        console.print(
-            f"[red]Batch job is not ready to download yet[/red] "
-            f"(status: {status or 'unknown'}). "
-            f"Check progress with [primary]tg batches get {id}[/primary]."
+        _fail(
+            json_mode=config.json,
+            error=(
+                f"Batch job is not ready to download yet (status: {status or 'unknown'}). "
+                f"Check progress with tg batches get {id}."
+            ),
+            rich_message=(
+                f"[red]Batch job is not ready to download yet[/red] "
+                f"(status: {status or 'unknown'}). "
+                f"Check progress with [primary]tg batches get {id}[/primary]."
+            ),
         )
-        sys.exit(1)
 
     if not job.output_file_id and not job.error_file_id:
-        console.print(f"[red]Batch job has no output or error files to download[/red] (status: {status}).")
-        sys.exit(1)
+        _fail(
+            json_mode=config.json,
+            error=f"Batch job has no output or error files to download (status: {status}).",
+            rich_message=f"[red]Batch job has no output or error files to download[/red] (status: {status}).",
+        )
 
     if output is not None:
         saved: list[dict[str, str]] = []
-        directory_output = _is_directory_output(output)
+        directory_output = is_directory_output(output)
         error_file_id = job.error_file_id
 
         if job.output_file_id:
@@ -101,39 +117,29 @@ async def download(
             console.print(f"[green]√[/green] {label} saved to [blue]{item['path']}[/blue]")
         return
 
-    if not job.output_file_id:
-        console.print(
-            "[red]Batch job has no output file[/red]. "
-            "Use [primary]--output[/primary] to download the error file instead."
+    output_file_id = job.output_file_id
+    if not output_file_id:
+        _fail(
+            json_mode=config.json,
+            error="Batch job has no output file. Use --output to download the error file instead.",
+            rich_message=(
+                "[red]Batch job has no output file[/red]. "
+                "Use [primary]--output[/primary] to download the error file instead."
+            ),
         )
-        sys.exit(1)
-
-    raw = await download_file_content(
-        config.client,
-        job.output_file_id,
-        stdout=True,
-        loading_message="Downloading batch output...",
-    )
-    assert isinstance(raw, bytes)
 
     if config.json:
-        try:
-            payload: dict[str, Any] = {
-                "batch_id": id,
-                "output_file_id": job.output_file_id,
-                "content": raw.decode("utf-8"),
-            }
-        except UnicodeDecodeError:
-            payload = {
-                "batch_id": id,
-                "output_file_id": job.output_file_id,
-                "content_base64": base64.b64encode(raw).decode("ascii"),
-            }
+        payload: dict[str, str] = {
+            "batch_id": id,
+            "output_file_id": output_file_id,
+        }
         if job.error_file_id:
             payload["error_file_id"] = job.error_file_id
         console.print_json(openapi_dumps(payload).decode("utf-8"))
         return
 
-    console.print(raw.decode("utf-8"))
+    await stream_file_content_to_stdout(config.client, output_file_id)
     if job.error_file_id:
-        console.print(f"\n[dim]Error file also available: tg batches download {id} --output ./out[/dim]")
+        error_console.print(
+            f"[dim]Error file also available: tg batches download {id} --output ./out[/dim]",
+        )

--- a/src/together/lib/cli/api/batches/list.py
+++ b/src/together/lib/cli/api/batches/list.py
@@ -8,17 +8,8 @@ from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.list import ListTable
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.api.batches._utils import format_endpoint
+from together.lib.cli.api.batches._utils import STATUS_COLORS, format_endpoint
 from together.lib.cli.utils._mock_pagination import AfterParameter, mock_pagination
-
-status_colors = {
-    "VALIDATING": "yellow",
-    "IN_PROGRESS": "yellow",
-    "COMPLETED": "green",
-    "FAILED": "red",
-    "EXPIRED": "red",
-    "CANCELLED": "red",
-}
 
 
 async def list(
@@ -50,7 +41,7 @@ async def list(
 
     for job in jobs_to_display:
         status = str(job.status) if job.status is not None else ""
-        status_color = status_colors.get(status, "white")
+        status_color = STATUS_COLORS.get(status, "white")
         if job.status == "IN_PROGRESS" and job.progress is not None:
             status = f"{status}: {job.progress:g}%"
 

--- a/src/together/lib/cli/api/batches/list.py
+++ b/src/together/lib/cli/api/batches/list.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from together._utils._json import openapi_dumps
+from together.lib.utils.tools import format_datetime
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+from together.lib.cli.components.list import ListTable
+from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.api.batches._utils import format_endpoint
+from together.lib.cli.utils._mock_pagination import AfterParameter, mock_pagination
+
+status_colors = {
+    "VALIDATING": "yellow",
+    "IN_PROGRESS": "yellow",
+    "COMPLETED": "green",
+    "FAILED": "red",
+    "EXPIRED": "red",
+    "CANCELLED": "red",
+}
+
+
+async def list(
+    after: AfterParameter = None,
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """List batch jobs."""
+    response = await show_loading_status("Loading batch jobs...", config.client.batches.list())
+    jobs = response or []
+
+    epoch_start = datetime.fromtimestamp(0, tz=timezone.utc)
+    jobs.sort(key=lambda x: x.created_at or epoch_start, reverse=True)
+
+    jobs_to_display, next_cursor = mock_pagination(jobs, cursor_field="id", cursor=after)
+
+    if config.json:
+        console.print_json(openapi_dumps(jobs_to_display).decode("utf-8"))
+        return
+
+    table = ListTable(
+        empty_message="You don't have any batch jobs yet. To submit your first batch run:\n  [dim]-[/dim] [primary]tg batches submit[/primary]"
+    )
+    table.add_primary_column("ID")
+    table.add_column("API")
+    table.add_column("Model")
+    table.add_column("Status")
+    table.add_column("Created At")
+
+    for job in jobs_to_display:
+        status = str(job.status) if job.status is not None else ""
+        status_color = status_colors.get(status, "white")
+        if job.status == "IN_PROGRESS" and job.progress is not None:
+            status = f"{status}: {job.progress:g}%"
+
+        table.add_row(
+            job.id or "",
+            format_endpoint(job.endpoint),
+            job.x_model_id or "",
+            f"[{status_color}]{status}[/{status_color}]",
+            format_datetime(job.created_at) if job.created_at else "",
+        )
+    console.print(table)
+    if next_cursor:
+        console.print("\n[blue dim]To display the next page, run:[/blue dim]")
+        console.print(f"  [dim]-[/dim] [white]tg batches list --after {next_cursor}[/white]")

--- a/src/together/lib/cli/api/batches/retrieve.py
+++ b/src/together/lib/cli/api/batches/retrieve.py
@@ -8,7 +8,7 @@ from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.components.model_dump import print_model_dump
+from together.lib.cli.api.batches._utils import print_batch_detail
 
 
 async def retrieve(
@@ -22,4 +22,4 @@ async def retrieve(
         console.print_json(openapi_dumps(response).decode("utf-8"))
         return
 
-    print_model_dump(response, show_nulls=False)
+    print_batch_detail(response)

--- a/src/together/lib/cli/api/batches/retrieve.py
+++ b/src/together/lib/cli/api/batches/retrieve.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from cyclopts import Parameter
+
+from together._utils._json import openapi_dumps
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.components.model_dump import print_model_dump
+
+
+async def retrieve(
+    batch_id: Annotated[str, Parameter(help="The ID of the batch job")],
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """Get details of a batch job."""
+    response = await show_loading_status("Retrieving batch job...", config.client.batches.retrieve(batch_id))
+    if config.json:
+        console.print_json(openapi_dumps(response).decode("utf-8"))
+        return
+
+    print_model_dump(response, show_nulls=False)

--- a/src/together/lib/cli/api/batches/submit.py
+++ b/src/together/lib/cli/api/batches/submit.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import sys
 from typing import Optional, Annotated
 from pathlib import Path
 
 from cyclopts import Parameter
+from rich.markup import escape as escape_rich_markup
 
 from together import omit
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
 from together.lib.cli.components.loader import show_loading_status
-from together.lib.cli.api.batches._utils import API_TO_ENDPOINT, BatchApiType
-from together.lib.cli.components.model_dump import print_model_dump
+from together.lib.cli.api.batches._utils import API_TO_ENDPOINT, BatchApiType, print_batch_detail
 
 
 def _check_path_exists(path_string: str) -> bool:
@@ -69,20 +70,25 @@ async def submit(
         ),
     )
 
+    job = response.job
+    created = job is not None and bool(job.id)
+
     if config.json:
         console.print_json(openapi_dumps(response).decode("utf-8"))
+        if not created:
+            sys.exit(1)
         return
 
-    job = response.job
-    if job is None or not job.id:
+    if not created:
         console.print("[red]x[/red] Batch job was not created")
         if response.warning:
-            console.print(response.warning)
-        return
+            console.print(escape_rich_markup(response.warning))
+        sys.exit(1)
 
+    assert job is not None
     console.print(f"[green]√ Batch job submitted.[/green] [dim]({job.id})[/dim]")
     if response.warning:
-        console.print(f"[yellow]{response.warning}[/yellow]")
-    print_model_dump(job, show_nulls=False)
+        console.print(f"[yellow]{escape_rich_markup(response.warning)}[/yellow]")
+    print_batch_detail(job)
     console.print("\n  You can track the job's progress with:")
     console.print(f"  [dim]-[/dim] [primary]tg batches get {job.id}[/primary]")

--- a/src/together/lib/cli/api/batches/submit.py
+++ b/src/together/lib/cli/api/batches/submit.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Optional, Annotated
+from pathlib import Path
+
+from cyclopts import Parameter
+
+from together import omit
+from together._utils._json import openapi_dumps
+from together.lib.cli.utils.config import CLIConfigParameter
+from together.lib.cli.utils._console import console
+from together.lib.cli.components.loader import show_loading_status
+from together.lib.cli.api.batches._utils import API_TO_ENDPOINT, BatchApiType
+from together.lib.cli.components.model_dump import print_model_dump
+
+
+def _check_path_exists(path_string: str) -> bool:
+    if path_string == "":
+        return False
+    p = Path(path_string)
+    if p.is_dir():
+        raise ValueError(f"Path {path_string} is a directory, not a file. Please provide a file path.")
+    return p.exists() and p.is_file()
+
+
+async def submit(
+    file: Annotated[
+        str,
+        Parameter(help="File ID from Files API or local path to a file to upload"),
+    ],
+    api: Annotated[
+        BatchApiType,
+        Parameter(help="API to dispatch each line of the input file against"),
+    ],
+    model: Annotated[
+        str,
+        Parameter(alias="-M", help="Model to use for processing batch requests"),
+    ],
+    completion_window: Annotated[
+        Optional[str],
+        Parameter(help="Time window for batch completion"),
+    ] = None,
+    priority: Annotated[
+        Optional[int],
+        Parameter(help="Priority for batch processing"),
+    ] = None,
+    *,
+    config: CLIConfigParameter,
+) -> None:
+    """Submit a new batch job."""
+    input_file_id = file
+    if _check_path_exists(file):
+        file_upload = await show_loading_status(
+            "Uploading file...",
+            config.client.files.upload(Path(file), purpose="batch-api", check=False),
+        )
+        if not file_upload.id:
+            raise ValueError("File upload did not return a file ID")
+        input_file_id = file_upload.id
+
+    response = await show_loading_status(
+        "Submitting batch job...",
+        config.client.batches.create(
+            endpoint=API_TO_ENDPOINT[api],
+            input_file_id=input_file_id,
+            model_id=model,
+            completion_window=completion_window or omit,
+            priority=priority if priority is not None else omit,
+        ),
+    )
+
+    if config.json:
+        console.print_json(openapi_dumps(response).decode("utf-8"))
+        return
+
+    job = response.job
+    if job is None or not job.id:
+        console.print("[red]x[/red] Batch job was not created")
+        if response.warning:
+            console.print(response.warning)
+        return
+
+    console.print(f"[green]√ Batch job submitted.[/green] [dim]({job.id})[/dim]")
+    if response.warning:
+        console.print(f"[yellow]{response.warning}[/yellow]")
+    print_model_dump(job, show_nulls=False)
+    console.print("\n  You can track the job's progress with:")
+    console.print(f"  [dim]-[/dim] [primary]tg batches get {job.id}[/primary]")

--- a/src/together/lib/cli/api/batches/submit.py
+++ b/src/together/lib/cli/api/batches/submit.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import sys
-from typing import Optional, Annotated
+from typing import Annotated
 from pathlib import Path
 
 from cyclopts import Parameter
 from rich.markup import escape as escape_rich_markup
 
-from together import omit
 from together._utils._json import openapi_dumps
 from together.lib.cli.utils.config import CLIConfigParameter
 from together.lib.cli.utils._console import console
@@ -33,18 +32,6 @@ async def submit(
         BatchApiType,
         Parameter(help="API to dispatch each line of the input file against"),
     ],
-    model: Annotated[
-        str,
-        Parameter(alias="-M", help="Model to use for processing batch requests"),
-    ],
-    completion_window: Annotated[
-        Optional[str],
-        Parameter(help="Time window for batch completion"),
-    ] = None,
-    priority: Annotated[
-        Optional[int],
-        Parameter(help="Priority for batch processing"),
-    ] = None,
     *,
     config: CLIConfigParameter,
 ) -> None:
@@ -55,8 +42,6 @@ async def submit(
             "Uploading file...",
             config.client.files.upload(Path(file), purpose="batch-api", check=False),
         )
-        if not file_upload.id:
-            raise ValueError("File upload did not return a file ID")
         input_file_id = file_upload.id
 
     response = await show_loading_status(
@@ -64,9 +49,6 @@ async def submit(
         config.client.batches.create(
             endpoint=API_TO_ENDPOINT[api],
             input_file_id=input_file_id,
-            model_id=model,
-            completion_window=completion_window or omit,
-            priority=priority if priority is not None else omit,
         ),
     )
 

--- a/src/together/lib/cli/api/files/retrieve_content.py
+++ b/src/together/lib/cli/api/files/retrieve_content.py
@@ -42,6 +42,27 @@ async def get_filename(client: AsyncTogether, id: str) -> str:
     return safe_download_filename(r.filename or "", fallback=id)
 
 
+def is_directory_output(path: Path) -> bool:
+    """True when *path* should be treated as a destination directory.
+
+    Existing files (including suffix-less names like ``./results``) are files.
+    Missing suffix-less paths are directories to create.
+    """
+    if path.is_dir():
+        return True
+    if path.exists():
+        return False
+    return path.suffix == ""
+
+
+async def stream_file_content_to_stdout(client: AsyncTogether, id: str) -> None:
+    """Stream file bytes to stdout without buffering the whole body."""
+    async with client.files.with_streaming_response.content(id=id) as response:
+        async for chunk in response.iter_bytes():
+            sys.stdout.buffer.write(chunk)
+        sys.stdout.buffer.flush()
+
+
 async def download_file_content(
     client: AsyncTogether,
     id: str,
@@ -56,21 +77,20 @@ async def download_file_content(
     if stdout is True and output is not None:
         raise ValueError("--stdout and --output cannot be used together")
 
-    response = await show_loading_status(loading_message, client.files.content(id=id))
+    async with client.files.with_streaming_response.content(id=id) as response:
+        if stdout:
+            return await response.read()
 
-    if stdout:
-        return await response.read()
+        assert output is not None
+        if is_directory_output(output):
+            output.mkdir(parents=True, exist_ok=True)
+            out_path = resolve_download_path(output, await get_filename(client, id))
+        else:
+            output.parent.mkdir(parents=True, exist_ok=True)
+            out_path = output
 
-    assert output is not None
-    if output.is_dir() or output.suffix == "":
-        output.mkdir(parents=True, exist_ok=True)
-        out_path = resolve_download_path(output, await get_filename(client, id))
-    else:
-        output.parent.mkdir(parents=True, exist_ok=True)
-        out_path = output
-
-    await response.write_to_file(out_path)
-    return out_path
+        await show_loading_status(loading_message, response.stream_to_file(out_path))
+        return out_path
 
 
 async def retrieve_content(

--- a/src/together/lib/cli/api/files/retrieve_content.py
+++ b/src/together/lib/cli/api/files/retrieve_content.py
@@ -42,6 +42,37 @@ async def get_filename(client: AsyncTogether, id: str) -> str:
     return safe_download_filename(r.filename or "", fallback=id)
 
 
+async def download_file_content(
+    client: AsyncTogether,
+    id: str,
+    *,
+    output: Path | None = None,
+    stdout: bool = False,
+    loading_message: str = "Retrieving file contents...",
+) -> Path | bytes:
+    """Download file content to *output*, or return raw bytes when *stdout* is True."""
+    if stdout is False and output is None:
+        raise ValueError("Either output or stdout must be specified")
+    if stdout is True and output is not None:
+        raise ValueError("--stdout and --output cannot be used together")
+
+    response = await show_loading_status(loading_message, client.files.content(id=id))
+
+    if stdout:
+        return await response.read()
+
+    assert output is not None
+    if output.is_dir() or output.suffix == "":
+        output.mkdir(parents=True, exist_ok=True)
+        out_path = resolve_download_path(output, await get_filename(client, id))
+    else:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        out_path = output
+
+    await response.write_to_file(out_path)
+    return out_path
+
+
 async def retrieve_content(
     id: str,
     output: Annotated[
@@ -63,31 +94,20 @@ async def retrieve_content(
         console.print(f"[red]Invalid usage: --stdout and --output cannot be used together[/red]")
         sys.exit(1)
 
-    response = await show_loading_status("Retrieving file contents...", config.client.files.content(id=id))
+    result = await download_file_content(config.client, id, output=output, stdout=bool(stdout))
 
-    if stdout:
-        raw = await response.read()
+    if isinstance(result, bytes):
         if config.json:
             try:
-                payload = {"id": id, "content": raw.decode("utf-8")}
+                payload = {"id": id, "content": result.decode("utf-8")}
             except UnicodeDecodeError:
-                payload = {"id": id, "content_base64": base64.b64encode(raw).decode("ascii")}
+                payload = {"id": id, "content_base64": base64.b64encode(result).decode("ascii")}
             console.print_json(openapi_dumps(payload).decode("utf-8"))
         else:
-            console.print(raw.decode("utf-8"))
+            console.print(result.decode("utf-8"))
         return
 
-    if output is not None:
-        if output.is_dir() or output.suffix == "":
-            output.mkdir(parents=True, exist_ok=True)
-            out_path = resolve_download_path(output, await get_filename(config.client, id))
-        else:
-            output.parent.mkdir(parents=True, exist_ok=True)
-            out_path = output
-
-        await response.write_to_file(out_path)
-
-        if config.json:
-            console.print_json(openapi_dumps({"id": id, "path": str(out_path)}).decode("utf-8"))
-        else:
-            console.print(f"File saved to [blue]{out_path}[/blue]")
+    if config.json:
+        console.print_json(openapi_dumps({"id": id, "path": str(result)}).decode("utf-8"))
+    else:
+        console.print(f"File saved to [blue]{result}[/blue]")

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -223,6 +223,33 @@ ENDPOINTS_UPDATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
   [primary]tg endpoints update ENDPOINT_ID --inactive-timeout 30[/primary]
 """
 
+## Batches API commands
+
+BATCHES_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Submit a chat completions batch from a local file:
+  [primary]tg batches submit ./requests.jsonl chat.completions Qwen/Qwen3.5-9B[/primary]
+
+[dim]-[/dim] List batch jobs:
+  [primary]tg batches ls[/primary]
+
+[dim]-[/dim] Get details of a batch job:
+  [primary]tg batches get <batch-id>[/primary]
+
+[dim]-[/dim] Cancel a batch job:
+  [primary]tg batches cancel <batch-id>[/primary]
+"""
+
+BATCHES_SUBMIT_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Submit a chat completions batch from a local JSONL file:
+  [primary]tg batches submit ./requests.jsonl chat.completions Qwen/Qwen3.5-9B[/primary]
+
+[dim]-[/dim] Submit using a previously uploaded file ID:
+  [primary]tg batches submit file-abc123 --api chat.completions -M Qwen/Qwen3.5-9B[/primary]
+
+[dim]-[/dim] Submit an audio transcription batch:
+  [primary]tg batches submit ./audio.jsonl --api audio.transcriptions --model openai/whisper-large-v3[/primary]
+"""
+
 ## Evals API commands
 
 EVALS_HELP_EXAMPLES = """[dim]Examples:[/dim]

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -227,7 +227,7 @@ ENDPOINTS_UPDATE_HELP_EXAMPLES = """[dim]Examples:[/dim]
 
 BATCHES_HELP_EXAMPLES = """[dim]Examples:[/dim]
 [dim]-[/dim] Submit a chat completions batch from a local file:
-  [primary]tg batches submit ./requests.jsonl chat.completions Qwen/Qwen3.5-9B[/primary]
+  [primary]tg batches submit ./requests.jsonl chat.completions[/primary]
 
 [dim]-[/dim] List batch jobs:
   [primary]tg batches ls[/primary]
@@ -244,13 +244,13 @@ BATCHES_HELP_EXAMPLES = """[dim]Examples:[/dim]
 
 BATCHES_SUBMIT_HELP_EXAMPLES = """[dim]Examples:[/dim]
 [dim]-[/dim] Submit a chat completions batch from a local JSONL file:
-  [primary]tg batches submit ./requests.jsonl chat.completions Qwen/Qwen3.5-9B[/primary]
+  [primary]tg batches submit ./requests.jsonl chat.completions[/primary]
 
 [dim]-[/dim] Submit using a previously uploaded file ID:
-  [primary]tg batches submit file-abc123 --api chat.completions -M Qwen/Qwen3.5-9B[/primary]
+  [primary]tg batches submit file-abc123 --api chat.completions[/primary]
 
 [dim]-[/dim] Submit an audio transcription batch:
-  [primary]tg batches submit ./audio.jsonl --api audio.transcriptions --model openai/whisper-large-v3[/primary]
+  [primary]tg batches submit ./audio.jsonl --api audio.transcriptions[/primary]
 """
 
 BATCHES_DOWNLOAD_HELP_EXAMPLES = """[dim]Examples:[/dim]

--- a/src/together/lib/cli/utils/_help_examples.py
+++ b/src/together/lib/cli/utils/_help_examples.py
@@ -233,7 +233,10 @@ BATCHES_HELP_EXAMPLES = """[dim]Examples:[/dim]
   [primary]tg batches ls[/primary]
 
 [dim]-[/dim] Get details of a batch job:
-  [primary]tg batches get <batch-id>[/primary]
+  [primary]tg batches <batch-id>[/primary]
+
+[dim]-[/dim] Print batch results to stdout:
+  [primary]tg batches download <batch-id>[/primary]
 
 [dim]-[/dim] Cancel a batch job:
   [primary]tg batches cancel <batch-id>[/primary]
@@ -248,6 +251,14 @@ BATCHES_SUBMIT_HELP_EXAMPLES = """[dim]Examples:[/dim]
 
 [dim]-[/dim] Submit an audio transcription batch:
   [primary]tg batches submit ./audio.jsonl --api audio.transcriptions --model openai/whisper-large-v3[/primary]
+"""
+
+BATCHES_DOWNLOAD_HELP_EXAMPLES = """[dim]Examples:[/dim]
+[dim]-[/dim] Print batch output to stdout:
+  [primary]tg batches download <batch-id>[/primary]
+
+[dim]-[/dim] Download batch output to a file:
+  [primary]tg batches download <batch-id> --output ./results.jsonl[/primary]
 """
 
 ## Evals API commands

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -22,6 +22,7 @@ _COMMAND_ID_IDENTIFIERS = {
     "beta clusters storage": _UUID_RE,
     "beta clusters remediations": _UUID_RE,
     "beta jig volumes": _UUID_RE,
+    "batches": _UUID_RE,
 }
 
 # Help/version flags registered on every App — not user subcommands.

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -12,6 +12,7 @@ _COMMAND_ID_IDENTIFIERS = {
     "fine-tuning": re.compile(r"^ft-"),
     "files": re.compile(r"^file-"),
     "evals": re.compile(r"^eval-"),
+    "batches": re.compile(r"^batch"),
     "endpoints": re.compile(r"^endpoint-"),
     "beta models configs": re.compile(r"^ep_"),
     # `beta endpoints` uses App.default(retrieve) instead of token rewriting.

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -22,7 +22,6 @@ _COMMAND_ID_IDENTIFIERS = {
     "beta clusters storage": _UUID_RE,
     "beta clusters remediations": _UUID_RE,
     "beta jig volumes": _UUID_RE,
-    "batches": _UUID_RE,
 }
 
 # Help/version flags registered on every App — not user subcommands.

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -206,12 +206,11 @@ class TestBatchesRetrieve:
         respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
         result = cli_runner.invoke(["batches", "get", "batch_job_newer"])
         assert result.exit_code == 0
-        assert "batch_job_newer" in result.output
-        assert "COMPLETED" in result.output
+        assert "Batch job details:" in result.output
+        assert "Completed at" in result.output
         assert "chat.completions" in result.output
         assert "Qwen/Qwen3.5-9B" in result.output
         assert "file-out" in result.output
-        assert "Progress:" not in result.output
         assert "tg batches download batch_job_newer --output ./out" in result.output
         # Raw dump fields that shouldn't clutter the human view
         assert "file_size_bytes" not in result.output
@@ -222,8 +221,7 @@ class TestBatchesRetrieve:
         respx_mock.get("/batches/batch_job_older").mock(return_value=httpx.Response(200, json=_BATCH_JOB_OLDER))
         result = cli_runner.invoke(["batches", "get", "batch_job_older"])
         assert result.exit_code == 0
-        assert "IN_PROGRESS" in result.output
-        assert "Progress:" in result.output
+        assert "In_progress" in result.output
         assert "42.5%" in result.output
         assert "audio.transcriptions" in result.output
         assert "tg batches download" not in result.output

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -361,28 +361,42 @@ class TestBatchesDownload:
                 },
             )
         )
-        respx_mock.get("/files/file-err").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "id": "file-err",
-                    "bytes": 12,
-                    "created_at": 1,
-                    "filename": "batch-errors.jsonl",
-                    "FileType": "jsonl",
-                    "object": "file",
-                    "Processed": True,
-                    "purpose": "batch-api",
-                },
-            )
-        )
 
         result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--output", str(tmp_path)])
         assert result.exit_code == 0
         assert (tmp_path / "batch-output.jsonl").read_bytes() == b'{"ok":true}\n'
-        assert (tmp_path / "batch-errors.jsonl").read_bytes() == b'{"err":true}\n'
+        assert (tmp_path / "batch-output.errors.jsonl").read_bytes() == b'{"err":true}\n'
         assert "Output saved" in result.output
         assert "Errors saved" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_directory_disambiguates_identical_filenames(
+        self, respx_mock: MockRouter, tmp_path: Path, cli_runner: CliRunner
+    ) -> None:
+        job = {**_BATCH_JOB, "error_file_id": "file-err"}
+        file_meta = {
+            "bytes": 12,
+            "created_at": 1,
+            "filename": "batch.jsonl",
+            "FileType": "jsonl",
+            "object": "file",
+            "Processed": True,
+            "purpose": "batch-api",
+        }
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=job))
+        respx_mock.get("/files/file-out/content").mock(return_value=httpx.Response(200, content=b'{"ok":true}\n'))
+        respx_mock.get("/files/file-err/content").mock(return_value=httpx.Response(200, content=b'{"err":true}\n'))
+        respx_mock.get("/files/file-out").mock(return_value=httpx.Response(200, json={"id": "file-out", **file_meta}))
+
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--output", str(tmp_path), "--json"])
+        assert result.exit_code == 0
+        assert (tmp_path / "batch.jsonl").read_bytes() == b'{"ok":true}\n'
+        assert (tmp_path / "batch.errors.jsonl").read_bytes() == b'{"err":true}\n'
+        body = json.loads(result.output)
+        paths = [item["path"] for item in body["files"]]
+        assert paths[0] != paths[1]
+        assert Path(paths[0]).name == "batch.jsonl"
+        assert Path(paths[1]).name == "batch.errors.jsonl"
 
     @pytest.mark.respx(base_url=base_url)
     def test_download_output_to_file(self, respx_mock: MockRouter, tmp_path: Path, cli_runner: CliRunner) -> None:

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -479,15 +479,15 @@ class TestBatchesDownload:
         assert "no output or error files" in body["error"].lower()
 
     @pytest.mark.respx(base_url=base_url)
-    def test_download_stdout_json_is_metadata_only(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+    def test_download_json_without_output_requires_output_flag(
+        self, respx_mock: MockRouter, cli_runner: CliRunner
+    ) -> None:
         respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
         result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--json"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         body = json.loads(result.output)
-        assert body["batch_id"] == "batch_job_newer"
-        assert body["output_file_id"] == "file-out"
-        assert "content" not in body
-        assert "content_base64" not in body
+        assert "--output" in body["error"]
+        assert "stdout" in body["error"]
 
     @pytest.mark.respx(base_url=base_url)
     def test_download_stdout_no_output_file_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -72,12 +72,12 @@ def _file_response(**kwargs: Any) -> FileResponse:
 
 
 class TestBatchesSubmit:
-    def test_submit_help_describes_api_and_model_flags(self, cli_runner: CliRunner) -> None:
+    def test_submit_help_describes_api_types(self, cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(["batches", "submit", "--help"])
         assert result.exit_code == 0
         assert "--api" in result.output
-        assert "--model" in result.output
-        assert "-M" in result.output
+        assert "--model" not in result.output
+        assert "-M" not in result.output
         assert "chat.completions" in result.output
         assert "audio.transcriptions" in result.output
         assert "audio.translations" in result.output
@@ -85,13 +85,13 @@ class TestBatchesSubmit:
     @pytest.mark.respx(base_url=base_url)
     def test_submit_positional_args(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         route = respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
-        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B"])
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions"])
         assert result.exit_code == 0
         assert "batch_job_created" in result.output
         payload = json.loads(cast(Call, route.calls[0]).request.content)
         assert payload["endpoint"] == "/v1/chat/completions"
         assert payload["input_file_id"] == "file-abc123"
-        assert payload["model_id"] == "Qwen/Qwen3.5-9B"
+        assert "model_id" not in payload
 
     @pytest.mark.respx(base_url=base_url)
     def test_submit_flag_args(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
@@ -103,21 +103,17 @@ class TestBatchesSubmit:
                 "file-abc123",
                 "--api",
                 "audio.transcriptions",
-                "-M",
-                "openai/whisper-large-v3",
             ]
         )
         assert result.exit_code == 0
         payload = json.loads(cast(Call, route.calls[0]).request.content)
         assert payload["endpoint"] == "/v1/audio/transcriptions"
-        assert payload["model_id"] == "openai/whisper-large-v3"
+        assert "model_id" not in payload
 
     @pytest.mark.respx(base_url=base_url)
     def test_submit_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
-        result = cli_runner.invoke(
-            ["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B", "--json"]
-        )
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions", "--json"])
         assert result.exit_code == 0
         body = json.loads(result.output)
         assert body["job"]["id"] == "batch_job_created"
@@ -129,7 +125,7 @@ class TestBatchesSubmit:
         create = respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
         with patch("together.resources.files.AsyncFilesResource.upload", new_callable=AsyncMock) as upload_mock:
             upload_mock.return_value = _file_response(id="file-uploaded")
-            result = cli_runner.invoke(["batches", "submit", str(sample), "chat.completions", "Qwen/Qwen3.5-9B"])
+            result = cli_runner.invoke(["batches", "submit", str(sample), "chat.completions"])
         assert result.exit_code == 0
         upload_mock.assert_called_once()
         assert upload_mock.call_args.kwargs["purpose"] == "batch-api"
@@ -138,12 +134,12 @@ class TestBatchesSubmit:
         assert payload["input_file_id"] == "file-uploaded"
 
     def test_submit_rejects_directory(self, tmp_path: Path, cli_runner: CliRunner) -> None:
-        result = cli_runner.invoke(["batches", "submit", str(tmp_path), "chat.completions", "Qwen/Qwen3.5-9B"])
+        result = cli_runner.invoke(["batches", "submit", str(tmp_path), "chat.completions"])
         assert result.exit_code == 1
         assert "directory" in result.output.lower()
 
     def test_submit_rejects_invalid_api(self, cli_runner: CliRunner) -> None:
-        result = cli_runner.invoke(["batches", "submit", "file-abc123", "not.an.api", "Qwen/Qwen3.5-9B"])
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "not.an.api"])
         assert result.exit_code == 1
 
     @pytest.mark.respx(base_url=base_url)
@@ -151,7 +147,7 @@ class TestBatchesSubmit:
         respx_mock.post("/batches").mock(
             return_value=httpx.Response(200, json={"job": None, "warning": "validation failed: missing [/close] tag"})
         )
-        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B"])
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions"])
         assert result.exit_code == 1
         assert "was not created" in result.output
         assert "MarkupError" not in result.output
@@ -160,9 +156,7 @@ class TestBatchesSubmit:
     @pytest.mark.respx(base_url=base_url)
     def test_submit_null_job_json_exits_nonzero(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         respx_mock.post("/batches").mock(return_value=httpx.Response(200, json={"job": None, "warning": "nope"}))
-        result = cli_runner.invoke(
-            ["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B", "--json"]
-        )
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions", "--json"])
         assert result.exit_code == 1
         body = json.loads(result.output)
         assert body["job"] is None
@@ -171,7 +165,7 @@ class TestBatchesSubmit:
     @pytest.mark.respx(base_url=base_url)
     def test_submit_does_not_print_x_model_id(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
-        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B"])
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions"])
         assert result.exit_code == 0
         assert "X Model Id" not in result.output
         assert "Qwen/Qwen3.5-9B" in result.output

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import os
+import json
+from typing import Any, cast
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from respx import MockRouter
+from respx.models import Call
+
+from tests.cli.utils import CliRunner
+from together.types.file_response import FileResponse
+
+base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+_BATCH_JOB = {
+    "id": "batch_job_newer",
+    "status": "COMPLETED",
+    "endpoint": "/v1/chat/completions",
+    "model_id": "Qwen/Qwen3.5-9B",
+    "input_file_id": "file-abc123",
+    "output_file_id": "file-out",
+    "progress": 100.0,
+    "file_size_bytes": 2048,
+    "created_at": "2024-06-02T12:00:00Z",
+    "completed_at": "2024-06-02T13:00:00Z",
+}
+
+_BATCH_JOB_OLDER = {
+    "id": "batch_job_older",
+    "status": "IN_PROGRESS",
+    "endpoint": "/v1/audio/transcriptions",
+    "model_id": "openai/whisper-large-v3",
+    "input_file_id": "file-xyz",
+    "progress": 42.5,
+    "file_size_bytes": 512,
+    "created_at": "2024-01-01T12:00:00Z",
+}
+
+_BATCH_CREATE = {
+    "job": {
+        "id": "batch_job_created",
+        "status": "VALIDATING",
+        "endpoint": "/v1/chat/completions",
+        "model_id": "Qwen/Qwen3.5-9B",
+        "input_file_id": "file-abc123",
+        "progress": 0.0,
+        "created_at": "2024-06-02T12:00:00Z",
+    },
+    "warning": None,
+}
+
+
+def _file_response(**kwargs: Any) -> FileResponse:
+    defaults: dict[str, Any] = {
+        "id": "file-up",
+        "bytes": 10,
+        "created_at": 1,
+        "filename": "x.jsonl",
+        "FileType": "jsonl",
+        "object": "file",
+        "Processed": True,
+        "purpose": "batch-api",
+    }
+    defaults.update(kwargs)
+    if hasattr(FileResponse, "model_validate"):
+        return FileResponse.model_validate(defaults)
+    return FileResponse.parse_obj(defaults)  # pyright: ignore[reportDeprecated]
+
+
+class TestBatchesSubmit:
+    def test_submit_help_describes_api_and_model_flags(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(["batches", "submit", "--help"])
+        assert result.exit_code == 0
+        assert "--api" in result.output
+        assert "--model" in result.output
+        assert "-M" in result.output
+        assert "chat.completions" in result.output
+        assert "audio.transcriptions" in result.output
+        assert "audio.translations" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_submit_positional_args(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        route = respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B"])
+        assert result.exit_code == 0
+        assert "batch_job_created" in result.output
+        payload = json.loads(cast(Call, route.calls[0]).request.content)
+        assert payload["endpoint"] == "/v1/chat/completions"
+        assert payload["input_file_id"] == "file-abc123"
+        assert payload["model_id"] == "Qwen/Qwen3.5-9B"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_submit_flag_args(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        route = respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
+        result = cli_runner.invoke(
+            [
+                "batches",
+                "submit",
+                "file-abc123",
+                "--api",
+                "audio.transcriptions",
+                "-M",
+                "openai/whisper-large-v3",
+            ]
+        )
+        assert result.exit_code == 0
+        payload = json.loads(cast(Call, route.calls[0]).request.content)
+        assert payload["endpoint"] == "/v1/audio/transcriptions"
+        assert payload["model_id"] == "openai/whisper-large-v3"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_submit_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
+        result = cli_runner.invoke(
+            ["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B", "--json"]
+        )
+        assert result.exit_code == 0
+        body = json.loads(result.output)
+        assert body["job"]["id"] == "batch_job_created"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_submit_uploads_local_file(self, respx_mock: MockRouter, tmp_path: Path, cli_runner: CliRunner) -> None:
+        sample = tmp_path / "requests.jsonl"
+        sample.write_text('{"custom_id": "1"}\n', encoding="utf-8")
+        create = respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
+        with patch("together.resources.files.AsyncFilesResource.upload", new_callable=AsyncMock) as upload_mock:
+            upload_mock.return_value = _file_response(id="file-uploaded")
+            result = cli_runner.invoke(["batches", "submit", str(sample), "chat.completions", "Qwen/Qwen3.5-9B"])
+        assert result.exit_code == 0
+        upload_mock.assert_called_once()
+        assert upload_mock.call_args.kwargs["purpose"] == "batch-api"
+        assert upload_mock.call_args.kwargs["check"] is False
+        payload = json.loads(cast(Call, create.calls[0]).request.content)
+        assert payload["input_file_id"] == "file-uploaded"
+
+    def test_submit_rejects_directory(self, tmp_path: Path, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(["batches", "submit", str(tmp_path), "chat.completions", "Qwen/Qwen3.5-9B"])
+        assert result.exit_code == 1
+        assert "directory" in result.output.lower()
+
+    def test_submit_rejects_invalid_api(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "not.an.api", "Qwen/Qwen3.5-9B"])
+        assert result.exit_code == 1
+
+
+class TestBatchesList:
+    @pytest.mark.respx(base_url=base_url)
+    def test_list_table(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches").mock(return_value=httpx.Response(200, json=[_BATCH_JOB_OLDER, _BATCH_JOB]))
+        result = cli_runner.invoke(["batches", "list"])
+        assert result.exit_code == 0
+        assert "batch_job_newer" in result.output
+        assert "batch_job_older" in result.output
+        assert result.output.index("batch_job_newer") < result.output.index("batch_job_older")
+        assert "42.5%" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_list_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches").mock(return_value=httpx.Response(200, json=[_BATCH_JOB_OLDER, _BATCH_JOB]))
+        result = cli_runner.invoke(["batches", "list", "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert [row["id"] for row in parsed] == ["batch_job_newer", "batch_job_older"]
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_ls_alias(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches").mock(return_value=httpx.Response(200, json=[]))
+        result = cli_runner.invoke(["batches", "ls"])
+        assert result.exit_code == 0
+        assert "tg batches submit" in result.output
+
+
+class TestBatchesRetrieve:
+    @pytest.mark.respx(base_url=base_url)
+    def test_retrieve_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
+        result = cli_runner.invoke(["batches", "retrieve", "batch_job_newer", "--json"])
+        assert result.exit_code == 0
+        body = json.loads(result.output)
+        assert body["id"] == "batch_job_newer"
+        assert body["status"] == "COMPLETED"
+        assert body["model_id"] == "Qwen/Qwen3.5-9B"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_get_alias(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
+        result = cli_runner.invoke(["batches", "get", "batch_job_newer", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output)["id"] == "batch_job_newer"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_implicit_retrieve_bare_job_id(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
+        result = cli_runner.invoke(["batches", "batch_job_newer", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output)["id"] == "batch_job_newer"
+
+
+class TestBatchesCancel:
+    @pytest.mark.respx(base_url=base_url)
+    def test_cancel(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        cancelled = {**_BATCH_JOB, "status": "CANCELLED"}
+        respx_mock.post("/batches/batch_job_newer/cancel").mock(return_value=httpx.Response(200, json=cancelled))
+        result = cli_runner.invoke(["batches", "cancel", "batch_job_newer"])
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_cancel_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        cancelled = {**_BATCH_JOB, "status": "CANCELLED"}
+        respx_mock.post("/batches/batch_job_newer/cancel").mock(return_value=httpx.Response(200, json=cancelled))
+        result = cli_runner.invoke(["batches", "cancel", "batch_job_newer", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output)["status"] == "CANCELLED"

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -146,6 +146,36 @@ class TestBatchesSubmit:
         result = cli_runner.invoke(["batches", "submit", "file-abc123", "not.an.api", "Qwen/Qwen3.5-9B"])
         assert result.exit_code == 1
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_submit_null_job_exits_nonzero(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.post("/batches").mock(
+            return_value=httpx.Response(200, json={"job": None, "warning": "validation failed: missing [/close] tag"})
+        )
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B"])
+        assert result.exit_code == 1
+        assert "was not created" in result.output
+        assert "MarkupError" not in result.output
+        assert "[/close]" in result.output or "close" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_submit_null_job_json_exits_nonzero(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.post("/batches").mock(return_value=httpx.Response(200, json={"job": None, "warning": "nope"}))
+        result = cli_runner.invoke(
+            ["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B", "--json"]
+        )
+        assert result.exit_code == 1
+        body = json.loads(result.output)
+        assert body["job"] is None
+        assert body["warning"] == "nope"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_submit_does_not_print_x_model_id(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.post("/batches").mock(return_value=httpx.Response(200, json=_BATCH_CREATE))
+        result = cli_runner.invoke(["batches", "submit", "file-abc123", "chat.completions", "Qwen/Qwen3.5-9B"])
+        assert result.exit_code == 0
+        assert "X Model Id" not in result.output
+        assert "Qwen/Qwen3.5-9B" in result.output
+
 
 class TestBatchesList:
     @pytest.mark.respx(base_url=base_url)
@@ -226,6 +256,30 @@ class TestBatchesRetrieve:
         assert "audio.transcriptions" in result.output
         assert "tg batches download" not in result.output
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_retrieve_error_header_printed_once(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        job = {
+            **_BATCH_JOB,
+            "status": "FAILED",
+            "error": "boom",
+            "error_file_id": "file-err",
+        }
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=job))
+        result = cli_runner.invoke(["batches", "get", "batch_job_newer"])
+        assert result.exit_code == 0
+        assert result.output.count("An error occurred") == 1
+        assert "file-err" in result.output
+        assert "boom" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_retrieve_escapes_error_markup(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        job = {**_BATCH_JOB, "status": "FAILED", "error": "validation failed: missing [/close] tag"}
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=job))
+        result = cli_runner.invoke(["batches", "get", "batch_job_newer"])
+        assert result.exit_code == 0
+        assert "MarkupError" not in result.output
+        assert "close" in result.output
+
 
 class TestBatchesCancel:
     @pytest.mark.respx(base_url=base_url)
@@ -235,6 +289,8 @@ class TestBatchesCancel:
         result = cli_runner.invoke(["batches", "cancel", "batch_job_newer"])
         assert result.exit_code == 0
         assert "Cancelled" in result.output
+        assert "X Model Id" not in result.output
+        assert "Qwen/Qwen3.5-9B" in result.output
 
     @pytest.mark.respx(base_url=base_url)
     def test_cancel_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
@@ -346,3 +402,57 @@ class TestBatchesDownload:
         assert body["files"][0]["kind"] == "output"
         assert body["files"][0]["id"] == "file-out"
         assert Path(body["files"][0]["path"]).read_bytes() == b"line\n"
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_existing_suffixless_file(
+        self, respx_mock: MockRouter, tmp_path: Path, cli_runner: CliRunner
+    ) -> None:
+        out = tmp_path / "results"
+        out.write_bytes(b"stale")
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
+        respx_mock.get("/files/file-out/content").mock(return_value=httpx.Response(200, content=b'{"ok":true}\n'))
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--output", str(out)])
+        assert result.exit_code == 0
+        assert out.is_file()
+        assert out.read_bytes() == b'{"ok":true}\n'
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_not_ready_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches/batch_job_older").mock(return_value=httpx.Response(200, json=_BATCH_JOB_OLDER))
+        result = cli_runner.invoke(["batches", "download", "batch_job_older", "--json"])
+        assert result.exit_code == 1
+        body = json.loads(result.output)
+        assert "not ready" in body["error"].lower()
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_no_files_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        job = {**_BATCH_JOB, "output_file_id": None, "error_file_id": None}
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=job))
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--json"])
+        assert result.exit_code == 1
+        body = json.loads(result.output)
+        assert "no output or error files" in body["error"].lower()
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_stdout_json_is_metadata_only(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        content_route = respx_mock.get("/files/file-out/content").mock(
+            return_value=httpx.Response(200, content=b"should-not-download\n")
+        )
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--json"])
+        assert result.exit_code == 0
+        body = json.loads(result.output)
+        assert body["batch_id"] == "batch_job_newer"
+        assert body["output_file_id"] == "file-out"
+        assert "content" not in body
+        assert "content_base64" not in body
+        assert content_route.call_count == 0
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_stdout_no_output_file_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        job = {**_BATCH_JOB, "output_file_id": None, "error_file_id": "file-err"}
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=job))
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--json"])
+        assert result.exit_code == 1
+        body = json.loads(result.output)
+        assert "no output file" in body["error"].lower()

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -199,6 +199,35 @@ class TestBatchesRetrieve:
         assert result.exit_code == 0
         assert json.loads(result.output)["id"] == "batch_job_newer"
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_retrieve_shows_curated_fields_and_download_hint(
+        self, respx_mock: MockRouter, cli_runner: CliRunner
+    ) -> None:
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
+        result = cli_runner.invoke(["batches", "get", "batch_job_newer"])
+        assert result.exit_code == 0
+        assert "batch_job_newer" in result.output
+        assert "COMPLETED" in result.output
+        assert "chat.completions" in result.output
+        assert "Qwen/Qwen3.5-9B" in result.output
+        assert "file-out" in result.output
+        assert "Progress:" not in result.output
+        assert "tg batches download batch_job_newer --output ./out" in result.output
+        # Raw dump fields that shouldn't clutter the human view
+        assert "file_size_bytes" not in result.output
+        assert "input_file_id" not in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_retrieve_shows_progress_when_in_progress(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches/batch_job_older").mock(return_value=httpx.Response(200, json=_BATCH_JOB_OLDER))
+        result = cli_runner.invoke(["batches", "get", "batch_job_older"])
+        assert result.exit_code == 0
+        assert "IN_PROGRESS" in result.output
+        assert "Progress:" in result.output
+        assert "42.5%" in result.output
+        assert "audio.transcriptions" in result.output
+        assert "tg batches download" not in result.output
+
 
 class TestBatchesCancel:
     @pytest.mark.respx(base_url=base_url)
@@ -216,3 +245,106 @@ class TestBatchesCancel:
         result = cli_runner.invoke(["batches", "cancel", "batch_job_newer", "--json"])
         assert result.exit_code == 0
         assert json.loads(result.output)["status"] == "CANCELLED"
+
+
+class TestBatchesDownload:
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_not_ready(self, respx_mock: MockRouter, tmp_path: Path, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches/batch_job_older").mock(return_value=httpx.Response(200, json=_BATCH_JOB_OLDER))
+        result = cli_runner.invoke(["batches", "download", "batch_job_older", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "not ready" in result.output.lower()
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_output_to_directory(self, respx_mock: MockRouter, tmp_path: Path, cli_runner: CliRunner) -> None:
+        job = {**_BATCH_JOB, "error_file_id": "file-err"}
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=job))
+        respx_mock.get("/files/file-out/content").mock(return_value=httpx.Response(200, content=b'{"ok":true}\n'))
+        respx_mock.get("/files/file-err/content").mock(return_value=httpx.Response(200, content=b'{"err":true}\n'))
+        respx_mock.get("/files/file-out").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "file-out",
+                    "bytes": 12,
+                    "created_at": 1,
+                    "filename": "batch-output.jsonl",
+                    "FileType": "jsonl",
+                    "object": "file",
+                    "Processed": True,
+                    "purpose": "batch-api",
+                },
+            )
+        )
+        respx_mock.get("/files/file-err").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "file-err",
+                    "bytes": 12,
+                    "created_at": 1,
+                    "filename": "batch-errors.jsonl",
+                    "FileType": "jsonl",
+                    "object": "file",
+                    "Processed": True,
+                    "purpose": "batch-api",
+                },
+            )
+        )
+
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--output", str(tmp_path)])
+        assert result.exit_code == 0
+        assert (tmp_path / "batch-output.jsonl").read_bytes() == b'{"ok":true}\n'
+        assert (tmp_path / "batch-errors.jsonl").read_bytes() == b'{"err":true}\n'
+        assert "Output saved" in result.output
+        assert "Errors saved" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_output_to_file(self, respx_mock: MockRouter, tmp_path: Path, cli_runner: CliRunner) -> None:
+        job = {**_BATCH_JOB, "error_file_id": "file-err"}
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=job))
+        respx_mock.get("/files/file-out/content").mock(return_value=httpx.Response(200, content=b'{"ok":true}\n'))
+        respx_mock.get("/files/file-err/content").mock(return_value=httpx.Response(200, content=b'{"err":true}\n'))
+
+        out = tmp_path / "results.jsonl"
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--output", str(out)])
+        assert result.exit_code == 0
+        assert out.read_bytes() == b'{"ok":true}\n'
+        assert (tmp_path / "results.errors.jsonl").read_bytes() == b'{"err":true}\n'
+        assert "Output saved" in result.output
+        assert "Errors saved" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_defaults_to_stdout(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
+        respx_mock.get("/files/file-out/content").mock(return_value=httpx.Response(200, content=b"stdout-batch\n"))
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer"])
+        assert result.exit_code == 0
+        assert "stdout-batch" in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_download_json(self, respx_mock: MockRouter, tmp_path: Path, cli_runner: CliRunner) -> None:
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
+        respx_mock.get("/files/file-out/content").mock(return_value=httpx.Response(200, content=b"line\n"))
+        respx_mock.get("/files/file-out").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "file-out",
+                    "bytes": 5,
+                    "created_at": 1,
+                    "filename": "out.jsonl",
+                    "FileType": "jsonl",
+                    "object": "file",
+                    "Processed": True,
+                    "purpose": "batch-api",
+                },
+            )
+        )
+        result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--output", str(tmp_path), "--json"])
+        assert result.exit_code == 0
+        body = json.loads(result.output)
+        assert body["batch_id"] == "batch_job_newer"
+        assert body["files"][0]["kind"] == "output"
+        assert body["files"][0]["id"] == "file-out"
+        assert Path(body["files"][0]["path"]).read_bytes() == b"line\n"

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -435,9 +435,6 @@ class TestBatchesDownload:
 
     @pytest.mark.respx(base_url=base_url)
     def test_download_stdout_json_is_metadata_only(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
-        content_route = respx_mock.get("/files/file-out/content").mock(
-            return_value=httpx.Response(200, content=b"should-not-download\n")
-        )
         respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=_BATCH_JOB))
         result = cli_runner.invoke(["batches", "download", "batch_job_newer", "--json"])
         assert result.exit_code == 0
@@ -446,7 +443,6 @@ class TestBatchesDownload:
         assert body["output_file_id"] == "file-out"
         assert "content" not in body
         assert "content_base64" not in body
-        assert content_route.call_count == 0
 
     @pytest.mark.respx(base_url=base_url)
     def test_download_stdout_no_output_file_json(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:

--- a/tests/cli/test_batches.py
+++ b/tests/cli/test_batches.py
@@ -257,6 +257,37 @@ class TestBatchesRetrieve:
         assert "tg batches download" not in result.output
 
     @pytest.mark.respx(base_url=base_url)
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            ("CANCELLED", "Cancelled"),
+            ("EXPIRED", "Expired"),
+            ("FAILED", "Failed"),
+            ("COMPLETED", "Completed"),
+        ],
+    )
+    def test_retrieve_always_prints_status(
+        self, status: str, expected: str, respx_mock: MockRouter, cli_runner: CliRunner
+    ) -> None:
+        job = {**_BATCH_JOB, "status": status, "error": None, "error_file_id": None}
+        respx_mock.get("/batches/batch_job_newer").mock(return_value=httpx.Response(200, json=job))
+        result = cli_runner.invoke(["batches", "get", "batch_job_newer"])
+        assert result.exit_code == 0
+        assert any(line.strip() == expected for line in result.output.splitlines())
+        assert "█" not in result.output
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_retrieve_prints_status_when_in_progress_without_progress(
+        self, respx_mock: MockRouter, cli_runner: CliRunner
+    ) -> None:
+        job = {**_BATCH_JOB_OLDER, "progress": None}
+        respx_mock.get("/batches/batch_job_older").mock(return_value=httpx.Response(200, json=job))
+        result = cli_runner.invoke(["batches", "get", "batch_job_older"])
+        assert result.exit_code == 0
+        assert "In_progress" in result.output
+        assert "█" not in result.output
+
+    @pytest.mark.respx(base_url=base_url)
     def test_retrieve_error_header_printed_once(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         job = {
             **_BATCH_JOB,

--- a/tests/cli/test_json_mode_pipeable_to_jq.py
+++ b/tests/cli/test_json_mode_pipeable_to_jq.py
@@ -94,7 +94,7 @@ class TestJSONMode:
     def test_batches_json_mode(self) -> None:
         batches = JSONValidator("batches")
         # Prism's create example has no job; submit correctly exits 1 when job is null.
-        batches.run_and_assert("submit file-abc123def456ghi789 chat.completions Qwen/Qwen3.5-9B", allow_nonzero=True)
+        batches.run_and_assert("submit file-abc123def456ghi789 chat.completions", allow_nonzero=True)
         batches.run_and_assert("list")
         batches.run_and_assert("retrieve batch_job_abc123def456")
         batches.run_and_assert("cancel batch_job_abc123def456")

--- a/tests/cli/test_json_mode_pipeable_to_jq.py
+++ b/tests/cli/test_json_mode_pipeable_to_jq.py
@@ -91,6 +91,13 @@ class TestJSONMode:
         evals.skip.run_and_assert("retrieve eval-123")
         evals.skip.run_and_assert("status eval-123")
 
+    def test_batches_json_mode(self) -> None:
+        batches = JSONValidator("batches")
+        batches.run_and_assert("submit file-abc123def456ghi789 chat.completions Qwen/Qwen3.5-9B")
+        batches.run_and_assert("list")
+        batches.run_and_assert("retrieve batch_job_abc123def456")
+        batches.run_and_assert("cancel batch_job_abc123def456")
+
     # All files commands (subprocess against mock server; no respx — child process never sees patches).
     def test_files_json_mode(self) -> None:
         files = JSONValidator("files")

--- a/tests/cli/test_json_mode_pipeable_to_jq.py
+++ b/tests/cli/test_json_mode_pipeable_to_jq.py
@@ -97,6 +97,7 @@ class TestJSONMode:
         batches.run_and_assert("list")
         batches.run_and_assert("retrieve batch_job_abc123def456")
         batches.run_and_assert("cancel batch_job_abc123def456")
+        batches.skip.run_and_assert("download batch_job_abc123def456")
 
     # All files commands (subprocess against mock server; no respx — child process never sees patches).
     def test_files_json_mode(self) -> None:

--- a/tests/cli/test_json_mode_pipeable_to_jq.py
+++ b/tests/cli/test_json_mode_pipeable_to_jq.py
@@ -36,7 +36,7 @@ class JSONValidator:
 
     # Invokes the command on the command line
     # It then pipes the results to jq to assert that the JSON is valid
-    def run_and_assert(self, command: str, **kwargs: Any) -> None:
+    def run_and_assert(self, command: str, *, allow_nonzero: bool = False, **kwargs: Any) -> None:
         if self._skip:
             print(f"Skipping {command} because it is not supported in JSON mode")
             return
@@ -50,7 +50,7 @@ class JSONValidator:
             )
 
         command_result = run_command(command)
-        if command_result.returncode != 0:
+        if command_result.returncode != 0 and not allow_nonzero:
             ns = " ".join(self.namespace_parts)
             raise AssertionError(f"{ns} {command} exited {command_result.returncode}: stderr={command_result.stderr!r}")
         try:
@@ -97,7 +97,8 @@ class TestJSONMode:
         batches.run_and_assert("list")
         batches.run_and_assert("retrieve batch_job_abc123def456")
         batches.run_and_assert("cancel batch_job_abc123def456")
-        batches.skip.run_and_assert("download batch_job_abc123def456")
+        # Prism job may not be terminal; stdout must still be jq-parseable JSON.
+        batches.run_and_assert("download batch_job_abc123def456", allow_nonzero=True)
 
     # All files commands (subprocess against mock server; no respx — child process never sees patches).
     def test_files_json_mode(self) -> None:

--- a/tests/cli/test_json_mode_pipeable_to_jq.py
+++ b/tests/cli/test_json_mode_pipeable_to_jq.py
@@ -93,11 +93,12 @@ class TestJSONMode:
 
     def test_batches_json_mode(self) -> None:
         batches = JSONValidator("batches")
-        batches.run_and_assert("submit file-abc123def456ghi789 chat.completions Qwen/Qwen3.5-9B")
+        # Prism's create example has no job; submit correctly exits 1 when job is null.
+        batches.run_and_assert("submit file-abc123def456ghi789 chat.completions Qwen/Qwen3.5-9B", allow_nonzero=True)
         batches.run_and_assert("list")
         batches.run_and_assert("retrieve batch_job_abc123def456")
         batches.run_and_assert("cancel batch_job_abc123def456")
-        # Prism job may not be terminal; stdout must still be jq-parseable JSON.
+        # Prism job has no status; download errors as JSON and must still be jq-parseable.
         batches.run_and_assert("download batch_job_abc123def456", allow_nonzero=True)
 
     # All files commands (subprocess against mock server; no respx — child process never sees patches).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes DX-918.

Adds CLI commands for the Batch API:

```
tg batches submit FILE_ID_OR_PATH API_TYPE
tg batches ls
tg batches get|retrieve BATCH_ID
tg batches download BATCH_ID [--output PATH]
tg batches cancel BATCH_ID
```

**Submit**
- `FILE_ID_OR_PATH` behaves like `ft create`: local paths are uploaded with `purpose=batch-api`, otherwise treated as a file ID
- `API_TYPE` is `chat.completions` | `audio.transcriptions` | `audio.translations`, positional or `--api`
- Model is taken from each JSONL request body, not from the CLI
- Human output uses the same curated job view as retrieve (no `X Model Id` dump)
- API warnings are Rich-escaped; a null job exits 1 (including `--json`)

**Retrieve**
- Human output is a curated summary (created/completed time, API, model, output/error file IDs)
- Status always prints; in-progress jobs also show a progress bar
- Completed/failed jobs print a download hint
- `tg batches <batch-id>` implicit retrieve
- Error file ID and `error` share a single "An error occurred" header; API error text is escaped

**Download**
- Writes output (and error) files to `--output` (file or directory)
- Existing suffix-less paths like `./results` are treated as files, not directories
- Error files are written as `<stem>.errors<suffix>` so a shared server filename cannot clobber output
- Omitting `--output` streams the output file to stdout
- `--json` requires `--output` (does not embed file contents); success JSON lists saved paths
- Early failures (`--json` included) print `{"error": "..."}` then exit 1
- Shared helper also used by `tg files download`

**Cancel**
- Human output uses the curated job view

Also supports `--json` and `ls`/`get` aliases.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DX-918](https://linear.app/together-ai/issue/DX-918/add-cli-commands-for-the-batch-api)

<div><a href="https://cursor.com/agents/bc-dd01321d-a7f2-4613-acd0-982e6219c96a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd01321d-a7f2-4613-acd0-982e6219c96a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

