### PR TITLE
fix(Endpoints CLI): Rename models output label 'Inference Name' to 'Endpoint string'

### DIFF
--- a/src/together/lib/cli/api/beta/models/_utils.py
+++ b/src/together/lib/cli/api/beta/models/_utils.py
@@ -103,7 +103,7 @@ async def print_model_detail(
     files: ModelListFilesResponse | None = None,
 ) -> None:
     _print_detail_header("Model Details", _short_name(model.name))
-    _print_detail_line("Inference Name", model.name)
+    _print_detail_line("Endpoint string", model.name)
     if model.id:
         _print_detail_line("ID", model.id)
     if model.base_model_id:


### PR DESCRIPTION
## What

One-line change: the `beta models` detail view now labels `model.name` **Endpoint string** instead of **Inference Name**.

## Why

The web console labels this value "Endpoint string" (`EndpointPage.tsx`), the `beta endpoints retrieve` view already uses "Endpoint string", and the docs style guide standardized on "endpoint string" in prose. The models detail view was the last CLI surface printing "Inference Name". Per the volume proto, `Model.name` is the same inference-addressable `<project_slug>/<name>` form passed as the `model` field, so it gets the same label.

## Out of scope

The generated SDK docstrings in `src/together/resources/` still say "inference name". Those come from the OpenAPI spec descriptions via Stainless, so they need a spec-side fix rather than an edit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)