### PR TITLE
fix(stlc): back-sync on SHA ancestry, not identical trees

### DIFF
--- a/.github/workflows/stlc-sync.yml
+++ b/.github/workflows/stlc-sync.yml
@@ -68,12 +68,12 @@ jobs:
       - name: Check whether production is ahead of staging
         id: diff
         run: |
-          # Content compare: would merging production into staging change its tree?
-          # If not, staging already has production's content (release-please commits).
-          MERGED=$(git merge-tree --write-tree origin/main production/main) || MERGED=conflict
-          STAGING_TREE=$(git rev-parse 'origin/main^{tree}')
-          if [ "$MERGED" = "$STAGING_TREE" ]; then
-            echo "Staging already has production's content. Nothing to pull back."
+          # Ancestry, not tree. generate + trunk-sync-lock refuse unless
+          # production/main is an ancestor of staging/main. Identical trees with
+          # extra production merge commits (a heal PR merged on both trunks)
+          # still need a SHA fast-forward — skipping them wedges codegen.
+          if git -c credential.helper= merge-base --is-ancestor production/main origin/main; then
+            echo "Production is already contained in staging. Nothing to pull back."
             echo "behind=false" >> "$GITHUB_OUTPUT"
           else
             echo "behind=true" >> "$GITHUB_OUTPUT"
@@ -85,17 +85,19 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          # Prefer a SHA-preserving fast-forward. If the trunks have forked
-          # (staging is not an ancestor of production), open a heal PR instead.
-          if git -c credential.helper= merge-base --is-ancestor origin/main production/main; then
-            git -c credential.helper= push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" production/main:refs/heads/main
-            echo "Fast-forwarded staging/main to production/main."
-            exit 0
-          fi
-
-          echo "::warning title=Back-sync blocked::staging main is not an ancestor of production/main — opening a heal PR."
-          branch="stlc/heal-promote-ancestry"
           staging_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Prefer a SHA-preserving fast-forward. Direct push often fails on an
+          # org "changes via PR" ruleset; fall through to a merge-commit PR.
+          if git -c credential.helper= merge-base --is-ancestor origin/main production/main; then
+            if git -c credential.helper= push "$staging_url" production/main:refs/heads/main; then
+              echo "Fast-forwarded staging/main to production/main."
+              exit 0
+            fi
+            echo "::warning title=Back-sync push blocked::Could not fast-forward staging/main (ruleset). Opening a back-sync PR — merge it with a merge commit, never squash."
+          else
+            echo "::warning title=Back-sync blocked::staging main is not an ancestor of production/main — opening a heal PR."
+          fi
+          branch="stlc/heal-promote-ancestry"
           git checkout -B "$branch" origin/main
           if ! git -c credential.helper= merge production/main -m "Merge production into staging (heal promote ancestry)"; then
             echo "::error title=Heal merge conflicted::Could not auto-merge production into staging. Resolve ancestry manually."
@@ -118,9 +120,11 @@ jobs:
               --title "Merge production into staging (heal promote ancestry)" \
               --reviewer blainekasten \
               --body "$(cat <<'EOF'
-          Staging and production have forked, so a fast-forward back-sync is unsafe.
+          Restores SHA ancestry so codegen / promote / trunk-sync-lock can proceed.
 
-          This PR merges `production/main` into staging to restore ancestry so promote/back-sync can fast-forward again. Review carefully — both trunks had unique commits.
+          Direct fast-forward of `staging/main` was blocked (org PR ruleset) or the trunks had forked. **Merge this PR with a merge commit or GitHub's fast-forward merge. Do not squash or rebase** — that rewrites SHAs and leaves production ahead, which holds codegen again.
+
+          After merge, re-run **Generate SDKs with stlc** on `togethercomputer/openapi`.
           EOF
           )"
             echo "Opened heal PR and requested review from blainekasten."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
SKIP_LINEAR_CHECK

## Why

Python staging back-sync has been a green no-op while codegen is held.

`stlc-sync.yml` skipped whenever `merge-tree` of production into staging equaled staging's tree. After `stlc/heal-promote-ancestry` was merged on **both** trunks, production was ahead by empty merge commits (`eee6f8ed` vs `243c5a4b`) with identical trees. Generate and `trunk-sync-lock` check **ancestry**, so they stayed red.

Direct FF of staging `main` is also blocked by the org PR ruleset; the old job exited 1 on push failure with no PR fallback for the FF-able case.

## This PR

- Treat production as "behind" unless it is an **ancestor** of staging (not merely tree-equal).
- If a direct FF of `main` is rejected, open the existing heal PR (`stlc/heal-promote-ancestry`) and require a **merge commit / FF merge, never squash**.

This workflow only *runs* on `together-py-staging`. Landing it here is so promote copies the same file.

## Merge order

1. Merge the SHA back-sync on staging first: https://github.com/togethercomputer/together-py-staging/pull/142 (unblocks codegen).
2. Then merge this. If you merge this first, production is ahead again on a real tree change and codegen holds until 142 (or a new back-sync PR) lands.

TypeScript and Go `stlc-sync.yml` have the same tree skip; they are not currently holding generate.

`SKIP_LINEAR_CHECK`: workflow-only fix, no SDK product change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13bd465a-a925-46d7-8697-72ae80d75754?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13bd465a-a925-46d7-8697-72ae80d75754&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

