### PR TITLE
fix(cli): stabilize UnknownOptionError telemetry

### DIFF
--- a/src/together/lib/cli/__init__.py
+++ b/src/together/lib/cli/__init__.py
@@ -19,7 +19,7 @@ from together.lib.cli._track_cli import (
     CliTrackingEvents,
     track_cli,
     flush_pending_events,
-    sanitize_cli_error_message,
+    format_cli_error_for_telemetry,
 )
 from together.lib.cli.utils.config import CLIConfig
 from together.lib.cli.utils._prompt import PromptParameter
@@ -376,7 +376,7 @@ async def launcher(
                 "command": parsed_command,
                 "arguments": explicit_args,
                 "is_beta_command": is_beta_command,
-                "error": sanitize_cli_error_message(str(e)),
+                "error": format_cli_error_for_telemetry(e, command=parsed_command),
             },
         )
         sys.exit(e.code)
@@ -387,7 +387,7 @@ async def launcher(
                 "command": parsed_command,
                 "arguments": explicit_args,
                 "is_beta_command": is_beta_command,
-                "error": sanitize_cli_error_message(str(e)),
+                "error": format_cli_error_for_telemetry(e, command=parsed_command),
             },
         )
 

--- a/src/together/lib/cli/_track_cli.py
+++ b/src/together/lib/cli/_track_cli.py
@@ -229,18 +229,23 @@ def sanitize_cli_error_message(msg: str) -> str:
     return s
 
 
+def _option_name_without_inline_value(name: str) -> str:
+    """Keep ``--flag`` from ``--flag=value`` so telemetry doesn't embed secrets/paths."""
+    return name.split("=", 1)[0]
+
+
 def _unknown_option_name(exc: BaseException) -> str | None:
     token = getattr(exc, "token", None)
     if isinstance(token, str):
-        return token or None
+        return _option_name_without_inline_value(token) if token else None
     if token is None:
         return None
     keyword = getattr(token, "keyword", None)
     if isinstance(keyword, str) and keyword:
-        return keyword
+        return _option_name_without_inline_value(keyword)
     value = getattr(token, "value", None)
     if isinstance(value, str) and value:
-        return value
+        return _option_name_without_inline_value(value)
     return None
 
 

--- a/src/together/lib/cli/_track_cli.py
+++ b/src/together/lib/cli/_track_cli.py
@@ -15,6 +15,7 @@ from typing import Any, TypeVar, Callable, cast
 from pathlib import Path
 
 from detect_agent import determine_agent
+from cyclopts.exceptions import CycloptsError, UnknownOptionError
 
 from together import __version__
 from together.lib.utils import log_debug
@@ -226,6 +227,52 @@ def sanitize_cli_error_message(msg: str) -> str:
         suffix_len = remaining_len - prefix_len
         s = f"{s[:prefix_len]}{_ERROR_MESSAGE_TRUNCATION_MARKER}{s[-suffix_len:]}"
     return s
+
+
+def _unknown_option_name(exc: BaseException) -> str | None:
+    token = getattr(exc, "token", None)
+    if isinstance(token, str):
+        return token or None
+    if token is None:
+        return None
+    keyword = getattr(token, "keyword", None)
+    if isinstance(keyword, str) and keyword:
+        return keyword
+    value = getattr(token, "value", None)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _stringify_cyclopts_error(exc: CycloptsError) -> str:
+    """Drop the verbose file-path / signature preamble (unique per install)."""
+    original = exc.verbose
+    try:
+        exc.verbose = False
+        return str(exc)
+    finally:
+        exc.verbose = original
+
+
+def format_cli_error_for_telemetry(exc: BaseException, *, command: str = "") -> str:
+    """Stable error text for CLI failure telemetry.
+
+    Cyclopts ``UnknownOptionError`` otherwise includes the command's install path and
+    full function signature, which makes every machine a unique event.
+    """
+    if isinstance(exc, UnknownOptionError):
+        option = _unknown_option_name(exc)
+        if option:
+            if command:
+                msg = f'Unknown option: "{option}" for command "{command}"'
+            else:
+                msg = f'Unknown option: "{option}"'
+            return sanitize_cli_error_message(msg)
+
+    if isinstance(exc, CycloptsError):
+        return sanitize_cli_error_message(_stringify_cyclopts_error(exc))
+
+    return sanitize_cli_error_message(str(exc))
 
 
 def _env_telemetry_disabled() -> bool:

