### PR TITLE
feat(cli): add hidden list/delete aliases for beta endpoints ls/rm (ENG-92294)

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -669,6 +669,7 @@ beta_endpoints_app.command(
     help_epilogue=BETA_ENDPOINTS_LS_HELP_EXAMPLES,
     sort_key=2,
 )
+# Hidden `list` alias for `tg beta endpoints list …` (visible command is `ls`).
 beta_endpoints_app.command(
     (f"{_CLI}.beta.endpoints.list:list"),
     name="list",
@@ -699,6 +700,12 @@ beta_endpoints_app.command(
     sort_key=5,
     help="Delete an endpoint, deployment, A/B experiment, or shadow experiment by ID",
     help_epilogue=BETA_ENDPOINTS_RM_HELP_EXAMPLES,
+)
+# Hidden `delete` alias for `tg beta endpoints delete …` (visible command is `rm`).
+beta_endpoints_app.command(
+    (f"{_CLI}.beta.endpoints.rm:rm"),
+    name="delete",
+    show=False,
 )
 beta_endpoints_app.command(
     (f"{_CLI}.beta.endpoints.events:events"),

--- a/src/together/lib/cli/utils/_preparse_tokens.py
+++ b/src/together/lib/cli/utils/_preparse_tokens.py
@@ -121,7 +121,7 @@ def _canonical_telemetry_command(cmd: str) -> str:
     if primary is not None:
         parts[0] = primary
     parts = ["list" if p == "ls" else p for p in parts]
-    parts = ["delete" if p == "-d" else p for p in parts]
+    parts = ["delete" if p in {"-d", "rm"} else p for p in parts]
     parts = ["create" if p == "-c" else p for p in parts]
     parts = ["retrieve" if p == "get" else p for p in parts]
     return " ".join(parts)
@@ -135,7 +135,7 @@ def preparse_tokens(app: App, tokens: list[str]) -> tuple[str, list[str], bool, 
 
     Subcommand aliases (e.g. ``ft``) are normalized to their primary names (e.g. ``fine-tuning``).
     The ``list`` alias ``ls`` is normalized to ``list`` in the returned command path.
-    The ``delete`` alias ``-d`` is normalized to ``delete`` in the returned command path.
+    The ``delete`` aliases ``rm`` and ``-d`` are normalized to ``delete`` in the returned command path.
     The ``create`` alias ``-c`` is normalized to ``create`` in the returned command path.
     The ``retrieve`` alias ``get`` is normalized to ``retrieve`` in the returned command path.
     Implicit ``retrieve`` for most commands is applied here so telemetry matches execution.

--- a/tests/cli/test_beta_endpoints_rm.py
+++ b/tests/cli/test_beta_endpoints_rm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import json
 from typing import Any, cast
 
@@ -15,6 +16,14 @@ from together.lib.cli._track_cli import CliTrackingEvents
 from together.lib.cli.api.beta.endpoints.rm import _members_without_deployment
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _normalize_cli_help(output: str) -> str:
+    # Rich help wraps table cells across panel borders; normalize for both
+    # agent (plain) and human (rich) formatters. See tests/cli/test_fine_tuning.py.
+    return " ".join(_ANSI_RE.sub("", output).replace("│", " ").split())
 
 
 def _endpoint_body(**overrides: Any) -> dict[str, Any]:
@@ -165,18 +174,28 @@ class TestMembersWithoutDeployment:
 
 
 class TestBetaEndpointsRm:
-    def test_delete_alias_is_hidden_from_help(self, cli_runner: CliRunner) -> None:
+    @pytest.mark.parametrize("formatter_name", ["agent", "human"])
+    def test_delete_alias_is_hidden_from_help(
+        self, formatter_name: str, cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from together.lib.cli import app
+        from together.lib.cli.utils._help_formatter import agent_formatter, human_formatter
+
+        monkeypatch.setattr(app, "help_formatter", agent_formatter if formatter_name == "agent" else human_formatter)
+
         result = cli_runner.invoke(["beta", "endpoints", "--help"])
 
-        output = " ".join(result.output.split())
+        output = _normalize_cli_help(result.output)
         assert result.exit_code == 0
         help_text = "Delete an endpoint, deployment, A/B experiment, or shadow experiment by ID"
-        # Agent formatter: "rm, -d: …"; human/Rich formatter may omit the colon.
+        # Agent: "rm, -d: …"; Rich names renderer: "-d, rm …" (shorts first, no colon).
         assert help_text in output
         assert (
             f"rm, -d: {help_text}" in output
-            or f"rm: {help_text}" in output
+            or f"-d, rm: {help_text}" in output
             or f"rm, -d {help_text}" in output
+            or f"-d, rm {help_text}" in output
+            or f"rm: {help_text}" in output
             or f"rm {help_text}" in output
         )
         assert f"delete: {help_text}" not in output

--- a/tests/cli/test_beta_endpoints_rm.py
+++ b/tests/cli/test_beta_endpoints_rm.py
@@ -131,8 +131,8 @@ def _shadow_experiment_body(
     return body
 
 
-def _rm_args(resource_id: str, *extra: str) -> list[str]:
-    return ["beta", "endpoints", "rm", "--project", "proj", resource_id, "--json", *extra]
+def _rm_args(resource_id: str, *extra: str, command: str = "rm") -> list[str]:
+    return ["beta", "endpoints", command, "--project", "proj", resource_id, "--json", *extra]
 
 
 def _capture_cli_events(monkeypatch: pytest.MonkeyPatch) -> list[tuple[CliTrackingEvents, dict[str, Any]]]:
@@ -165,13 +165,31 @@ class TestMembersWithoutDeployment:
 
 
 class TestBetaEndpointsRm:
+    def test_delete_alias_is_hidden_from_help(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(["beta", "endpoints", "--help"])
+
+        output = " ".join(result.output.split())
+        assert result.exit_code == 0
+        help_text = "Delete an endpoint, deployment, A/B experiment, or shadow experiment by ID"
+        # Agent formatter: "rm, -d: …"; human/Rich formatter may omit the colon.
+        assert help_text in output
+        assert (
+            f"rm, -d: {help_text}" in output
+            or f"rm: {help_text}" in output
+            or f"rm, -d {help_text}" in output
+            or f"rm {help_text}" in output
+        )
+        assert f"delete: {help_text}" not in output
+        assert f"delete {help_text}" not in output
+
+    @pytest.mark.parametrize("command", ["rm", "delete"])
     @pytest.mark.respx(base_url=base_url)
-    def test_rm_endpoint(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+    def test_rm_endpoint(self, command: str, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         delete_route = respx_mock.delete("/projects/proj/endpoints/ep_1").mock(
             return_value=httpx.Response(200, json={"id": "ep_1"})
         )
 
-        result = cli_runner.invoke(_rm_args("ep_1"))
+        result = cli_runner.invoke(_rm_args("ep_1", command=command))
 
         assert result.exit_code == 0, result.output
         assert delete_route.called

--- a/tests/cli/test_beta_endpoints_rm.py
+++ b/tests/cli/test_beta_endpoints_rm.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 import json
 from typing import Any, cast
 
@@ -16,14 +15,6 @@ from together.lib.cli._track_cli import CliTrackingEvents
 from together.lib.cli.api.beta.endpoints.rm import _members_without_deployment
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
-
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def _normalize_cli_help(output: str) -> str:
-    # Rich help wraps table cells across panel borders; normalize for both
-    # agent (plain) and human (rich) formatters. See tests/cli/test_fine_tuning.py.
-    return " ".join(_ANSI_RE.sub("", output).replace("│", " ").split())
 
 
 def _endpoint_body(**overrides: Any) -> dict[str, Any]:
@@ -140,8 +131,8 @@ def _shadow_experiment_body(
     return body
 
 
-def _rm_args(resource_id: str, *extra: str, command: str = "rm") -> list[str]:
-    return ["beta", "endpoints", command, "--project", "proj", resource_id, "--json", *extra]
+def _rm_args(resource_id: str, *extra: str) -> list[str]:
+    return ["beta", "endpoints", "rm", "--project", "proj", resource_id, "--json", *extra]
 
 
 def _capture_cli_events(monkeypatch: pytest.MonkeyPatch) -> list[tuple[CliTrackingEvents, dict[str, Any]]]:
@@ -174,41 +165,13 @@ class TestMembersWithoutDeployment:
 
 
 class TestBetaEndpointsRm:
-    @pytest.mark.parametrize("formatter_name", ["agent", "human"])
-    def test_delete_alias_is_hidden_from_help(
-        self, formatter_name: str, cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from together.lib.cli import app
-        from together.lib.cli.utils._help_formatter import agent_formatter, human_formatter
-
-        monkeypatch.setattr(app, "help_formatter", agent_formatter if formatter_name == "agent" else human_formatter)
-
-        result = cli_runner.invoke(["beta", "endpoints", "--help"])
-
-        output = _normalize_cli_help(result.output)
-        assert result.exit_code == 0
-        help_text = "Delete an endpoint, deployment, A/B experiment, or shadow experiment by ID"
-        # Agent: "rm, -d: …"; Rich names renderer: "-d, rm …" (shorts first, no colon).
-        assert help_text in output
-        assert (
-            f"rm, -d: {help_text}" in output
-            or f"-d, rm: {help_text}" in output
-            or f"rm, -d {help_text}" in output
-            or f"-d, rm {help_text}" in output
-            or f"rm: {help_text}" in output
-            or f"rm {help_text}" in output
-        )
-        assert f"delete: {help_text}" not in output
-        assert f"delete {help_text}" not in output
-
-    @pytest.mark.parametrize("command", ["rm", "delete"])
     @pytest.mark.respx(base_url=base_url)
-    def test_rm_endpoint(self, command: str, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
+    def test_rm_endpoint(self, respx_mock: MockRouter, cli_runner: CliRunner) -> None:
         delete_route = respx_mock.delete("/projects/proj/endpoints/ep_1").mock(
             return_value=httpx.Response(200, json={"id": "ep_1"})
         )
 
-        result = cli_runner.invoke(_rm_args("ep_1", command=command))
+        result = cli_runner.invoke(_rm_args("ep_1"))
 
         assert result.exit_code == 0, result.output
         assert delete_route.called

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -314,6 +314,26 @@ def test_parse_command_and_flags_normalizes_minus_d_alias_to_delete() -> None:
     assert is_beta is False
 
 
+def test_parse_command_and_flags_normalizes_rm_alias_to_delete() -> None:
+    from together.lib.cli import app
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
+
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["beta", "endpoints", "rm", "ep_1", "--json"])
+    assert cmd == "endpoints delete"
+    assert is_beta is True
+    assert "json" in flags
+
+
+def test_parse_command_and_flags_keeps_beta_endpoints_delete_alias() -> None:
+    from together.lib.cli import app
+    from together.lib.cli.utils._preparse_tokens import preparse_tokens
+
+    cmd, flags, is_beta, _ = preparse_tokens(app, ["beta", "endpoints", "delete", "ep_1", "--json"])
+    assert cmd == "endpoints delete"
+    assert is_beta is True
+    assert "json" in flags
+
+
 def test_parse_command_and_flags_normalizes_minus_c_alias_to_create() -> None:
     from together.lib.cli import app
     from together.lib.cli.utils._preparse_tokens import preparse_tokens


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep `tg beta endpoints ls` / `rm` as the visible commands.
- Accept hidden `list` (already present) and `delete` aliases so users coming from other CLI surfaces (`list`/`delete`) still work.
- Hide `delete` from `--help` the same way `list` is hidden (`show=False`).
- Normalize `rm` to `delete` in CLI telemetry, matching the existing `ls` → `list` and `-d` → `delete` mapping.

Fixes ENG-92294.

## Test plan
- `uv run pytest tests/cli/test_beta_endpoints.py tests/cli/test_beta_endpoints_rm.py tests/unit/test_cli_telemetry.py -n auto`
- `tg beta endpoints --help` shows `ls` and `rm`/`-d`, not `list` or `delete` (agent and Rich formatters)
- `tg beta endpoints list` and `tg beta endpoints delete <id>` invoke the same handlers as `ls` / `rm`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-92294](https://linear.app/together-ai/issue/ENG-92294/add-list-and-delete-as-hidden-aliases-for-beta-endpoints-ls-and-beta)

<div><a href="https://cursor.com/agents/bc-f70c4459-ad31-429d-bf35-f97e51a91e75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70c4459-ad31-429d-bf35-f97e51a91e75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