--- a/tests/cli/test_command_telemetry.py
+++ b/tests/cli/test_command_telemetry.py
@@ -149,6 +149,19 @@ def test_unknown_option_error_telemetry_is_option_and_command(
 
 
 @pytest.mark.usefixtures("isolated_cli_config")
+def test_unknown_option_equals_value_telemetry_strips_value(
+    track_cli_capture: list[tuple[CliTrackingEvents, dict[str, Any]]],
+    cli_runner: CliRunner,
+) -> None:
+    r = cli_runner.invoke(["beta", "clusters", "create", "--auth-token=hunter2secret"])
+    assert r.exit_code == 1
+    failed = track_cli_capture[1][1]
+    assert failed["command"] == "clusters create"
+    assert failed["error"] == 'Unknown option: "--auth-token" for command "clusters create"'
+    assert "hunter2secret" not in failed["error"]
+
+
+@pytest.mark.usefixtures("isolated_cli_config")
 def test_command_keyboard_interrupt_emits_started_then_user_aborted(
     track_cli_capture: list[tuple[CliTrackingEvents, dict[str, Any]]],
     cli_runner: CliRunner,

--- a/tests/cli/test_command_telemetry.py
+++ b/tests/cli/test_command_telemetry.py
@@ -130,6 +130,25 @@ def test_command_exception_emits_started_then_failed_then_reraises(
 
 
 @pytest.mark.usefixtures("isolated_cli_config")
+def test_unknown_option_error_telemetry_is_option_and_command(
+    track_cli_capture: list[tuple[CliTrackingEvents, dict[str, Any]]],
+    cli_runner: CliRunner,
+) -> None:
+    r = cli_runner.invoke(["beta", "clusters", "create", "--not-a-real-option"])
+    assert r.exit_code == 1
+    assert _event_kinds(track_cli_capture) == [
+        CliTrackingEvents.CommandStarted.value,
+        CliTrackingEvents.CommandFailed.value,
+    ]
+    failed = track_cli_capture[1][1]
+    assert failed["command"] == "clusters create"
+    assert failed["is_beta_command"] is True
+    assert failed["error"] == 'Unknown option: "--not-a-real-option" for command "clusters create"'
+    assert "Function defined in file" not in failed["error"]
+    assert ".py" not in failed["error"]
+
+
+@pytest.mark.usefixtures("isolated_cli_config")
 def test_command_keyboard_interrupt_emits_started_then_user_aborted(
     track_cli_capture: list[tuple[CliTrackingEvents, dict[str, Any]]],
     cli_runner: CliRunner,

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -179,13 +179,21 @@ def test_format_unknown_option_error_strips_inline_value() -> None:
 
 
 def test_format_cyclopts_error_omits_install_path() -> None:
-    from cyclopts.exceptions import CycloptsError
+    from cyclopts.exceptions import UnknownCommandError
 
-    err = CycloptsError(target=_long_signature_command)
-    assert "Function defined in file" in str(err)
+    # UnknownCommandError appends its diagnostic to the verbose preamble, unlike a bare
+    # CycloptsError which stringifies to "" once verbose=False.
+    err = UnknownCommandError(unused_tokens=["bogus-cmd"], target=_long_signature_command)
+    raw = str(err)
+    assert "Function defined in file" in raw
+    assert _long_signature_command.__code__.co_filename in raw
+    assert 'Unknown command "bogus-cmd"' in raw
+
     out = format_cli_error_for_telemetry(err, command="clusters create")
+    assert out == 'Unknown command "bogus-cmd".'
     assert "Function defined in file" not in out
     assert _long_signature_command.__code__.co_filename not in out
+    assert err.verbose is True
 
 
 def test_telemetry_env_opt_out_only_explicit_values(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -16,6 +16,7 @@ from together.lib.cli._track_cli import (
     save_telemetry_config,
     telemetry_config_path,
     sanitize_cli_error_message,
+    format_cli_error_for_telemetry,
 )
 
 
@@ -103,6 +104,73 @@ def test_sanitize_cli_error_message_redacts_secrets_before_truncation() -> None:
     out = sanitize_cli_error_message(f"{secret}{tail}")
     assert "sk-1" not in out
     assert "123456" not in out
+
+
+def _long_signature_command(
+    name: str | None = None,
+    num_gpus: int | None = None,
+    region: str | None = None,
+    billing_type: str | None = None,
+    nvidia_driver_version: str | None = None,
+    cuda_version: str | None = None,
+    duration_days: int | None = None,
+    gpu_type: str | None = None,
+    cluster_type: str | None = None,
+) -> None:
+    del (
+        name,
+        num_gpus,
+        region,
+        billing_type,
+        nvidia_driver_version,
+        cuda_version,
+        duration_days,
+        gpu_type,
+        cluster_type,
+    )
+
+
+def test_format_unknown_option_error_is_option_and_command() -> None:
+    from cyclopts.token import Token
+    from cyclopts.argument import ArgumentCollection
+    from cyclopts.exceptions import UnknownOptionError
+
+    err = UnknownOptionError(
+        token=Token(keyword="--bogus-flag", value="--bogus-flag", source="cli"),
+        argument_collection=ArgumentCollection(),
+        target=_long_signature_command,
+    )
+    raw = str(err)
+    assert "Function defined in file" in raw
+    assert _long_signature_command.__code__.co_filename in raw
+
+    out = format_cli_error_for_telemetry(err, command="clusters create")
+    assert out == 'Unknown option: "--bogus-flag" for command "clusters create"'
+    assert "Function defined in file" not in out
+    assert ".py" not in out
+    assert err.verbose is True
+
+
+def test_format_unknown_option_error_without_command() -> None:
+    from cyclopts.token import Token
+    from cyclopts.argument import ArgumentCollection
+    from cyclopts.exceptions import UnknownOptionError
+
+    err = UnknownOptionError(
+        token=Token(keyword="--bogus-flag", value="--bogus-flag", source="cli"),
+        argument_collection=ArgumentCollection(),
+    )
+    assert format_cli_error_for_telemetry(err) == 'Unknown option: "--bogus-flag"'
+
+
+def test_format_cyclopts_error_omits_install_path() -> None:
+    from cyclopts.exceptions import CycloptsError
+
+    err = CycloptsError(target=_long_signature_command)
+    assert "Function defined in file" in str(err)
+    out = format_cli_error_for_telemetry(err, command="clusters create")
+    assert "Function defined in file" not in out
+    assert _long_signature_command.__code__.co_filename not in out
 
 
 def test_telemetry_env_opt_out_only_explicit_values(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_cli_telemetry.py
+++ b/tests/unit/test_cli_telemetry.py
@@ -135,8 +135,9 @@ def test_format_unknown_option_error_is_option_and_command() -> None:
     from cyclopts.argument import ArgumentCollection
     from cyclopts.exceptions import UnknownOptionError
 
+    # Parser shape: keyword=None, raw CLI token in value.
     err = UnknownOptionError(
-        token=Token(keyword="--bogus-flag", value="--bogus-flag", source="cli"),
+        token=Token(keyword=None, value="--bogus-flag", source="cli"),
         argument_collection=ArgumentCollection(),
         target=_long_signature_command,
     )
@@ -157,10 +158,24 @@ def test_format_unknown_option_error_without_command() -> None:
     from cyclopts.exceptions import UnknownOptionError
 
     err = UnknownOptionError(
-        token=Token(keyword="--bogus-flag", value="--bogus-flag", source="cli"),
+        token=Token(keyword=None, value="--bogus-flag", source="cli"),
         argument_collection=ArgumentCollection(),
     )
     assert format_cli_error_for_telemetry(err) == 'Unknown option: "--bogus-flag"'
+
+
+def test_format_unknown_option_error_strips_inline_value() -> None:
+    from cyclopts.token import Token
+    from cyclopts.argument import ArgumentCollection
+    from cyclopts.exceptions import UnknownOptionError
+
+    err = UnknownOptionError(
+        token=Token(keyword=None, value="--auth-token=hunter2secret", source="cli"),
+        argument_collection=ArgumentCollection(),
+    )
+    out = format_cli_error_for_telemetry(err, command="clusters create")
+    assert out == 'Unknown option: "--auth-token" for command "clusters create"'
+    assert "hunter2secret" not in out
 
 
 def test_format_cyclopts_error_omits_install_path() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Cyclopts `UnknownOptionError` was recorded with the verbose preamble (`Function defined in file "…/create.py"` plus the full command signature). That path is unique per machine, so unknown-option failures exploded into many distinct telemetry events and the 500-char truncation often dropped the actual option.
- Failure telemetry now records `Unknown option: "--flag" for command "clusters create"` (command is also still a first-class event field). Other Cyclopts errors stringify with `verbose=False` so they don't leak install paths either.
- `--flag=value` tokens are stripped at the first `=` so telemetry keeps the option name only (no secrets/paths). Unit tests now use the parser's real Token shape (`keyword=None`, raw token in `value`).
- Generic CycloptsError coverage uses `UnknownCommandError` (real diagnostic text) rather than a bare `CycloptsError` that stringifies to `""` when verbose is off.

Fixes ENG-92296.

## Test plan
- [x] Unit: `format_cli_error_for_telemetry` keeps only option + command and omits file paths
- [x] Unit: `--flag=value` (parser Token shape) records the flag name, not the value
- [x] Unit: generic CycloptsError branch asserts a real diagnostic (`Unknown command "bogus-cmd".`), not an empty string
- [x] CLI: `tg beta clusters create --not-a-real-option` emits a stable `cli_command_failed` error string
- [x] CLI: `tg beta clusters create --auth-token=hunter2secret` does not record the secret
- [x] `uv run pytest tests/unit/test_cli_telemetry.py tests/cli/test_command_telemetry.py` (42 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-92296](https://linear.app/together-ai/issue/ENG-92296/improve-telemetry-for-unknownoptionerror)

<div><a href="https://cursor.com/agents/bc-9c250d36-e513-40ea-b78a-770219b1665a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c250d36-e513-40ea-b78a-770219b1665a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

